### PR TITLE
Link to IDs

### DIFF
--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -1186,7 +1186,17 @@ type Comment implements EventOriginObject {
   creationEvent: Event
   id: Int!
   name: String!
+
+  """
+  Fetch the next "count" items in chronological order
+  """
+  nextItems(count: Int!): [Comment!]!
   parsedComment: [CommentBodySegment!]!
+
+  """
+  Fetch the previous "count" items in chronological order
+  """
+  previousItems(count: Int!): [Comment!]!
   title: String
 }
 
@@ -2204,7 +2214,17 @@ type Flag implements Commentable & EventOriginObject {
   id: Int!
   lastCommentEvent: Event
   name: String!
+
+  """
+  Fetch the next "count" items in chronological order
+  """
+  nextItems(count: Int!): [Flag!]!
   openComment: Comment!
+
+  """
+  Fetch the previous "count" items in chronological order
+  """
+  previousItems(count: Int!): [Flag!]!
   resolutionComment: Comment
   resolvedAt: ISO8601DateTime
   resolvingUser: User
@@ -4691,6 +4711,16 @@ type Revision implements EventOriginObject & EventSubject {
   id: Int!
   linkoutData: LinkoutData!
   name: String!
+
+  """
+  Fetch the next "count" items in chronological order
+  """
+  nextItems(count: Int!): [Revision!]!
+
+  """
+  Fetch the previous "count" items in chronological order
+  """
+  previousItems(count: Int!): [Revision!]!
   resolutionComment: Comment
   resolvedAt: ISO8601DateTime
   resolver: User

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -5999,6 +5999,47 @@
               "deprecationReason": null
             },
             {
+              "name": "nextItems",
+              "description": "Fetch the next \"count\" items in chronological order",
+              "args": [
+                {
+                  "name": "count",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Comment",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "parsedComment",
               "description": null,
               "args": [
@@ -6016,6 +6057,47 @@
                     "ofType": {
                       "kind": "UNION",
                       "name": "CommentBodySegment",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previousItems",
+              "description": "Fetch the previous \"count\" items in chronological order",
+              "args": [
+                {
+                  "name": "count",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Comment",
                       "ofType": null
                     }
                   }
@@ -11163,6 +11245,47 @@
               "deprecationReason": null
             },
             {
+              "name": "nextItems",
+              "description": "Fetch the next \"count\" items in chronological order",
+              "args": [
+                {
+                  "name": "count",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Flag",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "openComment",
               "description": null,
               "args": [
@@ -11175,6 +11298,47 @@
                   "kind": "OBJECT",
                   "name": "Comment",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previousItems",
+              "description": "Fetch the previous \"count\" items in chronological order",
+              "args": [
+                {
+                  "name": "count",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Flag",
+                      "ofType": null
+                    }
+                  }
                 }
               },
               "isDeprecated": false,
@@ -21838,6 +22002,88 @@
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextItems",
+              "description": "Fetch the next \"count\" items in chronological order",
+              "args": [
+                {
+                  "name": "count",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Revision",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "previousItems",
+              "description": "Fetch the previous \"count\" items in chronological order",
+              "args": [
+                {
+                  "name": "count",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Revision",
+                      "ofType": null
+                    }
+                  }
                 }
               },
               "isDeprecated": false,

--- a/server/app/graphql/types/entities/comment_type.rb
+++ b/server/app/graphql/types/entities/comment_type.rb
@@ -1,5 +1,6 @@
 module Types::Entities
   class CommentType < Types::BaseObject
+    include Types::Shared::OrderedList
     connection_type_class Types::Connections::CommentsConnection
 
     implements Types::Interfaces::EventOriginObject
@@ -13,12 +14,17 @@ module Types::Entities
     field :commentable, Types::Interfaces::Commentable, null: false
     field :parsed_comment, [Types::Commentable::CommentBodySegment], null: false
 
+
     def commenter
       Loaders::AssociationLoader.for(Comment, :user).load(object)
     end
 
     def creation_event
       Loaders::AssociationLoader.for(Comment, :creation_event).load(object)
+    end
+
+    def commentable
+      Loaders::AssociationLoader.for(Comment, :commentable).load(object)
     end
 
     def parsed_comment
@@ -29,6 +35,11 @@ module Types::Entities
 
     def hash_key_from_object(object)
       "segments_#{object.class}_#{object.id}_#{object.updated_at}"
+    end
+
+    #used in OrderedList
+    def object_list_scope
+      ->(scope) { scope.where(commentable_id: object.commentable_id, commentable_type: object.commentable_type) }
     end
   end
 end

--- a/server/app/graphql/types/entities/flag_type.rb
+++ b/server/app/graphql/types/entities/flag_type.rb
@@ -1,5 +1,6 @@
 module Types::Entities
   class FlagType < Types::BaseObject
+    include Types::Shared::OrderedList
     connection_type_class Types::Connections::FlagsConnection
 
     implements Types::Interfaces::Commentable
@@ -42,6 +43,10 @@ module Types::Entities
     private
     def resolution_event
       Event.find_by(action: 'flag resolved', originating_object: object)
+    end
+
+    def object_list_scope
+      -> (scope) { scope.where(flaggable_id: object.flaggable_id, flaggable_type: object.flaggable_type) }
     end
   end
 end

--- a/server/app/graphql/types/interfaces/commentable.rb
+++ b/server/app/graphql/types/interfaces/commentable.rb
@@ -21,7 +21,7 @@ module Types::Interfaces
         when Gene
           Types::Entities::GeneType
         when Revision
-          Types::Entities::RevisionType
+          Types::Revisions::RevisionType
         when Source
           Types::Entities::SourceType
         when Variant

--- a/server/app/graphql/types/revisions/revision_type.rb
+++ b/server/app/graphql/types/revisions/revision_type.rb
@@ -1,5 +1,6 @@
 module Types::Revisions
   class RevisionType < Types::BaseObject
+    include Types::Shared::OrderedList
     connection_type_class Types::Connections::RevisionsConnection
 
     implements Types::Interfaces::EventSubject
@@ -78,5 +79,10 @@ module Types::Revisions
         end
       end
     end
+
+    def object_list_scope
+      -> (scope) { scope.where(subject_id: object.subject_id, subject_type: object.subject_type) }
+    end
   end
+
 end

--- a/server/app/graphql/types/shared/ordered_list.rb
+++ b/server/app/graphql/types/shared/ordered_list.rb
@@ -1,0 +1,68 @@
+module Types::Shared
+  module OrderedList
+
+    def self.included(klass)
+      klass.field :previous_items, [klass], null: false do
+        description 'Fetch the previous "count" items in chronological order'
+        argument :count, GraphQL::Types::Int, required: true,
+          validates: { numericality: { within: 1..10 } }
+      end
+
+      klass.field :next_items, [klass], null: false do
+        description 'Fetch the next "count" items in chronological order'
+        argument :count, GraphQL::Types::Int, required: true,
+          validates: { numericality: { within: 1..10 } }
+      end
+    end
+
+    def previous_items(count: )
+      base_query = object.class.where("index > ?", prev_object_index)
+        .from("(#{prev_table_with_index}) as #{object.class.table_name}")
+        .reorder(created_at: :desc)
+        .limit(count)
+
+      object_list_scope.call(base_query).reverse
+    end
+
+    def next_items(count: )
+      base_query = object.class.where("index > ?", next_object_index)
+        .from("(#{next_table_with_index}) as #{object.class.table_name}")
+        .limit(count)
+
+      object_list_scope.call(base_query)
+    end
+
+    private 
+    def next_object_index
+      @next_index ||= object_index_for_table(next_table_with_index)
+    end
+
+    def prev_object_index
+      @prev_index ||= object_index_for_table(prev_table_with_index)
+    end
+
+    def next_table_with_index
+      @next_table ||= object.class.select("#{object.class.table_name}.*, ROW_NUMBER() OVER (ORDER BY created_at asc) as index")
+        .to_sql
+    end
+
+    def prev_table_with_index
+      @prev_table ||= object.class.select("#{object.class.table_name}.*, ROW_NUMBER() OVER (ORDER BY created_at desc) as index")
+        .to_sql
+    end
+
+    def object_index_for_table(table)
+      object.class
+        .from("(#{table}) as #{object.class.table_name}")
+        .where(id: object.id)
+        .first
+        .index
+    end
+
+    #This can be overidden if you want to further scope the items. For instance you may not want _all_ comments
+    #only those that share a commentable
+    def object_list_scope
+      -> (scope) { scope }
+    end
+  end
+end


### PR DESCRIPTION
Its not easily possible to modify the cursor based connections to support an ID and then loading items around that ID. This is an alternative approach. 

Using the single item endpoint rather than a connection, I've added  `nextItems(count:)` and `previousItems(count:)` that return the next (or previous) `n` items chronologically. Furthermore, when mixing it in you can implement `object_list_scope` which can limit the list further. Right now its used to limit it to the next `n` flags/comments/revisions on the same subject, but we could also modify it to do things like the last `n` revisions that are part of the same changeset.