### PR TITLE
Enable google analytics

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -53,6 +53,10 @@
           },
           "configurations": {
             "production": {
+              "index": {
+                "input": "src/index.prod.html",
+                "output": "index.html"
+              },
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -3,6 +3,10 @@ import { NzIconService } from 'ng-zorro-antd/icon';
 
 import { fullColorIcons } from '@app/icons-provider.module';
 import { CivicIconLiteral } from './generated/civic.icons';
+import { NavigationEnd, Router } from '@angular/router';
+import { environment } from 'environments/environment';
+
+declare let gtag: Function;
 
 @Component({
   selector: 'app-root',
@@ -11,8 +15,17 @@ import { CivicIconLiteral } from './generated/civic.icons';
 })
 
 export class AppComponent {
-  constructor(private iconService: NzIconService) {
+  constructor(private iconService: NzIconService, private router: Router) {
     this.addIcons(fullColorIcons);
+    if (environment.production) {
+      this.router.events.subscribe(event => {
+        if(event instanceof NavigationEnd) {
+          gtag('config', 'UA-60119642-1', {
+            'page_path':  event.urlAfterRedirects
+          });
+        }
+      })
+    }
   }
 
   // TODO: switch to twotone civic custom icons ('civic-[entity]') exclusively.

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>CIViC</title>
+  <title>CIViC - Clinical Interpretation of Variants in Cancer</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/client/src/index.prod.html
+++ b/client/src/index.prod.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-60119642-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'UA-60119642-1');
+  </script>
+
+  <meta charset="utf-8">
+  <title>CIViC - Clinical Interpretation of Variants in Cancer</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+
+<body>
+  <app-root></app-root>
+</body>
+
+</html>

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -56,6 +56,9 @@ gem 'graphiql-rails', '~> 1.8.0'
 gem 'rinku', '~> 2.0.6'
 gem 'sanitize', '~> 6.0.0'
 
+#google analytics
+gem 'staccato', '~> 0.5.3'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -367,6 +367,7 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    staccato (0.5.3)
     thor (1.2.1)
     tilt (2.0.10)
     trestle (0.9.5)
@@ -447,6 +448,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   solargraph
+  staccato (~> 0.5.3)
   trestle (~> 0.9.5)
   trestle-search (~> 0.4.3)
   typhoeus (~> 1.4.0)

--- a/server/app/controllers/concerns/analytics.rb
+++ b/server/app/controllers/concerns/analytics.rb
@@ -1,0 +1,26 @@
+module Analytics
+  extend ActiveSupport::Concern
+  included do
+    after_action :submit_analytics
+  end
+
+
+  def submit_analytics
+    if should_submit?(request)
+      SubmitApiAnalytics.perform_later(
+        path: request.path,
+        referrer: request.referer,
+        user_agent: request.user_agent,
+        user_ip: request.remote_ip,
+      )
+    end
+  end
+
+  def should_submit?(req)
+    Rails.env.production? && req.headers['Civic-Client-Name'] != 'civic-frontend'
+  end
+
+  module_function :should_submit?
+end
+
+

--- a/server/app/controllers/graphql_controller.rb
+++ b/server/app/controllers/graphql_controller.rb
@@ -9,10 +9,12 @@ class GraphqlController < ApplicationController
     variables = prepare_variables(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
+
     context = {
-      #Query context goes here, for example:
-      current_user: current_user
+      current_user: current_user,
+      tracers: [GraphqlAnalyticsTracer.for_request(request)]
     }
+
     result = Civic2Schema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
   rescue => e

--- a/server/app/controllers/links_controller.rb
+++ b/server/app/controllers/links_controller.rb
@@ -1,4 +1,5 @@
 class LinksController < ApplicationController
+  include Analytics
 
   def redirect
     router = FrontendRouter.new(

--- a/server/app/jobs/submit_api_analytics.rb
+++ b/server/app/jobs/submit_api_analytics.rb
@@ -1,0 +1,5 @@
+class SubmitApiAnalytics < ApplicationJob
+  def perform(opts = {})
+    tracker = Staccato.tracker(Constants::GA_TRACKING_ID, nil, ssl: true)
+    tracker.pageview(opts)
+end

--- a/server/app/lib/graphql_analytics_tracer.rb
+++ b/server/app/lib/graphql_analytics_tracer.rb
@@ -1,0 +1,38 @@
+RequestTracer = Struct.new(:path, :referrer, :user_agent, :user_ip, keyword_init: true) do
+  def trace(key, data)
+    if key == "analyze_query"
+      query = data[:query]
+      title = query.selected_operation.selections&.first&.name
+
+      SubmitApiAnalytics.perform_later(
+        path: request.path,
+        referrer: request.referer,
+        user_agent: request.user_agent,
+        user_ip: request.remote_ip,
+        title: title
+      )
+    end
+    yield
+  end
+end
+
+class NullTracer
+  def self.trace(key, data)
+    yield
+  end
+end
+
+class GraphqlAnalyticsTracer
+  def self.for_request(req)
+    if Analytics.should_submit?(req)
+      RequestTracer.new(
+        path: request.path,
+        referrer: request.referer,
+        user_agent: request.user_agent,
+        user_ip: request.remote_ip,
+      )
+    else
+      NullTracer
+    end
+  end
+end

--- a/server/lib/constants.rb
+++ b/server/lib/constants.rb
@@ -1,0 +1,3 @@
+module Constants
+  GA_TRACKING_ID='UA-83153043-1'
+end


### PR DESCRIPTION
This will enable google analytics in production only for both server and client. The client will track pageviews and the server will track API requests and `/links/` redirects. The client will staple in an HTTP header with its requests that the server will check for so that it does not count requests coming from our own UI in the tracking.