### PR TITLE
Expose creation event for revisions and comments

### DIFF
--- a/client/src/app/generated/civic.model.graphql
+++ b/client/src/app/generated/civic.model.graphql
@@ -183,6 +183,7 @@ type Comment {
   comment: String!
   commentor: User!
   createdAt: ISO8601DateTime!
+  creationEvent: Event
   id: Int!
   title: String
 }
@@ -1204,6 +1205,7 @@ type ResolveFlagPayload {
 type Revision {
   comments: [Comment!]!
   createdAt: ISO8601DateTime!
+  creationEvent: Event
   currentValue: JSON!
   fieldName: String!
   id: Int!

--- a/client/src/app/generated/civic.schema.json
+++ b/client/src/app/generated/civic.schema.json
@@ -910,6 +910,20 @@
               "deprecationReason": null
             },
             {
+              "name": "creationEvent",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Event",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [
@@ -5937,6 +5951,20 @@
                   "name": "ISO8601DateTime",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "creationEvent",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Event",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/server/app/graphql/types/entities/comment_type.rb
+++ b/server/app/graphql/types/entities/comment_type.rb
@@ -5,9 +5,14 @@ module Types::Entities
     field :title, String, null: true
     field :comment, String, null: false
     field :commentor, Types::Entities::UserType, null: false
+    field :creation_event, Types::Entities::EventType, null: true
 
     def commentor
       Loaders::AssociationLoader.for(Comment, :user).load(object)
+    end
+
+    def creation_event
+      Loaders::AssociationLoader.for(Comment, :creation_event).load(object)
     end
   end
 end

--- a/server/app/graphql/types/revisions/revision_type.rb
+++ b/server/app/graphql/types/revisions/revision_type.rb
@@ -11,6 +11,7 @@ module Types::Revisions
     field :revisionset_id, String, null: false
     field :linkout_data, Types::Revisions::LinkoutData, null: false
     field :revisor, Types::Entities::UserType, null: false
+    field :creation_event, Types::Entities::EventType, null: true
 
     def comments
       Loaders::AssociationLoader.for(Revision, :comments).load(object)
@@ -18,6 +19,10 @@ module Types::Revisions
 
     def linkout_data
       Types::Revisions::LinkoutData.from_revision(object)
+    end
+
+    def creation_event
+      Loaders::AssociationLoader.for(Revision, :creation_event).load(object)
     end
   end
 end

--- a/server/app/models/comment.rb
+++ b/server/app/models/comment.rb
@@ -5,6 +5,13 @@ class Comment < ActiveRecord::Base
   belongs_to :user
   belongs_to :commentable, ->() { unscope(where: :deleted) }, polymorphic: true
 
+  has_many :events, as: :originating_object
+
+  has_one :creation_event,
+    ->() { where(action: 'commented') },
+    as: :originating_object,
+    class_name: 'Event'
+
   default_scope -> { order('created_at ASC') }
 
   alias_attribute :text, :comment

--- a/server/app/models/revision.rb
+++ b/server/app/models/revision.rb
@@ -5,6 +5,11 @@ class Revision < ApplicationRecord
   #TODO: will we want a mixin someday?
   has_many :events, as: :originating_object
 
+  has_one :creation_event,
+    ->() { where(action: 'revision suggested') },
+    as: :originating_object,
+    class_name: 'Event'
+
   validates :status, inclusion: {
     in: ['accepted', 'rejected', 'superseded', 'new'],
     message: "%{value} is not a valid revision status"


### PR DESCRIPTION
We will likely want to make the return type non-nullable once we've
backfilled and ensured events are getting created appropriately.

Closes #35