### PR TITLE
Implement generic event shortcuts (previously "lifecycle actions")

### DIFF
--- a/server/app/graphql/types/entities/assertion_type.rb
+++ b/server/app/graphql/types/entities/assertion_type.rb
@@ -27,6 +27,9 @@ module Types::Entities
     field :nccn_guideline, String, null: true
     field :acmg_codes, [Types::Entities::AcmgCodeType], null: true
     field :amp_level, Types::AmpLevelType, null: true
+    field :submission_event, Types::Entities::EventType, null: false
+    field :acceptance_event, Types::Entities::EventType, null: true
+    field :rejection_event, Types::Entities::EventType, null: true
 
     def disease
       Loaders::RecordLoader.for(Disease).load(object.disease_id)
@@ -69,11 +72,19 @@ module Types::Entities
     end
 
     def nccn_guideline
-      if object.nccn_guideline
-        object.nccn_guideline.name
-      else
-        nil
-      end
+      object.nccn_guideline&.name
+    end
+
+    def submission_event
+      Loaders::AssociationLoader.for(Assertion, :submission_event).load(object)
+    end
+
+    def acceptance_event
+      Loaders::AssociationLoader.for(Assertion, :acceptance_event).load(object)
+    end
+
+    def rejection_event
+      Loaders::AssociationLoader.for(Assertion, :rejection_event).load(object)
     end
   end
 end

--- a/server/app/graphql/types/entities/evidence_item_type.rb
+++ b/server/app/graphql/types/entities/evidence_item_type.rb
@@ -26,6 +26,9 @@ module Types::Entities
     field :variant, Types::Entities::VariantType, null: false
     field :variant_hgvs, String, null: false
     field :variant_origin, Types::VariantOriginType, null: false
+    field :submission_event, Types::Entities::EventType, null: false
+    field :acceptance_event, Types::Entities::EventType, null: true
+    field :rejection_event, Types::Entities::EventType, null: true
 
     def disease
       Loaders::RecordLoader.for(Disease).load(object.disease_id)
@@ -49,6 +52,18 @@ module Types::Entities
 
     def variant
       Loaders::RecordLoader.for(Variant).load(object.variant_id)
+    end
+
+    def submission_event
+      Loaders::AssociationLoader.for(EvidenceItem, :submission_event).load(object)
+    end
+
+    def acceptance_event
+      Loaders::AssociationLoader.for(EvidenceItem, :acceptance_event).load(object)
+    end
+
+    def rejection_event
+      Loaders::AssociationLoader.for(EvidenceItem, :rejection_event).load(object)
     end
   end
 end

--- a/server/app/graphql/types/entities/gene_type.rb
+++ b/server/app/graphql/types/entities/gene_type.rb
@@ -13,7 +13,6 @@ module Types::Entities
     field :aliases, [Types::Entities::GeneAliasType], null: false
     field :sources, [Types::Entities::SourceType], null: false
     field :variants, resolver: Resolvers::Variants
-    field :lifecycle_actions, Types::LifecycleType, null: false
     field :my_gene_info_details, GraphQL::Types::JSON, null: true
 
     def aliases
@@ -26,14 +25,6 @@ module Types::Entities
 
     def variants
       Loaders::AssociationLoader.for(Gene, :variants).load(object)
-    end
-
-    def lifecycle_actions
-      {
-        last_reviewed: object.last_review_event,
-        last_modified: object.last_accepted_revision_event,
-        #last_commented_on: object.last_comment_event,
-      }
     end
 
     def my_gene_info_details

--- a/server/app/graphql/types/interfaces/commentable.rb
+++ b/server/app/graphql/types/interfaces/commentable.rb
@@ -4,6 +4,10 @@ module Types::Interfaces
 
     description 'A CIViC entity that can have comments on it.'
     field :comments, resolver: Resolvers::Comments
+    field :last_comment_event, Types::Entities::EventType, null: true
 
+    def last_comment_event
+      Loaders::AssociationLoader.for(object.class, :last_comment_event).load(object)
+    end
   end
 end

--- a/server/app/graphql/types/interfaces/with_revisions.rb
+++ b/server/app/graphql/types/interfaces/with_revisions.rb
@@ -4,5 +4,15 @@ module Types::Interfaces
 
     description 'A CIViC entity that can have revisions proposed to it.'
     field :revisions, resolver: Resolvers::Revisions
