### PR TITLE
Initial attempt at autogenerating docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: Build and deploy docs
+on:
+  push:
+    branches: [main]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.1
+
+      - name: Build docs
+        run: |
+          npm install spectaql
+          npx spectaql --target-dir docs/build docs/config.yml
+
+      - name: Deploy docs
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          branch: gh-pages
+          folder: docs/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/build

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -1,0 +1,20 @@
+spectaql:
+
+introspection:
+  schemaFile: ./client/src/app/generated/civic.model.graphql
+
+info:
+  title: CiVIC 2 API Documentation
+  description: Documentation for the CIViC GraphQL API
+  termsOfService: https://www.example.com/terms
+  contact:
+    name: Development Team
+    email: help@civicdb.org
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://example.com/graphql
+    description: Production
+    production: true


### PR DESCRIPTION
This will (should?) generate docs using (https://github.com/griffithlab/civic-v2/pull/new/doc-generation) based on the schema file in the repo and publish them to github pages on every merge to master. It will need a  fair amount of config and examples provided to be truly useful, but this should at least bootstrap the process.


Example of it working locally: 
<img width="1397" alt="Screen Shot 2021-03-23 at 10 46 26 AM" src="https://user-images.githubusercontent.com/13370/112175182-085c0a80-8bc5-11eb-8bda-9901f8fa27da.png">
