### PR TITLE
Add field for mygene.info api call

### DIFF
--- a/server/app/graphql/types/entities/gene_type.rb
+++ b/server/app/graphql/types/entities/gene_type.rb
@@ -11,6 +11,7 @@ module Types::Entities
     field :sources, [Types::Entities::SourceType], null: true
     field :variants, [Types::Entities::VariantType], null: true
     field :lifecycle_actions, Types::LifecycleType, null: false
+    field :my_gene_info_details, GraphQL::Types::JSON, null: true
 
     def aliases
       Loaders::AssociationLoader.for(Gene, :gene_aliases).load(object)
@@ -30,6 +31,10 @@ module Types::Entities
         last_modified: object.last_accepted_revision_event,
         #last_commented_on: object.last_comment_event,
       }
+    end
+
+    def my_gene_info_details
+      MyGeneInfo.get_by_gene_id(object.id)
     end
   end
 end

--- a/server/app/models/my_gene_info.rb
+++ b/server/app/models/my_gene_info.rb
@@ -1,0 +1,25 @@
+class MyGeneInfo
+  def self.get_by_gene_id(gene_id)
+    Rails.cache.fetch(cache_key(gene_id), expires_in: 24.hours) do
+      make_request(gene_id)
+    end
+  end
+
+  def self.refresh_cache_for_gene_id(gene_id)
+    Rails.cache.write(cache_key(gene_id), make_request(gene_id), expires_in: 24.hours)
+  end
+
+  private
+  def self.make_request(gene_id)
+    entrez_id = Gene.find_by!(id: gene_id).entrez_id
+    ScrapingUtils.make_get_request(my_gene_info_url(entrez_id))
+  end
+
+  def self.my_gene_info_url(entrez_id)
+    "http://mygene.info/v2/gene/#{entrez_id}?fields=name,symbol,alias,interpro,pathway,summary,genomic_pos_hg19,uniprot"
+  end
+
+  def self.cache_key(gene_id)
+    "mygene_info_#{gene_id}"
+  end
+end

--- a/server/app/scrapers/scraping_utils.rb
+++ b/server/app/scrapers/scraping_utils.rb
@@ -1,0 +1,8 @@
+module ScrapingUtils
+  def self.make_get_request(url)
+    uri = URI(url)
+    res = Net::HTTP.get_response(uri)
+    raise StandardError.new(res.body) unless res.code == '200'
+    res.body
+  end
+end


### PR DESCRIPTION
This allows an api user to optionally request details from MyGene.info on a single gene request. As in the old codebase its proxied, cached, and just passed along as a JSON blob of their API response.