+    field :last_submitted_revision_event, Types::Entities::EventType, null: true
+    field :last_accepted_revision_event, Types::Entities::EventType, null: true
+
+    def last_submitted_revision_event
+      Loaders::AssociationLoader.for(object.class, :last_submitted_revision_event).load(object)
+    end
+
+    def last_accepted_revision_event
+      Loaders::AssociationLoader.for(object.class, :last_accepted_revision_event).load(object)
+    end
   end
 end

--- a/server/app/graphql/types/lifecycle_type.rb
+++ b/server/app/graphql/types/lifecycle_type.rb
@@ -1,7 +1,0 @@
-module Types
-  class LifecycleType < BaseObject
-    field :last_reviewed, Types::Entities::EventType, null: true
-    field :last_modified, Types::Entities::EventType, null: true
-    field :last_commented_on, Types::Entities::EventType, null: true
-  end
-end

--- a/server/app/models/assertion.rb
+++ b/server/app/models/assertion.rb
@@ -20,6 +20,22 @@ class Assertion < ActiveRecord::Base
   enum drug_interaction_type: Constants::DRUG_INTERACTION_TYPES
   enum variant_origin: Constants::VARIANT_ORIGINS, _suffix: true
 
+  has_one :submission_event,
+    ->() { where(action: 'assertion submitted').includes(:originating_user) },
+    as: :subject,
+    class_name: 'Event'
+  has_one :submitter, through: :submission_event, source: :originating_user
+  has_one :acceptance_event,
+    ->() { where(action: 'assertion accepted').includes(:originating_user) },
+    as: :subject,
+    class_name: 'Event'
+  has_one :acceptor, through: :acceptance_event, source: :originating_user
+  has_one :rejection_event,
+    ->() { where(action: 'assertion rejected').includes(:originating_user) },
+    as: :subject,
+    class_name: 'Event'
+  has_one :rejector, through: :rejection_event, source: :originating_user
+
   #associate_by_attribute :nccn_guideline, :name
   def name
     "AID#{self.id}"

--- a/server/app/models/concerns/moderated.rb
+++ b/server/app/models/concerns/moderated.rb
@@ -20,15 +20,11 @@ module Moderated
             as: :subject,
             class_name: 'Event'
 
-    #TODO re-visit this, its wrong
-    has_one :last_updator, through: :last_accepted_revision, source: :originating_user
-
     has_many :events, as: :subject
-    has_one :last_review_event,
-      ->() { where(action: 'revision accepted').includes(:originating_user).order('events.updated_at DESC') },
+    has_one :last_submitted_revision_event,
+      ->() { where(action: 'revision suggested').includes(:originating_user).order('events.updated_at DESC') },
       as: :subject,
       class_name: 'Event'
-    has_one :last_reviewer, through: :last_review_event, source: :originating_user
   end
 
   #TODO: Refactor to use new Revision format

--- a/server/app/models/evidence_item.rb
+++ b/server/app/models/evidence_item.rb
@@ -20,6 +20,22 @@ class EvidenceItem < ActiveRecord::Base
   enum clinical_significance: Constants::CLINICAL_SIGNIFICANCES
   enum drug_interaction_type: Constants::DRUG_INTERACTION_TYPES
 
+  has_one :submission_event,
+    ->() { where(action: 'submitted').includes(:originating_user) },
+    as: :subject,
+    class_name: 'Event'
+  has_one :submitter, through: :submission_event, source: :originating_user
+  has_one :acceptance_event,
+    ->() { where(action: 'accepted').includes(:originating_user) },
+    as: :subject,
+    class_name: 'Event'
+  has_one :acceptor, through: :acceptance_event, source: :originating_user
+  has_one :rejection_event,
+    ->() { where(action: 'rejected').includes(:originating_user) },
+    as: :subject,
+    class_name: 'Event'
+  has_one :rejector, through: :rejection_event, source: :originating_user
+
   validates :rating, inclusion: [1, 2, 3, 4, 5]
 
   def name

--- a/server/app/models/suggested_change.rb
+++ b/server/app/models/suggested_change.rb
@@ -1,3 +1,0 @@
-class SuggestedChange < ApplicationRecord
-
-end


### PR DESCRIPTION
There is no longer a `lifecycle_actions` hash on each entity. Instead:
- Anything that is a commentable will now have a `last_comment_event`
- Anything that is a with_revisions will now have a `last_submitted_revision_event` and a `last_accepted_revision_event`.
- Assertions and evidence items also have `submission_event`, `acceptance_event`,  and `rejection_event`.