### PR TITLE
Remove acts_as_commentable

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -28,8 +28,6 @@ gem 'search_object_graphql', '0.3.1'
 
 gem 'scenic', '~>1.5.4'
 
-gem 'acts_as_commentable', '~> 4.0.2'
-
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -60,7 +60,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    acts_as_commentable (4.0.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
@@ -282,7 +281,6 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
-  acts_as_commentable (~> 4.0.2)
   bootsnap (>= 1.4.4)
   byebug
   capistrano (~> 3.10.0)

--- a/server/app/models/comment.rb
+++ b/server/app/models/comment.rb
@@ -1,5 +1,4 @@
 class Comment < ActiveRecord::Base
-  include ActsAsCommentable::Comment
   ##include WithTimepointCounts
   ##before_destroy :mark_events_unlinkable
 

--- a/server/app/models/concerns/commentable.rb
+++ b/server/app/models/concerns/commentable.rb
@@ -1,7 +1,7 @@
 module Commentable
   extend ActiveSupport::Concern
   included do
-    acts_as_commentable
+    has_many :comments, as: :commentable
 
     has_one :last_comment_event,
       ->() { where(action: 'commented').includes(:originating_user).order('created_at DESC') },

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
 
   has_many :authorizations
 
-  #has_many :comments
+  has_many :comments
   #has_many :suggested_changes
   #has_many :subscriptions
   has_many :events, foreign_key: :originating_user_id

--- a/server/app/models/v2_suggested_change.rb
+++ b/server/app/models/v2_suggested_change.rb
@@ -1,17 +1,15 @@
 class V2SuggestedChange < ApplicationRecord
-  belongs_to :subject, polymorphic: true
+  include Commentable
 
+  belongs_to :subject, polymorphic: true
   #TODO: will we want a mixin someday?
   has_many :events, as: :originating_object
-
-  has_many :comments, as: :commentable
 
   validates :status, inclusion: {
     in: ['applied', 'rejected', 'superseded', 'new'],
     message: "%{value} is not a valid suggested change status"
   },
   allow_blank: false
-
 
   def suggesting_user
     events


### PR DESCRIPTION
The library is unmaiantained and we weren't using any of the
autognerated finder methods anyways. If we need additional helper
methods we can add them in Commentable

closes #10 