### PR TITLE
Move entity event feed to a separate tab

### DIFF
--- a/client/src/app/components/assertions/assertions-popover/assertion-popover.query.gql
+++ b/client/src/app/components/assertions/assertions-popover/assertion-popover.query.gql
@@ -22,23 +22,28 @@ fragment assertionPopover on Assertion {
   drugs {
     id
     name
+    link
   }
   drugInteractionType
   disease {
     id
     name
+    link
   }
   phenotypes {
     id
     name
+    link
   }
   gene {
     id
     name
+    link
   }
   variant {
     id
     name
+    link
   }
   flags(state: OPEN) {
     totalCount

--- a/client/src/app/components/assertions/assertions-table/assertions-table.query.gql
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.query.gql
@@ -66,25 +66,31 @@ query AssertionsBrowse (
 fragment AssertionBrowseTableRowFields on Assertion {
   id
   name
+  link
   gene {
     id
     name
+    link
   }
   variant {
     id
     name
+    link
   }
   disease {
     id
     name
+    link
   }
   drugs {
     id
     name
+    link
   }
   phenotypes @include(if: $cardView) {
     id
     name
+    link
   }
   drugInteractionType
   summary

--- a/client/src/app/components/assertions/assertions-tag/assertion-tag.component.html
+++ b/client/src/app/components/assertions/assertions-tag/assertion-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/assertions/{{assertion.id}}">
+  <a [routerLink]="assertion.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/assertions/assertions-tag/assertion-tag.component.ts
+++ b/client/src/app/components/assertions/assertions-tag/assertion-tag.component.ts
@@ -4,7 +4,8 @@ import { EvidenceStatus, Maybe } from '@app/generated/civic.apollo';
 export interface LinkableAssertion {
   id: number,
   name: string,
-  status?: EvidenceStatus
+  status?: EvidenceStatus,
+  link: string,
 }
 
 @Component({

--- a/client/src/app/components/clinical-trials/clinical-trial-tag/clinical-trial-tag.component.html
+++ b/client/src/app/components/clinical-trials/clinical-trial-tag/clinical-trial-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/clinical-trials/{{clinicalTrial.id}}">
+  <a [routerLink]="clinicalTrial.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/clinical-trials/clinical-trial-tag/clinical-trial-tag.component.ts
+++ b/client/src/app/components/clinical-trials/clinical-trial-tag/clinical-trial-tag.component.ts
@@ -4,6 +4,7 @@ import { Maybe } from '@app/generated/civic.apollo';
 export interface LinkableClinicalTrial {
   id: number,
   nctId: string,
+  link: string,
 }
 
 @Component({

--- a/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.query.gql
+++ b/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.query.gql
@@ -31,6 +31,7 @@ query ClinicalTrialsBrowse(
         nctId
         evidenceCount
         sourceCount
+        link
       }
     }
   }

--- a/client/src/app/components/comments/comment-body/comment-body.component.html
+++ b/client/src/app/components/comments/comment-body/comment-body.component.html
@@ -9,22 +9,22 @@
     <ng-container *ngIf="c.__typename == 'CommentTagSegment'">
         <ng-container [ngSwitch]="c.tagType">
             <span *ngSwitchCase="'REVISION'">
-                <cvc-revision-tag [revision]="{id: c.entityId, name: c.displayName}"></cvc-revision-tag>
+                <cvc-revision-tag [revision]="{id: c.entityId, name: c.displayName, link: c.link}"></cvc-revision-tag>
             </span>
             <span *ngSwitchCase="'GENE'">
-                <cvc-gene-tag [gene]="{id: c.entityId, name: c.displayName}"></cvc-gene-tag>
+                <cvc-gene-tag [gene]="{id: c.entityId, name: c.displayName, link: c.link}"></cvc-gene-tag>
             </span>
             <span *ngSwitchCase="'VARIANT'">
-                <cvc-variant-tag [variant]="{id: c.entityId, name: c.displayName}"></cvc-variant-tag>
+                <cvc-variant-tag [variant]="{id: c.entityId, name: c.displayName, link: c.link}"></cvc-variant-tag>
             </span>
             <span *ngSwitchCase="'VARIANT_GROUP'">
-                <cvc-variant-group-tag [variantgroup]="{id: c.entityId, name: c.displayName}"></cvc-variant-group-tag>
+                <cvc-variant-group-tag [variantgroup]="{id: c.entityId, name: c.displayName, link: c.link}"></cvc-variant-group-tag>
             </span>
             <span *ngSwitchCase="'EVIDENCE_ITEM'">
-                <cvc-evidence-tag [evidence]="{id: c.entityId, name: c.displayName, status: c.status}"></cvc-evidence-tag>
+                <cvc-evidence-tag [evidence]="{id: c.entityId, name: c.displayName, status: c.status, link: c.link}"></cvc-evidence-tag>
             </span>
             <span *ngSwitchCase="'ASSERTION'">
-                <cvc-assertion-tag [assertion]="{id: c.entityId, name: c.displayName, status: c.status}"></cvc-assertion-tag>
+                <cvc-assertion-tag [assertion]="{id: c.entityId, name: c.displayName, status: c.status, link: c.link}"></cvc-assertion-tag>
             </span>
             <span *ngSwitchCase="'ORGANIZATION'">
                 <cvc-organization-tag [org]="{id: c.entityId, name: c.displayName}"></cvc-organization-tag>

--- a/client/src/app/components/comments/comment-list/comment-list.query.gql
+++ b/client/src/app/components/comments/comment-list/comment-list.query.gql
@@ -45,11 +45,13 @@ query CommentList(
       displayName
       entityId
       tagType
+      link
     }
     mentionedEntities {
       displayName
       entityId
       tagType
+      link
     }
     unfilteredCountForSubject
     edges {
@@ -86,6 +88,7 @@ fragment commentListNode on Comment {
       displayName
       tagType
       status
+      link
       __typename
     }
     ... on CommentTextSegment {

--- a/client/src/app/components/comments/comment-popover/comment-popover.component.html
+++ b/client/src/app/components/comments/comment-popover/comment-popover.component.html
@@ -10,6 +10,7 @@
           <cvc-assertion-tag *ngSwitchCase="'Assertion'" [enablePopover]="false" [assertion]="c.commentable"></cvc-assertion-tag>
           <cvc-evidence-tag *ngSwitchCase="'EvidenceItem'" [enablePopover]="false" [evidence]="c.commentable"></cvc-evidence-tag>
           <cvc-variant-tag *ngSwitchCase="'Variant'" [enablePopover]="false" [variant]="c.commentable"></cvc-variant-tag>
+          <cvc-revision-tag *ngSwitchCase="'Revision'" [revision]="c.commentable"></cvc-revision-tag>
           <span *ngSwitchDefault>{{ c.commentable.name }}</span>
         </ng-container>
         {{ c.createdAt | timeago }}

--- a/client/src/app/components/comments/comment-popover/comment-popover.module.ts
+++ b/client/src/app/components/comments/comment-popover/comment-popover.module.ts
@@ -11,6 +11,7 @@ import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcGeneTagModule } from '@app/components/genes/gene-tag/gene-tag.module';
 import { CivicTimeagoFormatter } from '@app/core/utilities/timeago-formatter';
+import { CvcRevisionTagModule } from '@app/components/revisions/revision-tag/revision-tag.module';
 
 @NgModule({
   declarations: [CvcCommentPopoverComponent],
@@ -25,6 +26,7 @@ import { CivicTimeagoFormatter } from '@app/core/utilities/timeago-formatter';
     CvcEvidenceTagModule,
     CvcEvidenceTagModule,
     CvcVariantTagModule,
+    CvcRevisionTagModule,
     TimeagoModule.forChild({ formatter: {useClass: CivicTimeagoFormatter, provide: TimeagoFormatter} }),
   ],
   exports: [CvcCommentPopoverComponent]

--- a/client/src/app/components/comments/comment-popover/comment-popover.query.gql
+++ b/client/src/app/components/comments/comment-popover/comment-popover.query.gql
@@ -20,6 +20,7 @@ fragment commentPopover on Comment {
   commentable {
     id
     name
+    link
     __typename
   }
 }

--- a/client/src/app/components/comments/comment-tag/comment-tag.component.html
+++ b/client/src/app/components/comments/comment-tag/comment-tag.component.html
@@ -1,8 +1,6 @@
-<ng-container *ngIf="subject; else unlinked">
-  <a routerLink="/{{subject.__typename | typenameToRoute}}/{{subject.id}}/comments">
-    <ng-template [ngTemplateOutlet]="tag"></ng-template>
-  </a>
-</ng-container>
+<a [routerLink]="comment.link">
+  <ng-template [ngTemplateOutlet]="tag"></ng-template>
+</a>
 
 <ng-template #tag>
   <nz-tag *ngIf="enablePopover; else noPopover"
@@ -23,10 +21,6 @@
   <nz-tag>
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
-</ng-template>
-
-<ng-template #unlinked>
-  <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
 </ng-template>
 
 <ng-template #tagContent>

--- a/client/src/app/components/comments/comment-tag/comment-tag.component.ts
+++ b/client/src/app/components/comments/comment-tag/comment-tag.component.ts
@@ -2,7 +2,8 @@ import { Component, Input, OnInit } from '@angular/core';
 
 export interface LinkableComment {
   id: number,
-  name: string
+  name: string,
+  link: string
 }
 
 export interface Subject {

--- a/client/src/app/components/diseases/cvc-disease-popover/cvc-disease-popover.query.gql
+++ b/client/src/app/components/diseases/cvc-disease-popover/cvc-disease-popover.query.gql
@@ -9,5 +9,6 @@ query DiseasePopover($diseaseId: Int!) {
     assertionCount
     evidenceItemCount
     variantCount
+    link
   }
 }

--- a/client/src/app/components/diseases/cvc-disease-tag/cvc-disease-tag.component.html
+++ b/client/src/app/components/diseases/cvc-disease-tag/cvc-disease-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/diseases/{{disease.id}}">
+  <a [routerLink]="disease.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/diseases/cvc-disease-tag/cvc-disease-tag.component.ts
+++ b/client/src/app/components/diseases/cvc-disease-tag/cvc-disease-tag.component.ts
@@ -5,6 +5,7 @@ import { Maybe } from '@app/generated/civic.apollo';
 export interface LinkableDisease {
   id: number,
   name: string,
+  link: string,
 }
 
 @Component({

--- a/client/src/app/components/diseases/diseases-table/diseases-table.query.gql
+++ b/client/src/app/components/diseases/diseases-table/diseases-table.query.gql
@@ -46,4 +46,5 @@ fragment BrowseDiseaseRowFields on BrowseDisease {
   evidenceItemCount
   variantCount
   geneCount
+  link
 }

--- a/client/src/app/components/drugs/cvc-drug-popover/cvc-drug-popover.query.gql
+++ b/client/src/app/components/drugs/cvc-drug-popover/cvc-drug-popover.query.gql
@@ -7,5 +7,6 @@ query DrugPopover($drugId: Int!) {
     drugAliases
     assertionCount
     evidenceItemCount
+    link
   }
 }

--- a/client/src/app/components/drugs/cvc-drug-tag/cvc-drug-tag.component.html
+++ b/client/src/app/components/drugs/cvc-drug-tag/cvc-drug-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/drugs/{{drug.id}}">
+  <a [routerLink]="drug.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/drugs/cvc-drug-tag/cvc-drug-tag.component.ts
+++ b/client/src/app/components/drugs/cvc-drug-tag/cvc-drug-tag.component.ts
@@ -5,6 +5,7 @@ import { Maybe } from '@app/generated/civic.apollo';
 export interface LinkableDrug {
   id: number,
   name: string,
+  link: string,
 }
 
 @Component({

--- a/client/src/app/components/drugs/drugs-table/drugs-table.query.gql
+++ b/client/src/app/components/drugs/drugs-table/drugs-table.query.gql
@@ -39,4 +39,5 @@ fragment DrugBrowseTableRowFields on BrowseDrug {
   drugUrl
   assertionCount
   evidenceCount
+  link
 }

--- a/client/src/app/components/events/event-feed/event-feed.component.html
+++ b/client/src/app/components/events/event-feed/event-feed.component.html
@@ -1,92 +1,70 @@
-<ng-container *ngIf="events$ | ngrxPush as events">
-  <nz-card [nzTitle]="cardTitle"
-    [nzExtra]="cardExtra"
-    id="card-content">
-    <ng-template #cardTitle>
-      <i nz-icon
-        [nzType]="subscribable.entityType | iconNameForSubscribableEntity"
-        *ngIf="subscribable"></i> {{ subscribableName }} Events
-    </ng-template>
-    <ng-template #cardExtra>
-      <form nz-form
-        nzLayout="inline"
-        id="event-filters">
-        <nz-form-item>
-          <nz-form-label>Show</nz-form-label>
-          <nz-form-control>
-            <nz-select (ngModelChange)="onActionSelected($event)"
-              nzSize="small"
-              id="action-filter"
-              name="selectedAction"
-              [(ngModel)]="actionFilter"
-              [nzDropdownMatchSelectWidth]="false">
-              <nz-option nzLabel="All Actions"
-                nzValue="ALL"></nz-option>
-              <nz-option *ngFor="let a of actions$ | ngrxPush"
-                [nzLabel]="a.id"
-                [nzValue]="a.id">
-              </nz-option>
-            </nz-select>
-          </nz-form-control>
-        </nz-form-item>
-        <nz-form-item *ngIf="!userId">
-          <nz-form-control>
-            <nz-select (ngModelChange)="onParticipantSelected($event)"
-              nzSize="small"
-              id="participant-filter"
-              name="selectedParticipant"
-              [(ngModel)]="participantFilter"
-              [nzDropdownMatchSelectWidth]="false">
-              <nz-option nzLabel="All Curators"
-                nzValue="ALL"></nz-option>
-              <nz-option *ngFor="let p of participants$ | ngrxPush"
-                [nzLabel]="p.displayName"
-                [nzValue]="p.id">
-              </nz-option>
-            </nz-select>
-          </nz-form-control>
-        </nz-form-item>
-        <nz-form-item *ngIf="!organizationId">
-          <nz-form-control>
-            <nz-select (ngModelChange)="onOrganizationSelected($event)"
-              nzSize="small"
-              id="organization-filter"
-              name="selectedOrganization"
-              [(ngModel)]="organizationFilter"
-              [nzDropdownMatchSelectWidth]="false">
-              <nz-option nzLabel="All Organizations"
-                nzValue="ALL"></nz-option>
-              <nz-option *ngFor="let o of organizations$ | ngrxPush"
-                [nzLabel]="o.name"
-                [nzValue]="o.id">
-              </nz-option>
-            </nz-select>
-          </nz-form-control>
-        </nz-form-item>
-      </form>
-      <span *ngIf="subscribable">
+<nz-row [nzGutter]="16">
+  <nz-col nzSpan="18">
+    <nz-space nzDirection="vertical"
+      style="width: 100%">
+      <nz-card nzTitle="Events"
+        *nzSpaceItem>
+        <ng-container *ngIf="events$ | ngrxPush as events">
+            <nz-row [nzGutter]="16">
+              <nz-col nzSpan="24"
+                class="timeline">
+                <ng-container *ngIf="events.length">
+                  <cvc-event-timeline [events]="events" [tagDisplay]=tagDisplay></cvc-event-timeline>
+                </ng-container>
+                <ng-container *ngIf="pageInfo$ | ngrxPush as pageInfo">
+                  <div nz-list-load-more
+                    *ngIf="pageInfo.hasNextPage">
+                    <button nz-button
+                      nzType="default"
+                      nzSize="small"
+                      nzBlock
+                      (click)="fetchMore(pageInfo.endCursor)">Load More
+                    </button>
+                  </div>
+                </ng-container>
+              </nz-col>
+            </nz-row>
+        </ng-container>
+      </nz-card>
+    </nz-space>
+  </nz-col>
+  <nz-col nzSpan="6">
+    <nz-space nzDirection="vertical" *ngIf="subscribable">
+      <span *nzSpaceItem>
         Show Child Events
         <nz-switch nzSize="small" [(ngModel)]="showChildren" (ngModelChange)="onShowChildrenToggle()"></nz-switch>
       </span>
-    </ng-template>
-    <nz-row [nzGutter]="16">
-      <nz-col nzSpan="24"
-        class="timeline">
-        <ng-container *ngIf="events.length">
-          <cvc-event-timeline [events]="events" [tagDisplay]=tagDisplay></cvc-event-timeline>
-        </ng-container>
-        <ng-container *ngIf="pageInfo$ | ngrxPush as pageInfo">
-          <div nz-list-load-more
-            *ngIf="pageInfo.hasNextPage">
-            <button nz-button
-              nzType="default"
-              nzSize="small"
-              nzBlock
-              (click)="fetchMore(pageInfo.endCursor)">Load More
-            </button>
-          </div>
-        </ng-container>
-      </nz-col>
-    </nz-row>
-  </nz-card>
-</ng-container>
+      <ng-container *nzSpaceItem>
+        <cvc-participant-list listTitle="Action"
+          [participantList]="actions$ | ngrxPush"
+          (participantSelectedEvent)="onActionSelected($event)">
+          <ng-template #itemTemplate let-action>
+            {{ action.id | eventVerbiage: 'action-filter' }}
+          </ng-template>
+        </cvc-participant-list>
+        <cvc-participant-list *ngIf="!userId" listTitle="Curator" [participantList]="participants$ | ngrxPush"
+          (participantSelectedEvent)="onOriginatingUserSelected($event)">
+          <ng-template #itemTemplate let-user>
+            <nz-avatar *ngIf="user.profileImagePath; else noAvatar"
+              nz-comment-avatar
+              [nzSrc]="user.profileImagePath">
+            </nz-avatar>
+            <ng-template #noAvatar>
+              <nz-avatar nz-comment-avatar
+                [nzText]="user.displayName.charAt(0) | uppercase"></nz-avatar>
+            </ng-template>
+            <span>{{user.displayName}}</span>
+          </ng-template>
+        </cvc-participant-list>
+        <cvc-participant-list *ngIf="!organizationId" listTitle="Organization" [participantList]="organizations$ | ngrxPush"
+          (participantSelectedEvent)="onOrganizationSelected($event)">
+          <ng-template #itemTemplate let-organization>
+            <nz-col>
+              {{ organization.name }}
+            </nz-col>
+          </ng-template>
+        </cvc-participant-list>
+      </ng-container>
+    </nz-space>
+  </nz-col>
+</nz-row>

--- a/client/src/app/components/events/event-feed/event-feed.component.html
+++ b/client/src/app/components/events/event-feed/event-feed.component.html
@@ -1,70 +1,64 @@
-<nz-row [nzGutter]="16">
-  <nz-col nzSpan="18">
-    <nz-space nzDirection="vertical"
-      style="width: 100%">
-      <nz-card nzTitle="Events"
-        *nzSpaceItem>
-        <ng-container *ngIf="events$ | ngrxPush as events">
+<ng-container *ngIf="this.unfilteredCount$ | ngrxPush as count; else noEvents">
+  <nz-row [nzGutter]="16">
+    <nz-col nzSpan="18">
+      <nz-space nzDirection="vertical" style="width: 100%">
+        <nz-card nzTitle="Events" *nzSpaceItem>
+          <ng-container *ngIf="events$ | ngrxPush as events">
             <nz-row [nzGutter]="16">
-              <nz-col nzSpan="24"
-                class="timeline">
-                <ng-container *ngIf="events.length">
+              <nz-col nzSpan="24" class="timeline">
+                <ng-container *ngIf="events.length; else noEvents">
                   <cvc-event-timeline [events]="events" [tagDisplay]=tagDisplay></cvc-event-timeline>
                 </ng-container>
                 <ng-container *ngIf="pageInfo$ | ngrxPush as pageInfo">
-                  <div nz-list-load-more
-                    *ngIf="pageInfo.hasNextPage">
-                    <button nz-button
-                      nzType="default"
-                      nzSize="small"
-                      nzBlock
+                  <div nz-list-load-more *ngIf="pageInfo.hasNextPage">
+                    <button nz-button nzType="default" nzSize="small" nzBlock
                       (click)="fetchMore(pageInfo.endCursor)">Load More
                     </button>
                   </div>
                 </ng-container>
               </nz-col>
             </nz-row>
-        </ng-container>
-      </nz-card>
-    </nz-space>
-  </nz-col>
-  <nz-col nzSpan="6">
-    <nz-space nzDirection="vertical" *ngIf="subscribable">
-      <span *nzSpaceItem>
-        Show Child Events
-        <nz-switch nzSize="small" [(ngModel)]="showChildren" (ngModelChange)="onShowChildrenToggle()"></nz-switch>
-      </span>
-      <ng-container *nzSpaceItem>
-        <cvc-participant-list listTitle="Action"
-          [participantList]="actions$ | ngrxPush"
-          (participantSelectedEvent)="onActionSelected($event)">
-          <ng-template #itemTemplate let-action>
-            {{ action.id | eventVerbiage: 'action-filter' }}
-          </ng-template>
-        </cvc-participant-list>
-        <cvc-participant-list *ngIf="!userId" listTitle="Curator" [participantList]="participants$ | ngrxPush"
-          (participantSelectedEvent)="onOriginatingUserSelected($event)">
-          <ng-template #itemTemplate let-user>
-            <nz-avatar *ngIf="user.profileImagePath; else noAvatar"
-              nz-comment-avatar
-              [nzSrc]="user.profileImagePath">
-            </nz-avatar>
-            <ng-template #noAvatar>
-              <nz-avatar nz-comment-avatar
-                [nzText]="user.displayName.charAt(0) | uppercase"></nz-avatar>
+          </ng-container>
+        </nz-card>
+      </nz-space>
+    </nz-col>
+    <nz-col nzSpan="6">
+      <nz-space nzDirection="vertical" style="width: 100%" *ngIf="showFilters">
+        <span *nzSpaceItem>
+          Show Child Events
+          <nz-switch nzSize="small" [(ngModel)]="showChildren" (ngModelChange)="onShowChildrenToggle()"></nz-switch>
+        </span>
+        <ng-container *nzSpaceItem>
+          <cvc-participant-list listTitle="Action" [participantList]="actions$ | ngrxPush"
+            (participantSelectedEvent)="onActionSelected($event)">
+            <ng-template #itemTemplate let-action>
+              {{ action.id | eventVerbiage: 'action-filter' }}
             </ng-template>
-            <span>{{user.displayName}}</span>
-          </ng-template>
-        </cvc-participant-list>
-        <cvc-participant-list *ngIf="!organizationId" listTitle="Organization" [participantList]="organizations$ | ngrxPush"
-          (participantSelectedEvent)="onOrganizationSelected($event)">
-          <ng-template #itemTemplate let-organization>
-            <nz-col>
-              {{ organization.name }}
-            </nz-col>
-          </ng-template>
-        </cvc-participant-list>
-      </ng-container>
-    </nz-space>
-  </nz-col>
-</nz-row>
+          </cvc-participant-list>
+          <cvc-participant-list *ngIf="!userId" listTitle="Curator" [participantList]="participants$ | ngrxPush"
+            (participantSelectedEvent)="onOriginatingUserSelected($event)">
+            <ng-template #itemTemplate let-user>
+              <nz-avatar *ngIf="user.profileImagePath; else noAvatar" nz-comment-avatar [nzSrc]="user.profileImagePath">
+              </nz-avatar>
+              <ng-template #noAvatar>
+                <nz-avatar nz-comment-avatar [nzText]="user.displayName.charAt(0) | uppercase"></nz-avatar>
+              </ng-template>
+              <span>{{user.displayName}}</span>
+            </ng-template>
+          </cvc-participant-list>
+          <cvc-participant-list *ngIf="!organizationId" listTitle="Organization"
+            [participantList]="organizations$ | ngrxPush" (participantSelectedEvent)="onOrganizationSelected($event)">
+            <ng-template #itemTemplate let-organization>
+              <nz-col>
+                {{ organization.name }}
+              </nz-col>
+            </ng-template>
+          </cvc-participant-list>
+        </ng-container>
+      </nz-space>
+    </nz-col>
+  </nz-row>
+</ng-container>
+<ng-template #noEvents>
+  <nz-empty nzNotFoundImage="simple" nzNotFoundContent="No Events"></nz-empty>
+</ng-template>

--- a/client/src/app/components/events/event-feed/event-feed.component.ts
+++ b/client/src/app/components/events/event-feed/event-feed.component.ts
@@ -6,6 +6,8 @@ import {
   EventFeedQuery,
   EventFeedQueryVariables,
   Maybe,
+  NotificationOrganizationFragment,
+  NotificationOriginatingUsersFragment,
   PageInfo,
   SubscribableEntities,
   SubscribableInput,
@@ -39,10 +41,6 @@ export class CvcEventFeedComponent implements OnInit {
 
   private initialQueryVars?: EventFeedQueryVariables;
   private pageSize = 5;
-
-  participantFilter: 'ALL' | number = 'ALL';
-  organizationFilter: 'ALL' | number = 'ALL';
-  actionFilter: 'ALL' | number = 'ALL';
 
   events$?: Observable<Maybe<EventFeedNodeFragment>[]>;
   pageInfo$?: Observable<PageInfo>;
@@ -98,28 +96,24 @@ export class CvcEventFeedComponent implements OnInit {
     })
   }
 
-  onParticipantSelected(u: 'ALL' | number) {
+  onOrganizationSelected(s: Maybe<NotificationOrganizationFragment>) {
     this.queryRef.refetch({
-      ...this.initialQueryVars,
-      originatingUserId: u === 'ALL' ? undefined : u
+      organizationId: s?.id
     })
   }
 
-  onOrganizationSelected(o: 'ALL' | number) {
+  onActionSelected(a: Maybe<SelectableAction>) {
     this.queryRef.refetch({
-      ...this.initialQueryVars,
-      organizationId: o === 'ALL' ? undefined : o
+      eventType: a ? a.id : undefined
     })
   }
 
-  //onActionSelected(a: 'ALL' | Maybe<SelectableAction>) {
-  onActionSelected(a: 'ALL' | EventAction) {
-      console.log(a)
+  onOriginatingUserSelected(s: Maybe<NotificationOriginatingUsersFragment>) {
     this.queryRef.refetch({
-      ...this.initialQueryVars,
-      eventType: a === 'ALL'? undefined : a
+      originatingUserId: s?.id
     })
   }
+
 
   onShowChildrenToggle() {
     console.log(this.showChildren)

--- a/client/src/app/components/events/event-feed/event-feed.gql
+++ b/client/src/app/components/events/event-feed/event-feed.gql
@@ -6,7 +6,8 @@ query EventFeed (
     $after: String,
     $originatingUserId: Int,
     $organizationId: Int,
-    $eventType: EventAction
+    $eventType: EventAction,
+    $mode: EventFeedMode
 ){
 events (
     subject: $subject,
@@ -15,8 +16,9 @@ events (
     before: $before,
     after: $after,
     originatingUserId: $originatingUserId,
-    organizationId: $organizationId
-    eventType: $eventType
+    organizationId: $organizationId,
+    eventType: $eventType,
+    mode: $mode
 ) { ...eventFeed }
 
 }
@@ -28,6 +30,7 @@ fragment eventFeed on EventConnection {
         hasPreviousPage
     }
     eventTypes
+    unfilteredCount
     uniqueParticipants {
         id
         displayName

--- a/client/src/app/components/events/event-feed/event-feed.gql
+++ b/client/src/app/components/events/event-feed/event-feed.gql
@@ -66,6 +66,7 @@ fragment eventFeedNode on Event {
     subject {
         name
         id
+        link
         ... on Source {
             citation
             sourceType
@@ -81,6 +82,7 @@ fragment eventFeedNode on Event {
     originatingObject {
         id
         name
+        link
         __typename
         ... on Revision {
             id

--- a/client/src/app/components/events/event-feed/event-feed.module.ts
+++ b/client/src/app/components/events/event-feed/event-feed.module.ts
@@ -15,6 +15,7 @@ import { CvcPipesModule } from '@app/core/pipes/pipes.module';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
 import { CvcParticipantListModule } from '@app/components/shared/participant-list/participant-list.module';
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
+import { NzEmptyModule } from 'ng-zorro-antd/empty';
 
 @NgModule({
   declarations: [CvcEventFeedComponent],
@@ -30,6 +31,7 @@ import { NzAvatarModule } from 'ng-zorro-antd/avatar';
     NzSwitchModule,
     NzGridModule,
     NzSpaceModule,
+    NzEmptyModule,
     NzAvatarModule,
     CvcEventTimelineModule,
     CvcPipesModule,

--- a/client/src/app/components/events/event-feed/event-feed.module.ts
+++ b/client/src/app/components/events/event-feed/event-feed.module.ts
@@ -12,6 +12,9 @@ import { NzSelectModule } from 'ng-zorro-antd/select';
 import { CvcEventTimelineModule } from '../event-timeline/event-timeline.module';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { CvcPipesModule } from '@app/core/pipes/pipes.module';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { CvcParticipantListModule } from '@app/components/shared/participant-list/participant-list.module';
+import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 
 @NgModule({
   declarations: [CvcEventFeedComponent],
@@ -26,7 +29,11 @@ import { CvcPipesModule } from '@app/core/pipes/pipes.module';
     NzSelectModule,
     NzSwitchModule,
     NzGridModule,
+    NzSpaceModule,
+    NzAvatarModule,
     CvcEventTimelineModule,
+    CvcPipesModule,
+    CvcParticipantListModule,
     CvcPipesModule
   ],
   exports: [CvcEventFeedComponent]

--- a/client/src/app/components/events/event-timeline-item/event-timeline-item.component.html
+++ b/client/src/app/components/events/event-timeline-item/event-timeline-item.component.html
@@ -42,6 +42,7 @@
       <cvc-assertion-tag *ngSwitchCase="'Assertion'" [assertion]="subject"></cvc-assertion-tag>
       <cvc-evidence-tag *ngSwitchCase="'EvidenceItem'" [evidence]="subject"></cvc-evidence-tag>
       <cvc-variant-tag *ngSwitchCase="'Variant'" [variant]="subject"></cvc-variant-tag>
+      <cvc-revision-tag *ngSwitchCase="'Revision'" [revision]="subject"></cvc-revision-tag>
       <span *ngSwitchCase="'Source'"></span>
       <span *ngSwitchDefault>{{ subject.name }}</span>
     </ng-container>

--- a/client/src/app/components/evidence/evidence-popover/evidence-popover.component.html
+++ b/client/src/app/components/evidence/evidence-popover/evidence-popover.component.html
@@ -32,7 +32,7 @@
         <!-- source -->
         <nz-descriptions-item nzTitle="Source"
           nzSpan="2">
-          <cvc-source-tag [source]="evidence.source"></cvc-source-tag>
+          <cvc-source-tag [source]="evidence.source" [enablePopover]="false"></cvc-source-tag>
         </nz-descriptions-item>
 
         <!-- evidence level -->

--- a/client/src/app/components/evidence/evidence-popover/evidence-popover.query.gql
+++ b/client/src/app/components/evidence/evidence-popover/evidence-popover.query.gql
@@ -16,30 +16,36 @@ fragment evidencePopover on EvidenceItem {
   drugs {
     id
     name
+    link
   }
   drugInteractionType
   disease {
     id
     name
+    link
   }
   phenotypes {
     id
     name
+    link
   }
   evidenceRating
   gene {
     id
     name
+    link
   }
   variant {
     id
     name
+    link
   }
   source {
     id
     citation
     sourceType
     displayType
+    link
   }
   flags(state: OPEN) {
     totalCount

--- a/client/src/app/components/evidence/evidence-table/evidence-table.query.gql
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.query.gql
@@ -74,25 +74,31 @@ query EvidenceBrowse(
 fragment EvidenceGridFields on EvidenceItem {
     id
     name
+    link
     disease {
       id
       name
+      link
     }
     drugs {
       id
       name
+      link
     }
     gene {
       id
       name
+      link
     }
     variant {
       id
       name
+      link
     }
     phenotypes @include(if: $cardView) {
       id
       name
+      link
     }
     source @include(if: $cardView)  {
       id
@@ -104,10 +110,12 @@ fragment EvidenceGridFields on EvidenceItem {
         nctId
         id
       }
+      link
     }
     assertions @include(if: $cardView) {
       id
       name
+      link
     }
     status
     drugInteractionType

--- a/client/src/app/components/evidence/evidence-tag/evidence-tag.component.html
+++ b/client/src/app/components/evidence/evidence-tag/evidence-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/evidence/{{evidence.id}}">
+  <a [routerLink]="evidence.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/evidence/evidence-tag/evidence-tag.component.ts
+++ b/client/src/app/components/evidence/evidence-tag/evidence-tag.component.ts
@@ -5,7 +5,8 @@ import { EvidenceStatus, Maybe } from '@app/generated/civic.apollo';
 export interface LinkableEvidence {
   id: number,
   name: string,
-  status?: EvidenceStatus
+  status?: EvidenceStatus,
+  link: string,
 }
 
 @Component({

--- a/client/src/app/components/flags/flag-list-and-filter/flag-list-and-filter.gql
+++ b/client/src/app/components/flags/flag-list-and-filter/flag-list-and-filter.gql
@@ -58,6 +58,7 @@ fragment flag on Flag {
   flaggable {
     id
     name
+    link
   }
   flaggingUser {
     id
@@ -79,6 +80,7 @@ fragment flag on Flag {
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {
@@ -99,6 +101,7 @@ fragment flag on Flag {
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {

--- a/client/src/app/components/flags/flag-tag/flag-tag.component.html
+++ b/client/src/app/components/flags/flag-tag/flag-tag.component.html
@@ -1,16 +1,6 @@
-<ng-container *ngIf="subject; noSubject">
-  <a routerLink="/{{subject.__typename | typenameToRoute}}/{{subject.id}}/flags">
-    <nz-tag>
-      <ng-template [ngTemplateOutlet]="flagTemplate"></ng-template>
-    </nz-tag>
-  </a>
-</ng-container>
-
-<ng-template #flagTemplate>
-  <i nz-icon nzType="civic-flag" nzTheme="twotone" nzTwotoneColor="#E24759"></i>
-  {{ flag.name }}
-</ng-template>
-
-<ng-template #noSubject>
-  <ng-template [ngTemplateOutlet]="flagTemplate"></ng-template>
-</ng-template>
+<a [routerLink]="flag.link">
+  <nz-tag>
+    <i nz-icon nzType="civic-flag" nzTheme="twotone" nzTwotoneColor="#E24759"></i>
+    {{ flag.name }}
+  </nz-tag>
+</a>

--- a/client/src/app/components/flags/flag-tag/flag-tag.component.ts
+++ b/client/src/app/components/flags/flag-tag/flag-tag.component.ts
@@ -3,6 +3,7 @@ import { Component, Input, OnInit } from '@angular/core';
 export interface LinkableFlag {
   id: number,
   name: string,
+  link: string,
 }
 
 export interface Subject {

--- a/client/src/app/components/genes/gene-tag/gene-tag.component.html
+++ b/client/src/app/components/genes/gene-tag/gene-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/genes/{{gene.id}}">
+  <a [routerLink]="gene.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/genes/gene-tag/gene-tag.component.ts
+++ b/client/src/app/components/genes/gene-tag/gene-tag.component.ts
@@ -5,6 +5,7 @@ import { Maybe } from '@app/generated/civic.apollo';
 export interface LinkableGene {
   id: number;
   name: string;
+  link: string;
 }
 
 @Component({

--- a/client/src/app/components/genes/genes-table/genes-table.query.gql
+++ b/client/src/app/components/genes/genes-table/genes-table.query.gql
@@ -27,14 +27,17 @@ query BrowseGenes(
         id
         entrezId
         name
+        link
         geneAliases
         diseases {
           name
           id
+          link
         }
         drugs {
           name
           id
+          link
         }
         variantCount
         evidenceItemCount

--- a/client/src/app/components/phenotypes/phenotype-popover/phenotype-popover.query.gql
+++ b/client/src/app/components/phenotypes/phenotype-popover/phenotype-popover.query.gql
@@ -6,5 +6,6 @@ query PhenotypePopover($phenotypeId: Int!) {
     hpoId
     assertionCount
     evidenceItemCount
+    link
   }
 }

--- a/client/src/app/components/phenotypes/phenotype-tag/phenotype-tag.component.html
+++ b/client/src/app/components/phenotypes/phenotype-tag/phenotype-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/phenotypes/{{phenotype.id}}">
+  <a [routerLink]="phenotype.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/phenotypes/phenotype-tag/phenotype-tag.component.ts
+++ b/client/src/app/components/phenotypes/phenotype-tag/phenotype-tag.component.ts
@@ -5,6 +5,7 @@ import { Maybe } from '@app/generated/civic.apollo';
 export interface LinkablePhenotype {
   id: number,
   name: string,
+  link: string,
 }
 
 @Component({

--- a/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.query.gql
+++ b/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.query.gql
@@ -39,4 +39,5 @@ fragment PhenotypeBrowseTableRowFields on BrowsePhenotype {
   url
   assertionCount
   evidenceCount
+  link
 }

--- a/client/src/app/components/revisions/revision-list/revision-list.component.html
+++ b/client/src/app/components/revisions/revision-list/revision-list.component.html
@@ -25,7 +25,7 @@
               [diffObject]="revision.linkoutData.diffValue"
               entityType="Disease">
               <ng-template #itemTemplate let-item>
-                <cvc-disease-tag [disease]="{id: item.id, name: item.displayName}"></cvc-disease-tag>
+                <cvc-disease-tag [disease]="{id: item.id, name: item.displayName, link: item.link}"></cvc-disease-tag>
               </ng-template>
             </cvc-revision-list-diff>
           </ng-container>
@@ -34,7 +34,7 @@
               [diffObject]="revision.linkoutData.diffValue"
               entityType="Drugs">
               <ng-template #itemTemplate let-item>
-                <cvc-drug-tag [drug]="{id: item.id, name: item.displayName}"></cvc-drug-tag>
+                <cvc-drug-tag [drug]="{id: item.id, name: item.displayName, link: item.link}"></cvc-drug-tag>
               </ng-template>
             </cvc-revision-list-diff>
           </ng-container>
@@ -76,7 +76,7 @@
               [diffObject]="revision.linkoutData.diffValue"
               entityType="Variant Types">
               <ng-template #itemTemplate let-item>
-                <cvc-variant-type-tag [variantType]="{id: item.id, name: item.displayName}"></cvc-variant-type-tag>
+                <cvc-variant-type-tag [variantType]="{id: item.id, name: item.displayName, link: item.link}"></cvc-variant-type-tag>
               </ng-template>
             </cvc-revision-list-diff>
           </ng-container>
@@ -85,7 +85,7 @@
               [diffObject]="revision.linkoutData.diffValue"
               entityType="Phenotypes">
               <ng-template #itemTemplate let-item>
-                <cvc-phenotype-tag [phenotype]="{id: item.id, name: item.displayName}"></cvc-phenotype-tag>
+                <cvc-phenotype-tag [phenotype]="{id: item.id, name: item.displayName, link: item.link}"></cvc-phenotype-tag>
               </ng-template>
             </cvc-revision-list-diff>
           </ng-container>
@@ -94,7 +94,7 @@
               [diffObject]="revision.linkoutData.diffValue"
               entityType="Variant">
               <ng-template #itemTemplate let-item>
-                <cvc-variant-tag [variant]="{id: item.id, name: item.displayName}"></cvc-variant-tag>
+                <cvc-variant-tag [variant]="{id: item.id, name: item.displayName, link: item.link}"></cvc-variant-tag>
               </ng-template>
             </cvc-revision-list-diff>
           </ng-container>
@@ -103,7 +103,7 @@
               [diffObject]="revision.linkoutData.diffValue"
               entityType="Variants">
               <ng-template #itemTemplate let-item>
-                <cvc-variant-tag [variant]="{id: item.id, name: item.displayName}"></cvc-variant-tag>
+                <cvc-variant-tag [variant]="{id: item.id, name: item.displayName, link: item.link}"></cvc-variant-tag>
               </ng-template>
             </cvc-revision-list-diff>
           </ng-container>

--- a/client/src/app/components/revisions/revision-tag/revision-tag.component.html
+++ b/client/src/app/components/revisions/revision-tag/revision-tag.component.html
@@ -1,17 +1,6 @@
-
-<ng-container *ngIf="subject; noSubject">
-  <a routerLink="/{{subject.__typename | typenameToRoute}}/{{subject.id}}/revisions">
-    <nz-tag>
-      <ng-template [ngTemplateOutlet]="revisionTemplate"></ng-template>
-    </nz-tag>
-  </a>
-</ng-container>
-
-<ng-template #revisionTemplate>
-  <i nz-icon nzType="civic-revision" nzTheme="twotone" nzTwotoneColor="#F0673A"></i>
-  {{ revision.name }}
-</ng-template>
-
-<ng-template #noSubject>
-  <ng-template [ngTemplateOutlet]="revisionTemplate"></ng-template>
-</ng-template>
+<a [routerLink]="revision.link">
+  <nz-tag>
+    <i nz-icon nzType="civic-revision" nzTheme="twotone" nzTwotoneColor="#F0673A"></i>
+    {{ revision.name }}
+  </nz-tag>
+</a>

--- a/client/src/app/components/revisions/revision-tag/revision-tag.component.ts
+++ b/client/src/app/components/revisions/revision-tag/revision-tag.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { Maybe } from '@app/generated/civic.apollo';
 
 export interface LinkableRevision {
   id: number,
-  name: string
+  name: string,
+  link: string
 }
 
 export interface Subject {
@@ -18,6 +20,7 @@ export interface Subject {
 export class CvcRevisionTagComponent implements OnInit {
   @Input() revision!: LinkableRevision
   @Input() subject?: Subject
+  @Input() enablePopover: Boolean = true
 
   constructor() { }
 

--- a/client/src/app/components/revisions/revisions-list-and-filter/revisions-list-and-filter.query.gql
+++ b/client/src/app/components/revisions/revisions-list-and-filter/revisions-list-and-filter.query.gql
@@ -69,30 +69,35 @@ fragment revision on Revision {
           displayName
           displayType
           entityType
+          link
         }
         addedObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
         removedObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
         keptObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
         suggestedObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
       }
       ... on ScalarFieldDiff {
@@ -118,6 +123,7 @@ fragment revision on Revision {
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {
@@ -137,6 +143,7 @@ fragment revision on Revision {
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {

--- a/client/src/app/components/shared/tag-overflow/tag-overflow.component.ts
+++ b/client/src/app/components/shared/tag-overflow/tag-overflow.component.ts
@@ -6,6 +6,7 @@ export type SupportedPileupTags = 'drug' | 'disease' | 'organization'
 export type TagInfo = {
   id: number
   name: string
+  link: string
 }
 
 @Component({

--- a/client/src/app/components/sources/source-popover/source-popover.query.gql
+++ b/client/src/app/components/sources/source-popover/source-popover.query.gql
@@ -15,5 +15,6 @@ fragment sourcePopover on SourcePopover {
   clinicalTrials {
     id
     nctId
+    link
   }
 }

--- a/client/src/app/components/sources/source-tag/source-tag.component.html
+++ b/client/src/app/components/sources/source-tag/source-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/sources/{{source.id}}">
+  <a [routerLink]="source.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/sources/source-tag/source-tag.component.ts
+++ b/client/src/app/components/sources/source-tag/source-tag.component.ts
@@ -6,6 +6,7 @@ import { Maybe, SourceSource } from '@app/generated/civic.apollo';
 export interface LinkableSource {
   id: number;
   displayInfo: CitationSource | string
+  link: string;
 }
 
 export interface CitationSource {
@@ -16,12 +17,14 @@ export interface CitationSource {
 export interface SourceWithDisplayName {
   id: number,
   displayName: string
+  link: string
 }
 
 export interface SourceWithCitation {
   id: number,
   citation: string;
   sourceType: SourceSource;
+  link: string
 }
 
 @Component({
@@ -32,6 +35,7 @@ export interface SourceWithCitation {
 export class CvcSourceTagComponent extends BaseCloseableTag implements OnInit {
   @Input() source!: SourceWithDisplayName | SourceWithCitation;
   @Input() enablePopover: Maybe<boolean> = true
+  @Input() linked: Maybe<boolean> = true
 
   displayName!: string
 

--- a/client/src/app/components/sources/sources-table/sources-table.query.gql
+++ b/client/src/app/components/sources/sources-table/sources-table.query.gql
@@ -55,4 +55,5 @@ fragment BrowseSourceRowFields on BrowseSource {
   sourceType
   citation
   displayType
+  link
 }

--- a/client/src/app/components/variant-groups/variant-group-tag/variant-group-tag.component.html
+++ b/client/src/app/components/variant-groups/variant-group-tag/variant-group-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/variant-groups/{{variantgroup.id}}">
+  <a [routerLink]="variantgroup.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/variant-groups/variant-group-tag/variant-group-tag.component.ts
+++ b/client/src/app/components/variant-groups/variant-group-tag/variant-group-tag.component.ts
@@ -3,7 +3,8 @@ import { Maybe } from "@app/generated/civic.apollo";
 
 export interface LinkableVariantgroup {
   id: number,
-  name: string
+  name: string,
+  link: string
 }
 
 @Component({

--- a/client/src/app/components/variant-types/variant-type-tag/variant-type-tag.component.html
+++ b/client/src/app/components/variant-types/variant-type-tag/variant-type-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/variant-types/{{variantType.id}}">
+  <a [routerLink]="variantType.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/variant-types/variant-type-tag/variant-type-tag.component.ts
+++ b/client/src/app/components/variant-types/variant-type-tag/variant-type-tag.component.ts
@@ -5,6 +5,7 @@ import { Maybe } from '@app/generated/civic.apollo';
 export interface LinkableVariantType {
   id: number,
   name: string,
+  link: string,
 }
 
 @Component({

--- a/client/src/app/components/variant-types/variant-types-table/variant-types-table.query.gql
+++ b/client/src/app/components/variant-types/variant-types-table/variant-types-table.query.gql
@@ -38,4 +38,5 @@ fragment VariantTypeBrowseTableRowFields on BrowseVariantType {
   soid
   url
   variantCount
+  link
 }

--- a/client/src/app/components/variants/variant-popover/variant-popover.query.gql
+++ b/client/src/app/components/variants/variant-popover/variant-popover.query.gql
@@ -16,6 +16,7 @@ fragment variantPopoverFields on Variant {
   gene {
     id
     name
+    link
   }
   revisions(status: NEW) {
     totalCount

--- a/client/src/app/components/variants/variant-tag/variant-tag.component.html
+++ b/client/src/app/components/variants/variant-tag/variant-tag.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="linked; else unlinked">
-  <a routerLink="/variants/{{variant.id}}">
+  <a [routerLink]="variant.link">
     <ng-template [ngTemplateOutlet]="tag"></ng-template>
   </a>
 </ng-container>

--- a/client/src/app/components/variants/variant-tag/variant-tag.component.ts
+++ b/client/src/app/components/variants/variant-tag/variant-tag.component.ts
@@ -5,6 +5,7 @@ import { Maybe } from '@app/generated/civic.apollo';
 export interface LinkableVariant {
   id: number;
   name: string;
+  link: string;
 }
 
 @Component({

--- a/client/src/app/components/variants/variants-table/variants-table.component.html
+++ b/client/src/app/components/variants/variants-table/variants-table.component.html
@@ -154,7 +154,7 @@
           </span>
         </td>
         <td>
-          <cvc-gene-tag [gene]="{id: variant.geneId, name: variant.geneName}"></cvc-gene-tag>
+          <cvc-gene-tag [gene]="{id: variant.geneId, name: variant.geneName, link: variant.geneLink}"></cvc-gene-tag>
         </td>
         <td>
           <cvc-tag-overflow tagType="disease"

--- a/client/src/app/components/variants/variants-table/variants-table.query.gql
+++ b/client/src/app/components/variants/variants-table/variants-table.query.gql
@@ -37,17 +37,21 @@ query BrowseVariants(
       node {
         id
         name
+        link
         evidenceScore
         evidenceItemCount
         geneId
         geneName
+        geneLink
         diseases {
           id
           name
+          link
         }
         drugs {
           id
           name
+          link
         }
         aliases {
           name

--- a/client/src/app/core/pipes/typename-to-route-pipe.ts
+++ b/client/src/app/core/pipes/typename-to-route-pipe.ts
@@ -20,6 +20,8 @@ export class TypenameToRoutePipe implements PipeTransform {
         return 'sources'
       case ('SourceSuggestion'):
         return 'source-suggestions'
+      case ('Revision'):
+        return 'revisions'
       default:
         throw new Error('Not handling all typenames yet' + n)
     }

--- a/client/src/app/forms/evidence-revise/evidence-revise.query.gql
+++ b/client/src/app/forms/evidence-revise/evidence-revise.query.gql
@@ -9,6 +9,7 @@ fragment RevisableEvidenceFields on EvidenceItem {
   variant {
     id
     name
+    link
   }
   variantOrigin
   description

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -217,6 +217,7 @@ export type Assertion = Commentable & EventOriginObject & EventSubject & Flaggab
   lastAcceptedRevisionEvent?: Maybe<Event>;
   lastCommentEvent?: Maybe<Event>;
   lastSubmittedRevisionEvent?: Maybe<Event>;
+  link: Scalars['String'];
   name: Scalars['String'];
   nccnGuideline?: Maybe<Scalars['String']>;
   nccnGuidelineVersion?: Maybe<Scalars['String']>;
@@ -411,6 +412,7 @@ export type BrowseClinicalTrial = {
   __typename: 'BrowseClinicalTrial';
   evidenceCount: Scalars['Int'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   nctId?: Maybe<Scalars['String']>;
   sourceCount: Scalars['Int'];
@@ -453,6 +455,7 @@ export type BrowseDisease = {
   geneCount: Scalars['Int'];
   geneNames: Array<Scalars['String']>;
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   variantCount: Scalars['Int'];
 };
@@ -489,6 +492,7 @@ export type BrowseDrug = {
   drugUrl?: Maybe<Scalars['String']>;
   evidenceCount: Scalars['Int'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   ncitId?: Maybe<Scalars['String']>;
 };
@@ -529,6 +533,7 @@ export type BrowseGene = {
   evidenceItemCount: Scalars['Int'];
   geneAliases?: Maybe<Array<Scalars['String']>>;
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   variantCount: Scalars['Int'];
 };
@@ -565,6 +570,7 @@ export type BrowsePhenotype = {
   evidenceCount: Scalars['Int'];
   hpoId: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   url: Scalars['String'];
 };
@@ -605,6 +611,7 @@ export type BrowseSource = {
   evidenceItemCount: Scalars['Int'];
   id: Scalars['Int'];
   journal?: Maybe<Scalars['String']>;
+  link: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   publicationYear?: Maybe<Scalars['Int']>;
   sourceType: SourceSource;
@@ -646,8 +653,10 @@ export type BrowseVariant = {
   evidenceItemCount: Scalars['Int'];
   evidenceScore: Scalars['Float'];
   geneId: Scalars['Int'];
+  geneLink: Scalars['String'];
   geneName: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
 };
 
@@ -716,6 +725,7 @@ export type BrowseVariantGroupEdge = {
 export type BrowseVariantType = {
   __typename: 'BrowseVariantType';
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   soid: Scalars['String'];
   url?: Maybe<Scalars['String']>;
@@ -767,6 +777,7 @@ export type ClinicalTrial = {
   __typename: 'ClinicalTrial';
   description: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   nctId: Scalars['String'];
   url?: Maybe<Scalars['String']>;
@@ -822,6 +833,7 @@ export type Comment = EventOriginObject & {
   createdAt: Scalars['ISO8601DateTime'];
   creationEvent?: Maybe<Event>;
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   parsedComment: Array<CommentBodySegment>;
   title?: Maybe<Scalars['String']>;
@@ -871,6 +883,7 @@ export type CommentTagSegment = {
   __typename: 'CommentTagSegment';
   displayName: Scalars['String'];
   entityId: Scalars['Int'];
+  link: Scalars['String'];
   status?: Maybe<EvidenceStatus>;
   tagType: TaggableEntity;
 };
@@ -886,6 +899,7 @@ export type Commentable = {
   comments: CommentConnection;
   id: Scalars['Int'];
   lastCommentEvent?: Maybe<Event>;
+  link: Scalars['String'];
   name: Scalars['String'];
 };
 
@@ -995,6 +1009,7 @@ export type Disease = {
   displayName: Scalars['String'];
   doid?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
 };
 
@@ -1007,6 +1022,7 @@ export type DiseasePopover = {
   doid?: Maybe<Scalars['Int']>;
   evidenceItemCount: Scalars['Int'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   variantCount: Scalars['Int'];
 };
@@ -1038,6 +1054,7 @@ export type Drug = {
   drugAliases: Array<Scalars['String']>;
   drugUrl?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   ncitId?: Maybe<Scalars['String']>;
 };
@@ -1055,6 +1072,7 @@ export type DrugPopover = {
   drugUrl?: Maybe<Scalars['String']>;
   evidenceItemCount: Scalars['Int'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   ncitId?: Maybe<Scalars['String']>;
 };
@@ -1184,6 +1202,7 @@ export type EventEdge = {
  */
 export type EventOriginObject = {
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
 };
 
@@ -1192,6 +1211,7 @@ export type EventSubject = {
   /** List and filter events for an object */
   events: EventConnection;
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
 };
 
@@ -1269,6 +1289,7 @@ export type EvidenceItem = Commentable & EventOriginObject & EventSubject & Flag
   lastAcceptedRevisionEvent?: Maybe<Event>;
   lastCommentEvent?: Maybe<Event>;
   lastSubmittedRevisionEvent?: Maybe<Event>;
+  link: Scalars['String'];
   name: Scalars['String'];
   phenotypes: Array<Phenotype>;
   rejectionEvent?: Maybe<Event>;
@@ -1455,6 +1476,7 @@ export type Flag = Commentable & EventOriginObject & {
   flaggingUser: User;
   id: Scalars['Int'];
   lastCommentEvent?: Maybe<Event>;
+  link: Scalars['String'];
   name: Scalars['String'];
   openComment: Comment;
   resolutionComment?: Maybe<Comment>;
@@ -1546,6 +1568,7 @@ export type Flaggable = {
   /** List and filter flags. */
   flags: FlagConnection;
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
 };
 
@@ -1595,6 +1618,7 @@ export type Gene = Commentable & EventSubject & Flaggable & WithRevisions & {
   lastAcceptedRevisionEvent?: Maybe<Event>;
   lastCommentEvent?: Maybe<Event>;
   lastSubmittedRevisionEvent?: Maybe<Event>;
+  link: Scalars['String'];
   myGeneInfoDetails?: Maybe<Scalars['JSON']>;
   name: Scalars['String'];
   officialName: Scalars['String'];
@@ -1808,6 +1832,7 @@ export type ModeratedObjectField = {
   displayType?: Maybe<Scalars['String']>;
   entityType: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
 };
 
 export type Mutation = {
@@ -2330,6 +2355,7 @@ export type Phenotype = {
   __typename: 'Phenotype';
   hpoId: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   url: Scalars['String'];
 };
@@ -2340,6 +2366,7 @@ export type PhenotypePopover = {
   evidenceItemCount: Scalars['Int'];
   hpoId: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   url: Scalars['String'];
 };
@@ -3035,9 +3062,10 @@ export type ResolveFlagPayload = {
   flag?: Maybe<Flag>;
 };
 
-export type Revision = EventOriginObject & EventSubject & {
+export type Revision = Commentable & EventOriginObject & EventSubject & {
   __typename: 'Revision';
-  comments: Array<Comment>;
+  /** List and filter comments. */
+  comments: CommentConnection;
   createdAt: Scalars['ISO8601DateTime'];
   creationComment?: Maybe<Comment>;
   creationEvent?: Maybe<Event>;
@@ -3046,6 +3074,8 @@ export type Revision = EventOriginObject & EventSubject & {
   events: EventConnection;
   fieldName: Scalars['String'];
   id: Scalars['Int'];
+  lastCommentEvent?: Maybe<Event>;
+  link: Scalars['String'];
   linkoutData: LinkoutData;
   name: Scalars['String'];
   resolutionComment?: Maybe<Comment>;
@@ -3055,8 +3085,22 @@ export type Revision = EventOriginObject & EventSubject & {
   revisionsetId: Scalars['String'];
   revisor?: Maybe<User>;
   status: RevisionStatus;
+  subject: EventSubject;
   suggestedValue?: Maybe<Scalars['JSON']>;
   updatedAt: Scalars['ISO8601DateTime'];
+};
+
+
+export type RevisionCommentsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  mentionedEntity?: Maybe<TaggableEntityInput>;
+  mentionedRole?: Maybe<UserRole>;
+  mentionedUserId?: Maybe<Scalars['Int']>;
+  originatingUserId?: Maybe<Scalars['Int']>;
+  sortBy?: Maybe<DateSort>;
 };
 
 
@@ -3172,6 +3216,7 @@ export type Source = EventSubject & {
   fullJournalTitle?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   journal: Scalars['String'];
+  link: Scalars['String'];
   name: Scalars['String'];
   pmcId?: Maybe<Scalars['String']>;
   publicationDate?: Maybe<Scalars['String']>;
@@ -3210,6 +3255,7 @@ export type SourcePopover = EventSubject & {
   fullJournalTitle?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   journal: Scalars['String'];
+  link: Scalars['String'];
   name: Scalars['String'];
   pmcId?: Maybe<Scalars['String']>;
   publicationDate?: Maybe<Scalars['String']>;
@@ -3253,6 +3299,7 @@ export type SourceSuggestion = EventOriginObject & EventSubject & {
   geneName?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   initialComment: Scalars['String'];
+  link: Scalars['String'];
   name: Scalars['String'];
   source: Source;
   status: SourceSuggestionStatus;
@@ -3902,6 +3949,7 @@ export type Variant = Commentable & EventSubject & Flaggable & WithRevisions & {
   lastAcceptedRevisionEvent?: Maybe<Event>;
   lastCommentEvent?: Maybe<Event>;
   lastSubmittedRevisionEvent?: Maybe<Event>;
+  link: Scalars['String'];
   myVariantInfo?: Maybe<MyVariantInfo>;
   name: Scalars['String'];
   referenceBuild?: Maybe<ReferenceBuild>;
@@ -4057,6 +4105,7 @@ export type VariantGroup = Commentable & EventSubject & Flaggable & WithRevision
   lastAcceptedRevisionEvent?: Maybe<Event>;
   lastCommentEvent?: Maybe<Event>;
   lastSubmittedRevisionEvent?: Maybe<Event>;
+  link: Scalars['String'];
   name: Scalars['String'];
   /** List and filter revisions. */
   revisions: RevisionConnection;
@@ -4151,6 +4200,7 @@ export type VariantType = {
   __typename: 'VariantType';
   description: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   soid: Scalars['String'];
   url: Scalars['String'];
@@ -4160,6 +4210,7 @@ export type VariantTypePopover = {
   __typename: 'VariantTypePopover';
   description: Scalars['String'];
   id: Scalars['Int'];
+  link: Scalars['String'];
   name: Scalars['String'];
   soid: Scalars['String'];
   url: Scalars['String'];
@@ -4239,19 +4290,19 @@ export type AssertionPopoverFragment = (
     & Pick<AcmgCode, 'code'>
   )>, drugs: Array<(
     { __typename: 'Drug' }
-    & Pick<Drug, 'id' | 'name'>
+    & Pick<Drug, 'id' | 'name' | 'link'>
   )>, disease?: Maybe<(
     { __typename: 'Disease' }
-    & Pick<Disease, 'id' | 'name'>
+    & Pick<Disease, 'id' | 'name' | 'link'>
   )>, phenotypes: Array<(
     { __typename: 'Phenotype' }
-    & Pick<Phenotype, 'id' | 'name'>
+    & Pick<Phenotype, 'id' | 'name' | 'link'>
   )>, gene: (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
   ), variant: (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ), flags: (
     { __typename: 'FlagConnection' }
     & Pick<FlagConnection, 'totalCount'>
@@ -4312,22 +4363,22 @@ export type AssertionsBrowseQuery = (
 
 export type AssertionBrowseTableRowFieldsFragment = (
   { __typename: 'Assertion' }
-  & MakeOptional<Pick<Assertion, 'id' | 'name' | 'drugInteractionType' | 'summary' | 'assertionType' | 'assertionDirection' | 'clinicalSignificance' | 'ampLevel' | 'fdaCompanionTest' | 'regulatoryApproval' | 'nccnGuideline' | 'variantOrigin'>, 'fdaCompanionTest' | 'regulatoryApproval' | 'nccnGuideline' | 'variantOrigin'>
+  & MakeOptional<Pick<Assertion, 'id' | 'name' | 'link' | 'drugInteractionType' | 'summary' | 'assertionType' | 'assertionDirection' | 'clinicalSignificance' | 'ampLevel' | 'fdaCompanionTest' | 'regulatoryApproval' | 'nccnGuideline' | 'variantOrigin'>, 'fdaCompanionTest' | 'regulatoryApproval' | 'nccnGuideline' | 'variantOrigin'>
   & { gene: (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
   ), variant: (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ), disease?: Maybe<(
     { __typename: 'Disease' }
-    & Pick<Disease, 'id' | 'name'>
+    & Pick<Disease, 'id' | 'name' | 'link'>
   )>, drugs: Array<(
     { __typename: 'Drug' }
-    & Pick<Drug, 'id' | 'name'>
+    & Pick<Drug, 'id' | 'name' | 'link'>
   )>, phenotypes: Array<(
     { __typename: 'Phenotype' }
-    & Pick<Phenotype, 'id' | 'name'>
+    & Pick<Phenotype, 'id' | 'name' | 'link'>
   )>, acmgCodes: Array<(
     { __typename: 'AcmgCode' }
     & Pick<AcmgCode, 'code'>
@@ -4382,7 +4433,7 @@ export type ClinicalTrialsBrowseQuery = (
       & Pick<BrowseClinicalTrialEdge, 'cursor'>
       & { node?: Maybe<(
         { __typename: 'BrowseClinicalTrial' }
-        & Pick<BrowseClinicalTrial, 'id' | 'name' | 'nctId' | 'evidenceCount' | 'sourceCount'>
+        & Pick<BrowseClinicalTrial, 'id' | 'name' | 'nctId' | 'evidenceCount' | 'sourceCount' | 'link'>
       )> }
     )> }
   ) }
@@ -4418,10 +4469,10 @@ export type CommentListQuery = (
       & Pick<User, 'id' | 'displayName' | 'role' | 'profileImagePath'>
     )>, mentionedRoles: Array<(
       { __typename: 'CommentTagSegment' }
-      & Pick<CommentTagSegment, 'displayName' | 'entityId' | 'tagType'>
+      & Pick<CommentTagSegment, 'displayName' | 'entityId' | 'tagType' | 'link'>
     )>, mentionedEntities: Array<(
       { __typename: 'CommentTagSegment' }
-      & Pick<CommentTagSegment, 'displayName' | 'entityId' | 'tagType'>
+      & Pick<CommentTagSegment, 'displayName' | 'entityId' | 'tagType' | 'link'>
     )>, edges: Array<(
       { __typename: 'CommentEdge' }
       & Pick<CommentEdge, 'cursor'>
@@ -4445,7 +4496,7 @@ export type CommentListNodeFragment = (
     )> }
   ), parsedComment: Array<(
     { __typename: 'CommentTagSegment' }
-    & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType' | 'status'>
+    & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType' | 'status' | 'link'>
   ) | (
     { __typename: 'CommentTextSegment' }
     & Pick<CommentTextSegment, 'text'>
@@ -4476,22 +4527,25 @@ export type CommentPopoverFragment = (
     & Pick<User, 'id' | 'displayName' | 'role' | 'profileImagePath'>
   ), commentable: (
     { __typename: 'Assertion' }
-    & Pick<Assertion, 'id' | 'name'>
+    & Pick<Assertion, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'EvidenceItem' }
-    & Pick<EvidenceItem, 'id' | 'name'>
+    & Pick<EvidenceItem, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Flag' }
-    & Pick<Flag, 'id' | 'name'>
+    & Pick<Flag, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
+  ) | (
+    { __typename: 'Revision' }
+    & Pick<Revision, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'VariantGroup' }
-    & Pick<VariantGroup, 'id' | 'name'>
+    & Pick<VariantGroup, 'id' | 'name' | 'link'>
   ) }
 );
 
@@ -4504,7 +4558,7 @@ export type DiseasePopoverQuery = (
   { __typename: 'Query' }
   & { diseasePopover?: Maybe<(
     { __typename: 'DiseasePopover' }
-    & Pick<DiseasePopover, 'id' | 'name' | 'displayName' | 'doid' | 'diseaseUrl' | 'diseaseAliases' | 'assertionCount' | 'evidenceItemCount' | 'variantCount'>
+    & Pick<DiseasePopover, 'id' | 'name' | 'displayName' | 'doid' | 'diseaseUrl' | 'diseaseAliases' | 'assertionCount' | 'evidenceItemCount' | 'variantCount' | 'link'>
   )> }
 );
 
@@ -4541,7 +4595,7 @@ export type BrowseDiseasesQuery = (
 
 export type BrowseDiseaseRowFieldsFragment = (
   { __typename: 'BrowseDisease' }
-  & Pick<BrowseDisease, 'id' | 'name' | 'doid' | 'diseaseUrl' | 'geneNames' | 'assertionCount' | 'evidenceItemCount' | 'variantCount' | 'geneCount'>
+  & Pick<BrowseDisease, 'id' | 'name' | 'doid' | 'diseaseUrl' | 'geneNames' | 'assertionCount' | 'evidenceItemCount' | 'variantCount' | 'geneCount' | 'link'>
 );
 
 export type DrugPopoverQueryVariables = Exact<{
@@ -4553,7 +4607,7 @@ export type DrugPopoverQuery = (
   { __typename: 'Query' }
   & { drugPopover?: Maybe<(
     { __typename: 'DrugPopover' }
-    & Pick<DrugPopover, 'id' | 'name' | 'drugUrl' | 'ncitId' | 'drugAliases' | 'assertionCount' | 'evidenceItemCount'>
+    & Pick<DrugPopover, 'id' | 'name' | 'drugUrl' | 'ncitId' | 'drugAliases' | 'assertionCount' | 'evidenceItemCount' | 'link'>
   )> }
 );
 
@@ -4589,7 +4643,7 @@ export type DrugsBrowseQuery = (
 
 export type DrugBrowseTableRowFieldsFragment = (
   { __typename: 'BrowseDrug' }
-  & Pick<BrowseDrug, 'id' | 'name' | 'ncitId' | 'drugUrl' | 'assertionCount' | 'evidenceCount'>
+  & Pick<BrowseDrug, 'id' | 'name' | 'ncitId' | 'drugUrl' | 'assertionCount' | 'evidenceCount' | 'link'>
 );
 
 export type EventFeedQueryVariables = Exact<{
@@ -4645,49 +4699,49 @@ export type EventFeedNodeFragment = (
     & Pick<User, 'id' | 'username' | 'displayName' | 'role' | 'profileImagePath'>
   ), subject?: Maybe<(
     { __typename: 'Assertion' }
-    & Pick<Assertion, 'status' | 'name' | 'id'>
+    & Pick<Assertion, 'status' | 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'EvidenceItem' }
-    & Pick<EvidenceItem, 'status' | 'name' | 'id'>
+    & Pick<EvidenceItem, 'status' | 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'Gene' }
-    & Pick<Gene, 'name' | 'id'>
+    & Pick<Gene, 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'Revision' }
-    & Pick<Revision, 'name' | 'id'>
+    & Pick<Revision, 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'Source' }
-    & Pick<Source, 'citation' | 'sourceType' | 'name' | 'id'>
+    & Pick<Source, 'citation' | 'sourceType' | 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'SourcePopover' }
-    & Pick<SourcePopover, 'name' | 'id'>
+    & Pick<SourcePopover, 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'SourceSuggestion' }
-    & Pick<SourceSuggestion, 'name' | 'id'>
+    & Pick<SourceSuggestion, 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'Variant' }
-    & Pick<Variant, 'name' | 'id'>
+    & Pick<Variant, 'name' | 'id' | 'link'>
   ) | (
     { __typename: 'VariantGroup' }
-    & Pick<VariantGroup, 'name' | 'id'>
+    & Pick<VariantGroup, 'name' | 'id' | 'link'>
   )>, originatingObject?: Maybe<(
     { __typename: 'Assertion' }
-    & Pick<Assertion, 'id' | 'name'>
+    & Pick<Assertion, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Comment' }
-    & Pick<Comment, 'id' | 'name'>
+    & Pick<Comment, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'EvidenceItem' }
-    & Pick<EvidenceItem, 'id' | 'name'>
+    & Pick<EvidenceItem, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Flag' }
-    & Pick<Flag, 'id' | 'name'>
+    & Pick<Flag, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Revision' }
-    & Pick<Revision, 'id' | 'name'>
+    & Pick<Revision, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'SourceSuggestion' }
-    & Pick<SourceSuggestion, 'id' | 'name'>
+    & Pick<SourceSuggestion, 'id' | 'name' | 'link'>
   )> }
 );
 
@@ -4709,22 +4763,22 @@ export type EvidencePopoverFragment = (
   & Pick<EvidenceItem, 'id' | 'name' | 'description' | 'evidenceLevel' | 'evidenceType' | 'evidenceDirection' | 'clinicalSignificance' | 'variantOrigin' | 'drugInteractionType' | 'evidenceRating'>
   & { drugs: Array<(
     { __typename: 'Drug' }
-    & Pick<Drug, 'id' | 'name'>
+    & Pick<Drug, 'id' | 'name' | 'link'>
   )>, disease?: Maybe<(
     { __typename: 'Disease' }
-    & Pick<Disease, 'id' | 'name'>
+    & Pick<Disease, 'id' | 'name' | 'link'>
   )>, phenotypes: Array<(
     { __typename: 'Phenotype' }
-    & Pick<Phenotype, 'id' | 'name'>
+    & Pick<Phenotype, 'id' | 'name' | 'link'>
   )>, gene: (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
   ), variant: (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ), source: (
     { __typename: 'Source' }
-    & Pick<Source, 'id' | 'citation' | 'sourceType' | 'displayType'>
+    & Pick<Source, 'id' | 'citation' | 'sourceType' | 'displayType' | 'link'>
   ), flags: (
     { __typename: 'FlagConnection' }
     & Pick<FlagConnection, 'totalCount'>
@@ -4789,32 +4843,32 @@ export type EvidenceBrowseQuery = (
 
 export type EvidenceGridFieldsFragment = (
   { __typename: 'EvidenceItem' }
-  & Pick<EvidenceItem, 'id' | 'name' | 'status' | 'drugInteractionType' | 'description' | 'evidenceType' | 'evidenceDirection' | 'evidenceLevel' | 'evidenceRating' | 'clinicalSignificance' | 'variantOrigin'>
+  & Pick<EvidenceItem, 'id' | 'name' | 'link' | 'status' | 'drugInteractionType' | 'description' | 'evidenceType' | 'evidenceDirection' | 'evidenceLevel' | 'evidenceRating' | 'clinicalSignificance' | 'variantOrigin'>
   & { disease?: Maybe<(
     { __typename: 'Disease' }
-    & Pick<Disease, 'id' | 'name'>
+    & Pick<Disease, 'id' | 'name' | 'link'>
   )>, drugs: Array<(
     { __typename: 'Drug' }
-    & Pick<Drug, 'id' | 'name'>
+    & Pick<Drug, 'id' | 'name' | 'link'>
   )>, gene: (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
   ), variant: (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ), phenotypes: Array<(
     { __typename: 'Phenotype' }
-    & Pick<Phenotype, 'id' | 'name'>
+    & Pick<Phenotype, 'id' | 'name' | 'link'>
   )>, source: (
     { __typename: 'Source' }
-    & Pick<Source, 'id' | 'citation' | 'citationId' | 'sourceType' | 'sourceUrl'>
+    & Pick<Source, 'id' | 'citation' | 'citationId' | 'sourceType' | 'sourceUrl' | 'link'>
     & { clinicalTrials?: Maybe<Array<(
       { __typename: 'ClinicalTrial' }
       & Pick<ClinicalTrial, 'nctId' | 'id'>
     )>> }
   ), assertions: Array<(
     { __typename: 'Assertion' }
-    & Pick<Assertion, 'id' | 'name'>
+    & Pick<Assertion, 'id' | 'name' | 'link'>
   )> }
 );
 
@@ -4865,19 +4919,19 @@ export type FlagFragment = (
   & Pick<Flag, 'id' | 'state' | 'createdAt' | 'resolvedAt'>
   & { flaggable: (
     { __typename: 'Assertion' }
-    & Pick<Assertion, 'id' | 'name'>
+    & Pick<Assertion, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'EvidenceItem' }
-    & Pick<EvidenceItem, 'id' | 'name'>
+    & Pick<EvidenceItem, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ) | (
     { __typename: 'VariantGroup' }
-    & Pick<VariantGroup, 'id' | 'name'>
+    & Pick<VariantGroup, 'id' | 'name' | 'link'>
   ), flaggingUser: (
     { __typename: 'User' }
     & Pick<User, 'id' | 'displayName' | 'role' | 'profileImagePath'>
@@ -4888,7 +4942,7 @@ export type FlagFragment = (
     { __typename: 'Comment' }
     & { parsedComment: Array<(
       { __typename: 'CommentTagSegment' }
-      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType'>
+      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType' | 'link'>
     ) | (
       { __typename: 'CommentTextSegment' }
       & Pick<CommentTextSegment, 'text'>
@@ -4900,7 +4954,7 @@ export type FlagFragment = (
     { __typename: 'Comment' }
     & { parsedComment: Array<(
       { __typename: 'CommentTagSegment' }
-      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType'>
+      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType' | 'link'>
     ) | (
       { __typename: 'CommentTextSegment' }
       & Pick<CommentTextSegment, 'text'>
@@ -4965,13 +5019,13 @@ export type BrowseGenesQuery = (
       & Pick<BrowseGeneEdge, 'cursor'>
       & { node?: Maybe<(
         { __typename: 'BrowseGene' }
-        & Pick<BrowseGene, 'id' | 'entrezId' | 'name' | 'geneAliases' | 'variantCount' | 'evidenceItemCount' | 'assertionCount'>
+        & Pick<BrowseGene, 'id' | 'entrezId' | 'name' | 'link' | 'geneAliases' | 'variantCount' | 'evidenceItemCount' | 'assertionCount'>
         & { diseases?: Maybe<Array<(
           { __typename: 'Disease' }
-          & Pick<Disease, 'name' | 'id'>
+          & Pick<Disease, 'name' | 'id' | 'link'>
         )>>, drugs?: Maybe<Array<(
           { __typename: 'Drug' }
-          & Pick<Drug, 'name' | 'id'>
+          & Pick<Drug, 'name' | 'id' | 'link'>
         )>> }
       )> }
     )>, pageInfo: (
@@ -5072,7 +5126,7 @@ export type PhenotypePopoverQuery = (
   { __typename: 'Query' }
   & { phenotypePopover?: Maybe<(
     { __typename: 'PhenotypePopover' }
-    & Pick<PhenotypePopover, 'id' | 'name' | 'url' | 'hpoId' | 'assertionCount' | 'evidenceItemCount'>
+    & Pick<PhenotypePopover, 'id' | 'name' | 'url' | 'hpoId' | 'assertionCount' | 'evidenceItemCount' | 'link'>
   )> }
 );
 
@@ -5108,7 +5162,7 @@ export type PhenotypesBrowseQuery = (
 
 export type PhenotypeBrowseTableRowFieldsFragment = (
   { __typename: 'BrowsePhenotype' }
-  & Pick<BrowsePhenotype, 'id' | 'name' | 'hpoId' | 'url' | 'assertionCount' | 'evidenceCount'>
+  & Pick<BrowsePhenotype, 'id' | 'name' | 'hpoId' | 'url' | 'assertionCount' | 'evidenceCount' | 'link'>
 );
 
 export type AcceptRevisionMutationVariables = Exact<{
@@ -5216,19 +5270,19 @@ export type RevisionFragment = (
       { __typename: 'ObjectFieldDiff' }
       & { currentObjects: Array<(
         { __typename: 'ModeratedObjectField' }
-        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType'>
+        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType' | 'link'>
       )>, addedObjects: Array<(
         { __typename: 'ModeratedObjectField' }
-        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType'>
+        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType' | 'link'>
       )>, removedObjects: Array<(
         { __typename: 'ModeratedObjectField' }
-        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType'>
+        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType' | 'link'>
       )>, keptObjects: Array<(
         { __typename: 'ModeratedObjectField' }
-        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType'>
+        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType' | 'link'>
       )>, suggestedObjects: Array<(
         { __typename: 'ModeratedObjectField' }
-        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType'>
+        & Pick<ModeratedObjectField, 'id' | 'displayName' | 'displayType' | 'entityType' | 'link'>
       )> }
     ) | (
       { __typename: 'ScalarFieldDiff' }
@@ -5244,7 +5298,7 @@ export type RevisionFragment = (
     { __typename: 'Comment' }
     & { parsedComment: Array<(
       { __typename: 'CommentTagSegment' }
-      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType'>
+      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType' | 'link'>
     ) | (
       { __typename: 'CommentTextSegment' }
       & Pick<CommentTextSegment, 'text'>
@@ -5256,7 +5310,7 @@ export type RevisionFragment = (
     { __typename: 'Comment' }
     & { parsedComment: Array<(
       { __typename: 'CommentTagSegment' }
-      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType'>
+      & Pick<CommentTagSegment, 'entityId' | 'displayName' | 'tagType' | 'link'>
     ) | (
       { __typename: 'CommentTextSegment' }
       & Pick<CommentTextSegment, 'text'>
@@ -5479,7 +5533,7 @@ export type SourcePopoverFragment = (
   & Pick<SourcePopover, 'id' | 'name' | 'evidenceItemCount' | 'citation' | 'citationId' | 'displayType' | 'sourceUrl'>
   & { clinicalTrials?: Maybe<Array<(
     { __typename: 'ClinicalTrial' }
-    & Pick<ClinicalTrial, 'id' | 'nctId'>
+    & Pick<ClinicalTrial, 'id' | 'nctId' | 'link'>
   )>> }
 );
 
@@ -5520,7 +5574,7 @@ export type BrowseSourcesQuery = (
 
 export type BrowseSourceRowFieldsFragment = (
   { __typename: 'BrowseSource' }
-  & Pick<BrowseSource, 'id' | 'authors' | 'citationId' | 'evidenceItemCount' | 'journal' | 'name' | 'publicationYear' | 'sourceType' | 'citation' | 'displayType'>
+  & Pick<BrowseSource, 'id' | 'authors' | 'citationId' | 'evidenceItemCount' | 'journal' | 'name' | 'publicationYear' | 'sourceType' | 'citation' | 'displayType' | 'link'>
 );
 
 export type UserPopoverQueryVariables = Exact<{
@@ -5674,7 +5728,7 @@ export type VariantTypesBrowseQuery = (
 
 export type VariantTypeBrowseTableRowFieldsFragment = (
   { __typename: 'BrowseVariantType' }
-  & Pick<BrowseVariantType, 'id' | 'name' | 'soid' | 'url' | 'variantCount'>
+  & Pick<BrowseVariantType, 'id' | 'name' | 'soid' | 'url' | 'variantCount' | 'link'>
 );
 
 export type VariantPopoverQueryVariables = Exact<{
@@ -5698,7 +5752,7 @@ export type VariantPopoverFieldsFragment = (
     & Pick<EvidenceItemConnection, 'totalCount'>
   ), gene: (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
   ), revisions: (
     { __typename: 'RevisionConnection' }
     & Pick<RevisionConnection, 'totalCount'>
@@ -5775,13 +5829,13 @@ export type BrowseVariantsQuery = (
       & Pick<BrowseVariantEdge, 'cursor'>
       & { node?: Maybe<(
         { __typename: 'BrowseVariant' }
-        & Pick<BrowseVariant, 'id' | 'name' | 'evidenceScore' | 'evidenceItemCount' | 'geneId' | 'geneName' | 'assertionCount'>
+        & Pick<BrowseVariant, 'id' | 'name' | 'link' | 'evidenceScore' | 'evidenceItemCount' | 'geneId' | 'geneName' | 'geneLink' | 'assertionCount'>
         & { diseases: Array<(
           { __typename: 'Disease' }
-          & Pick<Disease, 'id' | 'name'>
+          & Pick<Disease, 'id' | 'name' | 'link'>
         )>, drugs: Array<(
           { __typename: 'Drug' }
-          & Pick<Drug, 'id' | 'name'>
+          & Pick<Drug, 'id' | 'name' | 'link'>
         )>, aliases: Array<(
           { __typename: 'VariantAlias' }
           & Pick<VariantAlias, 'name'>
@@ -6283,7 +6337,7 @@ export type RevisableEvidenceFieldsFragment = (
   & Pick<EvidenceItem, 'id' | 'variantOrigin' | 'description' | 'clinicalSignificance' | 'drugInteractionType' | 'evidenceDirection' | 'evidenceLevel' | 'evidenceType' | 'evidenceRating'>
   & { variant: (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ), disease?: Maybe<(
     { __typename: 'Disease' }
     & Pick<Disease, 'id' | 'doid' | 'name' | 'displayName'>
@@ -6758,7 +6812,7 @@ export type ClinicalTrialDetailQuery = (
   { __typename: 'Query' }
   & { clinicalTrial?: Maybe<(
     { __typename: 'ClinicalTrial' }
-    & Pick<ClinicalTrial, 'id' | 'name' | 'nctId' | 'description' | 'url'>
+    & Pick<ClinicalTrial, 'id' | 'name' | 'nctId' | 'description' | 'url' | 'link'>
   )> }
 );
 
@@ -6771,7 +6825,7 @@ export type DiseaseDetailQuery = (
   { __typename: 'Query' }
   & { disease?: Maybe<(
     { __typename: 'Disease' }
-    & Pick<Disease, 'id' | 'name' | 'doid' | 'diseaseUrl' | 'displayName' | 'diseaseAliases'>
+    & Pick<Disease, 'id' | 'name' | 'doid' | 'diseaseUrl' | 'displayName' | 'diseaseAliases' | 'link'>
   )> }
 );
 
@@ -6784,7 +6838,7 @@ export type DrugDetailQuery = (
   { __typename: 'Query' }
   & { drug?: Maybe<(
     { __typename: 'Drug' }
-    & Pick<Drug, 'id' | 'name' | 'ncitId' | 'drugUrl' | 'drugAliases'>
+    & Pick<Drug, 'id' | 'name' | 'ncitId' | 'drugUrl' | 'drugAliases' | 'link'>
   )> }
 );
 
@@ -6806,13 +6860,13 @@ export type EvidenceDetailFieldsFragment = (
   & Pick<EvidenceItem, 'id' | 'name' | 'status'>
   & { variant: (
     { __typename: 'Variant' }
-    & Pick<Variant, 'id' | 'name'>
+    & Pick<Variant, 'id' | 'name' | 'link'>
   ), gene: (
     { __typename: 'Gene' }
-    & Pick<Gene, 'id' | 'name'>
+    & Pick<Gene, 'id' | 'name' | 'link'>
   ), assertions: Array<(
     { __typename: 'Assertion' }
-    & Pick<Assertion, 'id' | 'name'>
+    & Pick<Assertion, 'id' | 'name' | 'link'>
   )>, flags: (
     { __typename: 'FlagConnection' }
     & Pick<FlagConnection, 'totalCount'>
@@ -7054,7 +7108,7 @@ export type PhenotypeDetailQuery = (
   { __typename: 'Query' }
   & { phenotype?: Maybe<(
     { __typename: 'Phenotype' }
-    & Pick<Phenotype, 'id' | 'name' | 'hpoId' | 'url'>
+    & Pick<Phenotype, 'id' | 'name' | 'hpoId' | 'url' | 'link'>
   )> }
 );
 
@@ -7462,7 +7516,7 @@ export type VariantTypeDetailQuery = (
   { __typename: 'Query' }
   & { variantType?: Maybe<(
     { __typename: 'VariantType' }
-    & Pick<VariantType, 'id' | 'name' | 'soid' | 'description' | 'url'>
+    & Pick<VariantType, 'id' | 'name' | 'soid' | 'description' | 'url' | 'link'>
   )> }
 );
 
@@ -7579,23 +7633,28 @@ export const AssertionPopoverFragmentDoc = gql`
   drugs {
     id
     name
+    link
   }
   drugInteractionType
   disease {
     id
     name
+    link
   }
   phenotypes {
     id
     name
+    link
   }
   gene {
     id
     name
+    link
   }
   variant {
     id
     name
+    link
   }
   flags(state: OPEN) {
     totalCount
@@ -7612,25 +7671,31 @@ export const AssertionBrowseTableRowFieldsFragmentDoc = gql`
     fragment AssertionBrowseTableRowFields on Assertion {
   id
   name
+  link
   gene {
     id
     name
+    link
   }
   variant {
     id
     name
+    link
   }
   disease {
     id
     name
+    link
   }
   drugs {
     id
     name
+    link
   }
   phenotypes @include(if: $cardView) {
     id
     name
+    link
   }
   drugInteractionType
   summary
@@ -7683,6 +7748,7 @@ export const CommentListNodeFragmentDoc = gql`
       displayName
       tagType
       status
+      link
       __typename
     }
     ... on CommentTextSegment {
@@ -7712,6 +7778,7 @@ export const CommentPopoverFragmentDoc = gql`
   commentable {
     id
     name
+    link
     __typename
   }
 }
@@ -7727,6 +7794,7 @@ export const BrowseDiseaseRowFieldsFragmentDoc = gql`
   evidenceItemCount
   variantCount
   geneCount
+  link
 }
     `;
 export const DrugBrowseTableRowFieldsFragmentDoc = gql`
@@ -7737,6 +7805,7 @@ export const DrugBrowseTableRowFieldsFragmentDoc = gql`
   drugUrl
   assertionCount
   evidenceCount
+  link
 }
     `;
 export const EventFeedNodeFragmentDoc = gql`
@@ -7759,6 +7828,7 @@ export const EventFeedNodeFragmentDoc = gql`
   subject {
     name
     id
+    link
     ... on Source {
       citation
       sourceType
@@ -7774,6 +7844,7 @@ export const EventFeedNodeFragmentDoc = gql`
   originatingObject {
     id
     name
+    link
     __typename
     ... on Revision {
       id
@@ -7828,30 +7899,36 @@ export const EvidencePopoverFragmentDoc = gql`
   drugs {
     id
     name
+    link
   }
   drugInteractionType
   disease {
     id
     name
+    link
   }
   phenotypes {
     id
     name
+    link
   }
   evidenceRating
   gene {
     id
     name
+    link
   }
   variant {
     id
     name
+    link
   }
   source {
     id
     citation
     sourceType
     displayType
+    link
   }
   flags(state: OPEN) {
     totalCount
@@ -7868,25 +7945,31 @@ export const EvidenceGridFieldsFragmentDoc = gql`
     fragment EvidenceGridFields on EvidenceItem {
   id
   name
+  link
   disease {
     id
     name
+    link
   }
   drugs {
     id
     name
+    link
   }
   gene {
     id
     name
+    link
   }
   variant {
     id
     name
+    link
   }
   phenotypes @include(if: $cardView) {
     id
     name
+    link
   }
   source @include(if: $cardView) {
     id
@@ -7898,10 +7981,12 @@ export const EvidenceGridFieldsFragmentDoc = gql`
       nctId
       id
     }
+    link
   }
   assertions @include(if: $cardView) {
     id
     name
+    link
   }
   status
   drugInteractionType
@@ -7923,6 +8008,7 @@ export const FlagFragmentDoc = gql`
   flaggable {
     id
     name
+    link
   }
   flaggingUser {
     id
@@ -7944,6 +8030,7 @@ export const FlagFragmentDoc = gql`
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {
@@ -7964,6 +8051,7 @@ export const FlagFragmentDoc = gql`
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {
@@ -8078,6 +8166,7 @@ export const PhenotypeBrowseTableRowFieldsFragmentDoc = gql`
   url
   assertionCount
   evidenceCount
+  link
 }
     `;
 export const ValidationErrorFragmentDoc = gql`
@@ -8104,30 +8193,35 @@ export const RevisionFragmentDoc = gql`
           displayName
           displayType
           entityType
+          link
         }
         addedObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
         removedObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
         keptObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
         suggestedObjects {
           id
           displayName
           displayType
           entityType
+          link
         }
       }
       ... on ScalarFieldDiff {
@@ -8153,6 +8247,7 @@ export const RevisionFragmentDoc = gql`
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {
@@ -8172,6 +8267,7 @@ export const RevisionFragmentDoc = gql`
         entityId
         displayName
         tagType
+        link
         __typename
       }
       ... on CommentTextSegment {
@@ -8251,6 +8347,7 @@ export const SourcePopoverFragmentDoc = gql`
   clinicalTrials {
     id
     nctId
+    link
   }
 }
     `;
@@ -8266,6 +8363,7 @@ export const BrowseSourceRowFieldsFragmentDoc = gql`
   sourceType
   citation
   displayType
+  link
 }
     `;
 export const PopoverUserFragmentDoc = gql`
@@ -8324,6 +8422,7 @@ export const VariantTypeBrowseTableRowFieldsFragmentDoc = gql`
   soid
   url
   variantCount
+  link
 }
     `;
 export const VariantPopoverFieldsFragmentDoc = gql`
@@ -8339,6 +8438,7 @@ export const VariantPopoverFieldsFragmentDoc = gql`
   gene {
     id
     name
+    link
   }
   revisions(status: NEW) {
     totalCount
@@ -8465,6 +8565,7 @@ export const RevisableEvidenceFieldsFragmentDoc = gql`
   variant {
     id
     name
+    link
   }
   variantOrigin
   description
@@ -8702,14 +8803,17 @@ export const EvidenceDetailFieldsFragmentDoc = gql`
   variant {
     id
     name
+    link
   }
   gene {
     id
     name
+    link
   }
   assertions {
     id
     name
+    link
   }
   flags(state: OPEN) {
     totalCount
@@ -9382,6 +9486,7 @@ export const ClinicalTrialsBrowseDocument = gql`
         nctId
         evidenceCount
         sourceCount
+        link
       }
     }
   }
@@ -9435,11 +9540,13 @@ export const CommentListDocument = gql`
       displayName
       entityId
       tagType
+      link
     }
     mentionedEntities {
       displayName
       entityId
       tagType
+      link
     }
     unfilteredCountForSubject
     edges {
@@ -9492,6 +9599,7 @@ export const DiseasePopoverDocument = gql`
     assertionCount
     evidenceItemCount
     variantCount
+    link
   }
 }
     `;
@@ -9557,6 +9665,7 @@ export const DrugPopoverDocument = gql`
     drugAliases
     assertionCount
     evidenceItemCount
+    link
   }
 }
     `;
@@ -9776,14 +9885,17 @@ export const BrowseGenesDocument = gql`
         id
         entrezId
         name
+        link
         geneAliases
         diseases {
           name
           id
+          link
         }
         drugs {
           name
           id
+          link
         }
         variantCount
         evidenceItemCount
@@ -9896,6 +10008,7 @@ export const PhenotypePopoverDocument = gql`
     hpoId
     assertionCount
     evidenceItemCount
+    link
   }
 }
     `;
@@ -10564,17 +10677,21 @@ export const BrowseVariantsDocument = gql`
       node {
         id
         name
+        link
         evidenceScore
         evidenceItemCount
         geneId
         geneName
+        geneLink
         diseases {
           id
           name
+          link
         }
         drugs {
           id
           name
+          link
         }
         aliases {
           name
@@ -11595,6 +11712,7 @@ export const ClinicalTrialDetailDocument = gql`
     nctId
     description
     url
+    link
   }
 }
     `;
@@ -11618,6 +11736,7 @@ export const DiseaseDetailDocument = gql`
     diseaseUrl
     displayName
     diseaseAliases
+    link
   }
 }
     `;
@@ -11640,6 +11759,7 @@ export const DrugDetailDocument = gql`
     ncitId
     drugUrl
     drugAliases
+    link
   }
 }
     `;
@@ -11796,6 +11916,7 @@ export const PhenotypeDetailDocument = gql`
     name
     hpoId
     url
+    link
   }
 }
     `;
@@ -12120,6 +12241,7 @@ export const VariantTypeDetailDocument = gql`
     soid
     description
     url
+    link
   }
 }
     `;

--- a/client/src/app/generated/server.field-policies.ts
+++ b/client/src/app/generated/server.field-policies.ts
@@ -45,7 +45,7 @@ export type AdvancedSearchResultFieldPolicy = {
 	resultIds?: FieldPolicy<any> | FieldReadFunction<any>,
 	searchEndpoint?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type AssertionKeySpecifier = ('acceptanceEvent' | 'acmgCodes' | 'ampLevel' | 'assertionDirection' | 'assertionType' | 'clinicalSignificance' | 'comments' | 'description' | 'disease' | 'drugInteractionType' | 'drugs' | 'events' | 'evidenceItems' | 'fdaCompanionTest' | 'flagged' | 'flags' | 'gene' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'name' | 'nccnGuideline' | 'nccnGuidelineVersion' | 'phenotypes' | 'regulatoryApproval' | 'rejectionEvent' | 'revisions' | 'status' | 'submissionEvent' | 'summary' | 'variant' | 'variantOrigin' | AssertionKeySpecifier)[];
+export type AssertionKeySpecifier = ('acceptanceEvent' | 'acmgCodes' | 'ampLevel' | 'assertionDirection' | 'assertionType' | 'clinicalSignificance' | 'comments' | 'description' | 'disease' | 'drugInteractionType' | 'drugs' | 'events' | 'evidenceItems' | 'fdaCompanionTest' | 'flagged' | 'flags' | 'gene' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'name' | 'nccnGuideline' | 'nccnGuidelineVersion' | 'phenotypes' | 'regulatoryApproval' | 'rejectionEvent' | 'revisions' | 'status' | 'submissionEvent' | 'summary' | 'variant' | 'variantOrigin' | AssertionKeySpecifier)[];
 export type AssertionFieldPolicy = {
 	acceptanceEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	acmgCodes?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -68,6 +68,7 @@ export type AssertionFieldPolicy = {
 	lastAcceptedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastSubmittedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	nccnGuideline?: FieldPolicy<any> | FieldReadFunction<any>,
 	nccnGuidelineVersion?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -94,10 +95,11 @@ export type AssertionEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseClinicalTrialKeySpecifier = ('evidenceCount' | 'id' | 'name' | 'nctId' | 'sourceCount' | 'url' | BrowseClinicalTrialKeySpecifier)[];
+export type BrowseClinicalTrialKeySpecifier = ('evidenceCount' | 'id' | 'link' | 'name' | 'nctId' | 'sourceCount' | 'url' | BrowseClinicalTrialKeySpecifier)[];
 export type BrowseClinicalTrialFieldPolicy = {
 	evidenceCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	nctId?: FieldPolicy<any> | FieldReadFunction<any>,
 	sourceCount?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -117,7 +119,7 @@ export type BrowseClinicalTrialEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseDiseaseKeySpecifier = ('assertionCount' | 'diseaseUrl' | 'displayName' | 'doid' | 'evidenceItemCount' | 'geneCount' | 'geneNames' | 'id' | 'name' | 'variantCount' | BrowseDiseaseKeySpecifier)[];
+export type BrowseDiseaseKeySpecifier = ('assertionCount' | 'diseaseUrl' | 'displayName' | 'doid' | 'evidenceItemCount' | 'geneCount' | 'geneNames' | 'id' | 'link' | 'name' | 'variantCount' | BrowseDiseaseKeySpecifier)[];
 export type BrowseDiseaseFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	diseaseUrl?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -127,6 +129,7 @@ export type BrowseDiseaseFieldPolicy = {
 	geneCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	geneNames?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantCount?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -144,12 +147,13 @@ export type BrowseDiseaseEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseDrugKeySpecifier = ('assertionCount' | 'drugUrl' | 'evidenceCount' | 'id' | 'name' | 'ncitId' | BrowseDrugKeySpecifier)[];
+export type BrowseDrugKeySpecifier = ('assertionCount' | 'drugUrl' | 'evidenceCount' | 'id' | 'link' | 'name' | 'ncitId' | BrowseDrugKeySpecifier)[];
 export type BrowseDrugFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	drugUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	ncitId?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -167,7 +171,7 @@ export type BrowseDrugEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseGeneKeySpecifier = ('assertionCount' | 'description' | 'diseases' | 'drugs' | 'entrezId' | 'evidenceItemCount' | 'geneAliases' | 'id' | 'name' | 'variantCount' | BrowseGeneKeySpecifier)[];
+export type BrowseGeneKeySpecifier = ('assertionCount' | 'description' | 'diseases' | 'drugs' | 'entrezId' | 'evidenceItemCount' | 'geneAliases' | 'id' | 'link' | 'name' | 'variantCount' | BrowseGeneKeySpecifier)[];
 export type BrowseGeneFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -177,6 +181,7 @@ export type BrowseGeneFieldPolicy = {
 	evidenceItemCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	geneAliases?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantCount?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -194,12 +199,13 @@ export type BrowseGeneEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowsePhenotypeKeySpecifier = ('assertionCount' | 'evidenceCount' | 'hpoId' | 'id' | 'name' | 'url' | BrowsePhenotypeKeySpecifier)[];
+export type BrowsePhenotypeKeySpecifier = ('assertionCount' | 'evidenceCount' | 'hpoId' | 'id' | 'link' | 'name' | 'url' | BrowsePhenotypeKeySpecifier)[];
 export type BrowsePhenotypeFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	hpoId?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -217,7 +223,7 @@ export type BrowsePhenotypeEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseSourceKeySpecifier = ('authors' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'evidenceItemCount' | 'id' | 'journal' | 'name' | 'publicationYear' | 'sourceType' | 'sourceUrl' | BrowseSourceKeySpecifier)[];
+export type BrowseSourceKeySpecifier = ('authors' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'evidenceItemCount' | 'id' | 'journal' | 'link' | 'name' | 'publicationYear' | 'sourceType' | 'sourceUrl' | BrowseSourceKeySpecifier)[];
 export type BrowseSourceFieldPolicy = {
 	authors?: FieldPolicy<any> | FieldReadFunction<any>,
 	citation?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -227,6 +233,7 @@ export type BrowseSourceFieldPolicy = {
 	evidenceItemCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	journal?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	publicationYear?: FieldPolicy<any> | FieldReadFunction<any>,
 	sourceType?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -246,7 +253,7 @@ export type BrowseSourceEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseVariantKeySpecifier = ('aliases' | 'assertionCount' | 'diseases' | 'drugs' | 'evidenceItemCount' | 'evidenceScore' | 'geneId' | 'geneName' | 'id' | 'name' | BrowseVariantKeySpecifier)[];
+export type BrowseVariantKeySpecifier = ('aliases' | 'assertionCount' | 'diseases' | 'drugs' | 'evidenceItemCount' | 'evidenceScore' | 'geneId' | 'geneLink' | 'geneName' | 'id' | 'link' | 'name' | BrowseVariantKeySpecifier)[];
 export type BrowseVariantFieldPolicy = {
 	aliases?: FieldPolicy<any> | FieldReadFunction<any>,
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -255,8 +262,10 @@ export type BrowseVariantFieldPolicy = {
 	evidenceItemCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceScore?: FieldPolicy<any> | FieldReadFunction<any>,
 	geneId?: FieldPolicy<any> | FieldReadFunction<any>,
+	geneLink?: FieldPolicy<any> | FieldReadFunction<any>,
 	geneName?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type BrowseVariantConnectionKeySpecifier = ('edges' | 'filteredCount' | 'nodes' | 'pageCount' | 'pageInfo' | 'totalCount' | BrowseVariantConnectionKeySpecifier)[];
@@ -296,9 +305,10 @@ export type BrowseVariantGroupEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseVariantTypeKeySpecifier = ('id' | 'name' | 'soid' | 'url' | 'variantCount' | BrowseVariantTypeKeySpecifier)[];
+export type BrowseVariantTypeKeySpecifier = ('id' | 'link' | 'name' | 'soid' | 'url' | 'variantCount' | BrowseVariantTypeKeySpecifier)[];
 export type BrowseVariantTypeFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	soid?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -331,10 +341,11 @@ export type CivicTimepointStatsFieldPolicy = {
 	users?: FieldPolicy<any> | FieldReadFunction<any>,
 	variants?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ClinicalTrialKeySpecifier = ('description' | 'id' | 'name' | 'nctId' | 'url' | ClinicalTrialKeySpecifier)[];
+export type ClinicalTrialKeySpecifier = ('description' | 'id' | 'link' | 'name' | 'nctId' | 'url' | ClinicalTrialKeySpecifier)[];
 export type ClinicalTrialFieldPolicy = {
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	nctId?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
@@ -348,7 +359,7 @@ export type CoiFieldPolicy = {
 	expiresAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type CommentKeySpecifier = ('comment' | 'commentable' | 'commenter' | 'createdAt' | 'creationEvent' | 'id' | 'name' | 'parsedComment' | 'title' | CommentKeySpecifier)[];
+export type CommentKeySpecifier = ('comment' | 'commentable' | 'commenter' | 'createdAt' | 'creationEvent' | 'id' | 'link' | 'name' | 'parsedComment' | 'title' | CommentKeySpecifier)[];
 export type CommentFieldPolicy = {
 	comment?: FieldPolicy<any> | FieldReadFunction<any>,
 	commentable?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -356,6 +367,7 @@ export type CommentFieldPolicy = {
 	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	creationEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	parsedComment?: FieldPolicy<any> | FieldReadFunction<any>,
 	title?: FieldPolicy<any> | FieldReadFunction<any>
@@ -378,10 +390,11 @@ export type CommentEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type CommentTagSegmentKeySpecifier = ('displayName' | 'entityId' | 'status' | 'tagType' | CommentTagSegmentKeySpecifier)[];
+export type CommentTagSegmentKeySpecifier = ('displayName' | 'entityId' | 'link' | 'status' | 'tagType' | CommentTagSegmentKeySpecifier)[];
 export type CommentTagSegmentFieldPolicy = {
 	displayName?: FieldPolicy<any> | FieldReadFunction<any>,
 	entityId?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	status?: FieldPolicy<any> | FieldReadFunction<any>,
 	tagType?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -389,11 +402,12 @@ export type CommentTextSegmentKeySpecifier = ('text' | CommentTextSegmentKeySpec
 export type CommentTextSegmentFieldPolicy = {
 	text?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type CommentableKeySpecifier = ('comments' | 'id' | 'lastCommentEvent' | 'name' | CommentableKeySpecifier)[];
+export type CommentableKeySpecifier = ('comments' | 'id' | 'lastCommentEvent' | 'link' | 'name' | CommentableKeySpecifier)[];
 export type CommentableFieldPolicy = {
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type ContributingUserKeySpecifier = ('lastActionDate' | 'totalActionCount' | 'uniqueActions' | 'user' | ContributingUserKeySpecifier)[];
@@ -439,16 +453,17 @@ export type DataReleaseFieldPolicy = {
 	variantGroupTsv?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantTsv?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type DiseaseKeySpecifier = ('diseaseAliases' | 'diseaseUrl' | 'displayName' | 'doid' | 'id' | 'name' | DiseaseKeySpecifier)[];
+export type DiseaseKeySpecifier = ('diseaseAliases' | 'diseaseUrl' | 'displayName' | 'doid' | 'id' | 'link' | 'name' | DiseaseKeySpecifier)[];
 export type DiseaseFieldPolicy = {
 	diseaseAliases?: FieldPolicy<any> | FieldReadFunction<any>,
 	diseaseUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	displayName?: FieldPolicy<any> | FieldReadFunction<any>,
 	doid?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type DiseasePopoverKeySpecifier = ('assertionCount' | 'diseaseAliases' | 'diseaseUrl' | 'displayName' | 'doid' | 'evidenceItemCount' | 'id' | 'name' | 'variantCount' | DiseasePopoverKeySpecifier)[];
+export type DiseasePopoverKeySpecifier = ('assertionCount' | 'diseaseAliases' | 'diseaseUrl' | 'displayName' | 'doid' | 'evidenceItemCount' | 'id' | 'link' | 'name' | 'variantCount' | DiseasePopoverKeySpecifier)[];
 export type DiseasePopoverFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	diseaseAliases?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -457,6 +472,7 @@ export type DiseasePopoverFieldPolicy = {
 	doid?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItemCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantCount?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -465,21 +481,23 @@ export type DownloadableFileFieldPolicy = {
 	filename?: FieldPolicy<any> | FieldReadFunction<any>,
 	path?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type DrugKeySpecifier = ('drugAliases' | 'drugUrl' | 'id' | 'name' | 'ncitId' | DrugKeySpecifier)[];
+export type DrugKeySpecifier = ('drugAliases' | 'drugUrl' | 'id' | 'link' | 'name' | 'ncitId' | DrugKeySpecifier)[];
 export type DrugFieldPolicy = {
 	drugAliases?: FieldPolicy<any> | FieldReadFunction<any>,
 	drugUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	ncitId?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type DrugPopoverKeySpecifier = ('assertionCount' | 'drugAliases' | 'drugUrl' | 'evidenceItemCount' | 'id' | 'name' | 'ncitId' | DrugPopoverKeySpecifier)[];
+export type DrugPopoverKeySpecifier = ('assertionCount' | 'drugAliases' | 'drugUrl' | 'evidenceItemCount' | 'id' | 'link' | 'name' | 'ncitId' | DrugPopoverKeySpecifier)[];
 export type DrugPopoverFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	drugAliases?: FieldPolicy<any> | FieldReadFunction<any>,
 	drugUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItemCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	ncitId?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -498,7 +516,7 @@ export type EventFieldPolicy = {
 	originatingUser?: FieldPolicy<any> | FieldReadFunction<any>,
 	subject?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type EventConnectionKeySpecifier = ('edges' | 'eventTypes' | 'nodes' | 'pageCount' | 'pageInfo' | 'participatingOrganizations' | 'totalCount' | 'uniqueParticipants' | EventConnectionKeySpecifier)[];
+export type EventConnectionKeySpecifier = ('edges' | 'eventTypes' | 'nodes' | 'pageCount' | 'pageInfo' | 'participatingOrganizations' | 'totalCount' | 'unfilteredCount' | 'uniqueParticipants' | EventConnectionKeySpecifier)[];
 export type EventConnectionFieldPolicy = {
 	edges?: FieldPolicy<any> | FieldReadFunction<any>,
 	eventTypes?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -507,6 +525,7 @@ export type EventConnectionFieldPolicy = {
 	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
 	participatingOrganizations?: FieldPolicy<any> | FieldReadFunction<any>,
 	totalCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	unfilteredCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	uniqueParticipants?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type EventEdgeKeySpecifier = ('cursor' | 'node' | EventEdgeKeySpecifier)[];
@@ -514,15 +533,17 @@ export type EventEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type EventOriginObjectKeySpecifier = ('id' | 'name' | EventOriginObjectKeySpecifier)[];
+export type EventOriginObjectKeySpecifier = ('id' | 'link' | 'name' | EventOriginObjectKeySpecifier)[];
 export type EventOriginObjectFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type EventSubjectKeySpecifier = ('events' | 'id' | 'name' | EventSubjectKeySpecifier)[];
+export type EventSubjectKeySpecifier = ('events' | 'id' | 'link' | 'name' | EventSubjectKeySpecifier)[];
 export type EventSubjectFieldPolicy = {
 	events?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type EventSubjectWithCountKeySpecifier = ('occuranceCount' | 'subject' | EventSubjectWithCountKeySpecifier)[];
@@ -530,7 +551,7 @@ export type EventSubjectWithCountFieldPolicy = {
 	occuranceCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	subject?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type EvidenceItemKeySpecifier = ('acceptanceEvent' | 'assertions' | 'clinicalSignificance' | 'comments' | 'description' | 'disease' | 'drugInteractionType' | 'drugs' | 'events' | 'evidenceDirection' | 'evidenceLevel' | 'evidenceRating' | 'evidenceType' | 'flagged' | 'flags' | 'gene' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'name' | 'phenotypes' | 'rejectionEvent' | 'revisions' | 'source' | 'status' | 'submissionEvent' | 'variant' | 'variantHgvs' | 'variantOrigin' | EvidenceItemKeySpecifier)[];
+export type EvidenceItemKeySpecifier = ('acceptanceEvent' | 'assertions' | 'clinicalSignificance' | 'comments' | 'description' | 'disease' | 'drugInteractionType' | 'drugs' | 'events' | 'evidenceDirection' | 'evidenceLevel' | 'evidenceRating' | 'evidenceType' | 'flagged' | 'flags' | 'gene' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'name' | 'phenotypes' | 'rejectionEvent' | 'revisions' | 'source' | 'status' | 'submissionEvent' | 'variant' | 'variantHgvs' | 'variantOrigin' | EvidenceItemKeySpecifier)[];
 export type EvidenceItemFieldPolicy = {
 	acceptanceEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	assertions?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -552,6 +573,7 @@ export type EvidenceItemFieldPolicy = {
 	lastAcceptedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastSubmittedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	phenotypes?: FieldPolicy<any> | FieldReadFunction<any>,
 	rejectionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -586,7 +608,7 @@ export type FieldValidationErrorFieldPolicy = {
 	error?: FieldPolicy<any> | FieldReadFunction<any>,
 	fieldName?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type FlagKeySpecifier = ('comments' | 'createdAt' | 'flaggable' | 'flaggingUser' | 'id' | 'lastCommentEvent' | 'name' | 'openComment' | 'resolutionComment' | 'resolvedAt' | 'resolvingUser' | 'state' | FlagKeySpecifier)[];
+export type FlagKeySpecifier = ('comments' | 'createdAt' | 'flaggable' | 'flaggingUser' | 'id' | 'lastCommentEvent' | 'link' | 'name' | 'openComment' | 'resolutionComment' | 'resolvedAt' | 'resolvingUser' | 'state' | FlagKeySpecifier)[];
 export type FlagFieldPolicy = {
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
 	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -594,6 +616,7 @@ export type FlagFieldPolicy = {
 	flaggingUser?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	openComment?: FieldPolicy<any> | FieldReadFunction<any>,
 	resolutionComment?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -622,14 +645,15 @@ export type FlagEntityPayloadFieldPolicy = {
 	clientMutationId?: FieldPolicy<any> | FieldReadFunction<any>,
 	flag?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type FlaggableKeySpecifier = ('flagged' | 'flags' | 'id' | 'name' | FlaggableKeySpecifier)[];
+export type FlaggableKeySpecifier = ('flagged' | 'flags' | 'id' | 'link' | 'name' | FlaggableKeySpecifier)[];
 export type FlaggableFieldPolicy = {
 	flagged?: FieldPolicy<any> | FieldReadFunction<any>,
 	flags?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type GeneKeySpecifier = ('comments' | 'description' | 'entrezId' | 'events' | 'flagged' | 'flags' | 'geneAliases' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'myGeneInfoDetails' | 'name' | 'officialName' | 'revisions' | 'sources' | 'variants' | GeneKeySpecifier)[];
+export type GeneKeySpecifier = ('comments' | 'description' | 'entrezId' | 'events' | 'flagged' | 'flags' | 'geneAliases' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'myGeneInfoDetails' | 'name' | 'officialName' | 'revisions' | 'sources' | 'variants' | GeneKeySpecifier)[];
 export type GeneFieldPolicy = {
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -642,6 +666,7 @@ export type GeneFieldPolicy = {
 	lastAcceptedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastSubmittedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	myGeneInfoDetails?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	officialName?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -666,12 +691,13 @@ export type ModerateEvidenceItemPayloadFieldPolicy = {
 	clientMutationId?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItem?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type ModeratedObjectFieldKeySpecifier = ('displayName' | 'displayType' | 'entityType' | 'id' | ModeratedObjectFieldKeySpecifier)[];
+export type ModeratedObjectFieldKeySpecifier = ('displayName' | 'displayType' | 'entityType' | 'id' | 'link' | ModeratedObjectFieldKeySpecifier)[];
 export type ModeratedObjectFieldFieldPolicy = {
 	displayName?: FieldPolicy<any> | FieldReadFunction<any>,
 	displayType?: FieldPolicy<any> | FieldReadFunction<any>,
 	entityType?: FieldPolicy<any> | FieldReadFunction<any>,
-	id?: FieldPolicy<any> | FieldReadFunction<any>
+	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type MutationKeySpecifier = ('acceptRevisions' | 'addComment' | 'addDisease' | 'addDrug' | 'addRemoteCitation' | 'addVariant' | 'editUser' | 'flagEntity' | 'moderateAssertion' | 'moderateEvidenceItem' | 'rejectRevisions' | 'resolveFlag' | 'submitAssertion' | 'submitEvidence' | 'subscribe' | 'suggestAssertionRevision' | 'suggestEvidenceItemRevision' | 'suggestGeneRevision' | 'suggestSource' | 'suggestVariantRevision' | 'unsubscribe' | 'updateCoi' | 'updateNotificationStatus' | 'updateSourceSuggestionStatus' | MutationKeySpecifier)[];
 export type MutationFieldPolicy = {
@@ -848,19 +874,21 @@ export type PageInfoFieldPolicy = {
 	hasPreviousPage?: FieldPolicy<any> | FieldReadFunction<any>,
 	startCursor?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PhenotypeKeySpecifier = ('hpoId' | 'id' | 'name' | 'url' | PhenotypeKeySpecifier)[];
+export type PhenotypeKeySpecifier = ('hpoId' | 'id' | 'link' | 'name' | 'url' | PhenotypeKeySpecifier)[];
 export type PhenotypeFieldPolicy = {
 	hpoId?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PhenotypePopoverKeySpecifier = ('assertionCount' | 'evidenceItemCount' | 'hpoId' | 'id' | 'name' | 'url' | PhenotypePopoverKeySpecifier)[];
+export type PhenotypePopoverKeySpecifier = ('assertionCount' | 'evidenceItemCount' | 'hpoId' | 'id' | 'link' | 'name' | 'url' | PhenotypePopoverKeySpecifier)[];
 export type PhenotypePopoverFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItemCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	hpoId?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -940,7 +968,7 @@ export type ResolveFlagPayloadFieldPolicy = {
 	clientMutationId?: FieldPolicy<any> | FieldReadFunction<any>,
 	flag?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type RevisionKeySpecifier = ('comments' | 'createdAt' | 'creationComment' | 'creationEvent' | 'currentValue' | 'events' | 'fieldName' | 'id' | 'linkoutData' | 'name' | 'resolutionComment' | 'resolvedAt' | 'resolver' | 'resolvingEvent' | 'revisionsetId' | 'revisor' | 'status' | 'suggestedValue' | 'updatedAt' | RevisionKeySpecifier)[];
+export type RevisionKeySpecifier = ('comments' | 'createdAt' | 'creationComment' | 'creationEvent' | 'currentValue' | 'events' | 'fieldName' | 'id' | 'lastCommentEvent' | 'link' | 'linkoutData' | 'name' | 'resolutionComment' | 'resolvedAt' | 'resolver' | 'resolvingEvent' | 'revisionsetId' | 'revisor' | 'status' | 'subject' | 'suggestedValue' | 'updatedAt' | RevisionKeySpecifier)[];
 export type RevisionFieldPolicy = {
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
 	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -950,6 +978,8 @@ export type RevisionFieldPolicy = {
 	events?: FieldPolicy<any> | FieldReadFunction<any>,
 	fieldName?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	linkoutData?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	resolutionComment?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -959,6 +989,7 @@ export type RevisionFieldPolicy = {
 	revisionsetId?: FieldPolicy<any> | FieldReadFunction<any>,
 	revisor?: FieldPolicy<any> | FieldReadFunction<any>,
 	status?: FieldPolicy<any> | FieldReadFunction<any>,
+	subject?: FieldPolicy<any> | FieldReadFunction<any>,
 	suggestedValue?: FieldPolicy<any> | FieldReadFunction<any>,
 	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -1002,7 +1033,7 @@ export type SearchResultFieldPolicy = {
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	resultType?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type SourceKeySpecifier = ('abstract' | 'ascoAbstractId' | 'authorString' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'events' | 'fullJournalTitle' | 'id' | 'journal' | 'name' | 'pmcId' | 'publicationDate' | 'publicationDay' | 'publicationMonth' | 'publicationYear' | 'sourceType' | 'sourceUrl' | 'title' | SourceKeySpecifier)[];
+export type SourceKeySpecifier = ('abstract' | 'ascoAbstractId' | 'authorString' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'events' | 'fullJournalTitle' | 'id' | 'journal' | 'link' | 'name' | 'pmcId' | 'publicationDate' | 'publicationDay' | 'publicationMonth' | 'publicationYear' | 'sourceType' | 'sourceUrl' | 'title' | SourceKeySpecifier)[];
 export type SourceFieldPolicy = {
 	abstract?: FieldPolicy<any> | FieldReadFunction<any>,
 	ascoAbstractId?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1015,6 +1046,7 @@ export type SourceFieldPolicy = {
 	fullJournalTitle?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	journal?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	pmcId?: FieldPolicy<any> | FieldReadFunction<any>,
 	publicationDate?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1025,7 +1057,7 @@ export type SourceFieldPolicy = {
 	sourceUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	title?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type SourcePopoverKeySpecifier = ('abstract' | 'ascoAbstractId' | 'authorString' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'events' | 'evidenceItemCount' | 'fullJournalTitle' | 'id' | 'journal' | 'name' | 'pmcId' | 'publicationDate' | 'publicationDay' | 'publicationMonth' | 'publicationYear' | 'sourceType' | 'sourceUrl' | 'title' | SourcePopoverKeySpecifier)[];
+export type SourcePopoverKeySpecifier = ('abstract' | 'ascoAbstractId' | 'authorString' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'events' | 'evidenceItemCount' | 'fullJournalTitle' | 'id' | 'journal' | 'link' | 'name' | 'pmcId' | 'publicationDate' | 'publicationDay' | 'publicationMonth' | 'publicationYear' | 'sourceType' | 'sourceUrl' | 'title' | SourcePopoverKeySpecifier)[];
 export type SourcePopoverFieldPolicy = {
 	abstract?: FieldPolicy<any> | FieldReadFunction<any>,
 	ascoAbstractId?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1039,6 +1071,7 @@ export type SourcePopoverFieldPolicy = {
 	fullJournalTitle?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	journal?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	pmcId?: FieldPolicy<any> | FieldReadFunction<any>,
 	publicationDate?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1055,13 +1088,14 @@ export type SourceStubFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	sourceType?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type SourceSuggestionKeySpecifier = ('diseaseName' | 'events' | 'geneName' | 'id' | 'initialComment' | 'name' | 'source' | 'status' | 'user' | 'variantName' | SourceSuggestionKeySpecifier)[];
+export type SourceSuggestionKeySpecifier = ('diseaseName' | 'events' | 'geneName' | 'id' | 'initialComment' | 'link' | 'name' | 'source' | 'status' | 'user' | 'variantName' | SourceSuggestionKeySpecifier)[];
 export type SourceSuggestionFieldPolicy = {
 	diseaseName?: FieldPolicy<any> | FieldReadFunction<any>,
 	events?: FieldPolicy<any> | FieldReadFunction<any>,
 	geneName?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	initialComment?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	source?: FieldPolicy<any> | FieldReadFunction<any>,
 	status?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1218,7 +1252,7 @@ export type ValidationErrorsFieldPolicy = {
 	genericErrors?: FieldPolicy<any> | FieldReadFunction<any>,
 	validationErrors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type VariantKeySpecifier = ('alleleRegistryId' | 'clinvarIds' | 'comments' | 'description' | 'ensemblVersion' | 'events' | 'evidenceItems' | 'evidenceScore' | 'fivePrimeCoordinates' | 'flagged' | 'flags' | 'gene' | 'hgvsDescriptions' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'myVariantInfo' | 'name' | 'referenceBuild' | 'revisions' | 'sources' | 'threePrimeCoordinates' | 'variantAliases' | 'variantTypes' | VariantKeySpecifier)[];
+export type VariantKeySpecifier = ('alleleRegistryId' | 'clinvarIds' | 'comments' | 'description' | 'ensemblVersion' | 'events' | 'evidenceItems' | 'evidenceScore' | 'fivePrimeCoordinates' | 'flagged' | 'flags' | 'gene' | 'hgvsDescriptions' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'myVariantInfo' | 'name' | 'referenceBuild' | 'revisions' | 'sources' | 'threePrimeCoordinates' | 'variantAliases' | 'variantTypes' | VariantKeySpecifier)[];
 export type VariantFieldPolicy = {
 	alleleRegistryId?: FieldPolicy<any> | FieldReadFunction<any>,
 	clinvarIds?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1237,6 +1271,7 @@ export type VariantFieldPolicy = {
 	lastAcceptedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastSubmittedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	myVariantInfo?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	referenceBuild?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1263,7 +1298,7 @@ export type VariantEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type VariantGroupKeySpecifier = ('comments' | 'description' | 'events' | 'flagged' | 'flags' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'name' | 'revisions' | 'variants' | VariantGroupKeySpecifier)[];
+export type VariantGroupKeySpecifier = ('comments' | 'description' | 'events' | 'flagged' | 'flags' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'name' | 'revisions' | 'variants' | VariantGroupKeySpecifier)[];
 export type VariantGroupFieldPolicy = {
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1274,22 +1309,25 @@ export type VariantGroupFieldPolicy = {
 	lastAcceptedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastSubmittedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	revisions?: FieldPolicy<any> | FieldReadFunction<any>,
 	variants?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type VariantTypeKeySpecifier = ('description' | 'id' | 'name' | 'soid' | 'url' | VariantTypeKeySpecifier)[];
+export type VariantTypeKeySpecifier = ('description' | 'id' | 'link' | 'name' | 'soid' | 'url' | VariantTypeKeySpecifier)[];
 export type VariantTypeFieldPolicy = {
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	soid?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type VariantTypePopoverKeySpecifier = ('description' | 'id' | 'name' | 'soid' | 'url' | 'variantCount' | VariantTypePopoverKeySpecifier)[];
+export type VariantTypePopoverKeySpecifier = ('description' | 'id' | 'link' | 'name' | 'soid' | 'url' | 'variantCount' | VariantTypePopoverKeySpecifier)[];
 export type VariantTypePopoverFieldPolicy = {
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	soid?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>,

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -1833,7 +1833,7 @@ type EventConnection {
   for that subject/user/organization, irregardless of other filters. Returns
   null when there is no subject, user, or organization.
   """
-  unfilteredCount: Int
+  unfilteredCount: Int!
 
   """
   List of all users that have generated an event on the subject entity.
@@ -1854,6 +1854,16 @@ type EventEdge {
   The item at the end of the edge.
   """
   node: Event
+}
+
+"""
+The context of an event feed, i.e. what is the root subject of the feed. This
+option is a no-op when accessing events via a parent.
+"""
+enum EventFeedMode {
+  ORGANIZATION
+  SUBJECT
+  USER
 }
 
 """
@@ -4270,6 +4280,7 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+    mode: EventFeedMode
     organizationId: Int
     originatingUserId: Int
 

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -429,6 +429,7 @@ type Assertion implements Commentable & EventOriginObject & EventSubject & Flagg
   lastAcceptedRevisionEvent: Event
   lastCommentEvent: Event
   lastSubmittedRevisionEvent: Event
+  link: String!
   name: String!
   nccnGuideline: String
   nccnGuidelineVersion: String
@@ -704,6 +705,7 @@ input BooleanSearchInput {
 type BrowseClinicalTrial {
   evidenceCount: Int!
   id: Int!
+  link: String!
   name: String!
   nctId: String
   sourceCount: Int!
@@ -769,6 +771,7 @@ type BrowseDisease {
   geneCount: Int!
   geneNames: [String!]!
   id: Int!
+  link: String!
   name: String!
   variantCount: Int!
 }
@@ -828,6 +831,7 @@ type BrowseDrug {
   drugUrl: String
   evidenceCount: Int!
   id: Int!
+  link: String!
   name: String!
   ncitId: String
 }
@@ -891,6 +895,7 @@ type BrowseGene {
   evidenceItemCount: Int!
   geneAliases: [String!]
   id: Int!
+  link: String!
   name: String!
   variantCount: Int!
 }
@@ -950,6 +955,7 @@ type BrowsePhenotype {
   evidenceCount: Int!
   hpoId: String!
   id: Int!
+  link: String!
   name: String!
   url: String!
 }
@@ -1013,6 +1019,7 @@ type BrowseSource {
   evidenceItemCount: Int!
   id: Int!
   journal: String
+  link: String!
   name: String
   publicationYear: Int
   sourceType: SourceSource!
@@ -1077,8 +1084,10 @@ type BrowseVariant {
   evidenceItemCount: Int!
   evidenceScore: Float!
   geneId: Int!
+  geneLink: String!
   geneName: String!
   id: Int!
+  link: String!
   name: String!
 }
 
@@ -1193,6 +1202,7 @@ type BrowseVariantGroupEdge {
 
 type BrowseVariantType {
   id: Int!
+  link: String!
   name: String!
   soid: String!
   url: String
@@ -1268,6 +1278,7 @@ type CivicTimepointStats {
 type ClinicalTrial {
   description: String!
   id: Int!
+  link: String!
   name: String!
   nctId: String!
   url: String
@@ -1328,6 +1339,7 @@ type Comment implements EventOriginObject {
   createdAt: ISO8601DateTime!
   creationEvent: Event
   id: Int!
+  link: String!
   name: String!
   parsedComment: [CommentBodySegment!]!
   title: String
@@ -1412,6 +1424,7 @@ type CommentEdge {
 type CommentTagSegment {
   displayName: String!
   entityId: Int!
+  link: String!
   status: EvidenceStatus
   tagType: TaggableEntity!
 }
@@ -1475,6 +1488,7 @@ interface Commentable {
   ): CommentConnection!
   id: Int!
   lastCommentEvent: Event
+  link: String!
   name: String!
 }
 
@@ -1577,6 +1591,7 @@ type Disease {
   displayName: String!
   doid: Int
   id: Int!
+  link: String!
   name: String!
 }
 
@@ -1588,6 +1603,7 @@ type DiseasePopover {
   doid: Int
   evidenceItemCount: Int!
   id: Int!
+  link: String!
   name: String!
   variantCount: Int!
 }
@@ -1622,6 +1638,7 @@ type Drug {
   drugAliases: [String!]!
   drugUrl: String
   id: Int!
+  link: String!
   name: String!
   ncitId: String
 }
@@ -1638,6 +1655,7 @@ type DrugPopover {
   drugUrl: String
   evidenceItemCount: Int!
   id: Int!
+  link: String!
   name: String!
   ncitId: String
 }
@@ -1811,6 +1829,13 @@ type EventConnection {
   totalCount: Int!
 
   """
+  When filtered on a subject, user, or organization, the total number of events
+  for that subject/user/organization, irregardless of other filters. Returns
+  null when there is no subject, user, or organization.
+  """
+  unfilteredCount: Int
+
+  """
   List of all users that have generated an event on the subject entity.
   """
   uniqueParticipants: [User!]!
@@ -1839,6 +1864,7 @@ while the originating object will be the Revision itself.
 """
 interface EventOriginObject {
   id: Int!
+  link: String!
   name: String!
 }
 
@@ -1879,6 +1905,7 @@ interface EventSubject {
     sortBy: DateSort
   ): EventConnection!
   id: Int!
+  link: String!
   name: String!
 }
 
@@ -2065,6 +2092,7 @@ type EvidenceItem implements Commentable & EventOriginObject & EventSubject & Fl
   lastAcceptedRevisionEvent: Event
   lastCommentEvent: Event
   lastSubmittedRevisionEvent: Event
+  link: String!
   name: String!
   phenotypes: [Phenotype!]!
   rejectionEvent: Event
@@ -2364,6 +2392,7 @@ type Flag implements Commentable & EventOriginObject {
   flaggingUser: User!
   id: Int!
   lastCommentEvent: Event
+  link: String!
   name: String!
   openComment: Comment!
   resolutionComment: Comment
@@ -2532,6 +2561,7 @@ interface Flaggable {
     state: FlagState
   ): FlagConnection!
   id: Int!
+  link: String!
   name: String!
 }
 
@@ -2697,6 +2727,7 @@ type Gene implements Commentable & EventSubject & Flaggable & WithRevisions {
   lastAcceptedRevisionEvent: Event
   lastCommentEvent: Event
   lastSubmittedRevisionEvent: Event
+  link: String!
   myGeneInfoDetails: JSON
   name: String!
   officialName: String!
@@ -2998,6 +3029,7 @@ type ModeratedObjectField {
   displayType: String
   entityType: String!
   id: Int!
+  link: String!
 }
 
 type Mutation {
@@ -3716,6 +3748,7 @@ type PageInfo {
 type Phenotype {
   hpoId: String!
   id: Int!
+  link: String!
   name: String!
   url: String!
 }
@@ -3725,6 +3758,7 @@ type PhenotypePopover {
   evidenceItemCount: Int!
   hpoId: String!
   id: Int!
+  link: String!
   name: String!
   url: String!
 }
@@ -4999,8 +5033,56 @@ type ResolveFlagPayload {
   flag: Flag
 }
 
-type Revision implements EventOriginObject & EventSubject {
-  comments: [Comment!]!
+type Revision implements Commentable & EventOriginObject & EventSubject {
+  """
+  List and filter comments.
+  """
+  comments(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Limit to comments that mention a certain entity
+    """
+    mentionedEntity: TaggableEntityInput
+
+    """
+    Limit to comments that mention a certain user role
+    """
+    mentionedRole: UserRole
+
+    """
+    Limit to comments that mention a certain user
+    """
+    mentionedUserId: Int
+
+    """
+    Limit to comments by a certain user
+    """
+    originatingUserId: Int
+
+    """
+    Sort order for the comments. Defaults to most recent.
+    """
+    sortBy: DateSort
+  ): CommentConnection!
   createdAt: ISO8601DateTime!
   creationComment: Comment
   creationEvent: Event
@@ -5040,6 +5122,8 @@ type Revision implements EventOriginObject & EventSubject {
   ): EventConnection!
   fieldName: String!
   id: Int!
+  lastCommentEvent: Event
+  link: String!
   linkoutData: LinkoutData!
   name: String!
   resolutionComment: Comment
@@ -5049,6 +5133,7 @@ type Revision implements EventOriginObject & EventSubject {
   revisionsetId: String!
   revisor: User
   status: RevisionStatus!
+  subject: EventSubject!
   suggestedValue: JSON
   updatedAt: ISO8601DateTime!
 }
@@ -5222,6 +5307,7 @@ type Source implements EventSubject {
   fullJournalTitle: String
   id: Int!
   journal: String!
+  link: String!
   name: String!
   pmcId: String
   publicationDate: String
@@ -5278,6 +5364,7 @@ type SourcePopover implements EventSubject {
   fullJournalTitle: String
   id: Int!
   journal: String!
+  link: String!
   name: String!
   pmcId: String
   publicationDate: String
@@ -5338,6 +5425,7 @@ type SourceSuggestion implements EventOriginObject & EventSubject {
   geneName: String
   id: Int!
   initialComment: String!
+  link: String!
   name: String!
   source: Source!
   status: SourceSuggestionStatus!
@@ -6444,6 +6532,7 @@ type Variant implements Commentable & EventSubject & Flaggable & WithRevisions {
   lastAcceptedRevisionEvent: Event
   lastCommentEvent: Event
   lastSubmittedRevisionEvent: Event
+  link: String!
   myVariantInfo: MyVariantInfo
   name: String!
   referenceBuild: ReferenceBuild
@@ -6783,6 +6872,7 @@ type VariantGroup implements Commentable & EventSubject & Flaggable & WithRevisi
   lastAcceptedRevisionEvent: Event
   lastCommentEvent: Event
   lastSubmittedRevisionEvent: Event
+  link: String!
   name: String!
 
   """
@@ -6902,6 +6992,7 @@ enum VariantOrigin {
 type VariantType {
   description: String!
   id: Int!
+  link: String!
   name: String!
   soid: String!
   url: String!
@@ -6910,6 +7001,7 @@ type VariantType {
 type VariantTypePopover {
   description: String!
   id: Int!
+  link: String!
   name: String!
   soid: String!
   url: String!

--- a/client/src/app/generated/server.possible-types.ts
+++ b/client/src/app/generated/server.possible-types.ts
@@ -45,6 +45,9 @@
             "name": "Gene"
           },
           {
+            "name": "Revision"
+          },
+          {
             "name": "Variant"
           },
           {

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -8968,9 +8968,13 @@
               "description": "When filtered on a subject, user, or organization, the total number of events for that subject/user/organization, irregardless of other filters. Returns null when there is no subject, user, or organization.",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -9042,6 +9046,35 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "EventFeedMode",
+          "description": "The context of an event feed, i.e. what is the root subject of the feed. This option is a no-op when accessing events via a parent.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "USER",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ORGANIZATION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBJECT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -19343,6 +19376,18 @@
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "DateSort",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "mode",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "EventFeedMode",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -1530,6 +1530,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -2718,6 +2734,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -3075,6 +3107,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -3333,6 +3381,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -3681,6 +3745,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -3943,6 +4023,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -4290,6 +4386,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4660,6 +4772,22 @@
               "deprecationReason": null
             },
             {
+              "name": "geneLink",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "geneName",
               "description": null,
               "args": [],
@@ -4685,6 +4813,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -5182,6 +5326,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -5618,6 +5778,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -6032,6 +6208,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -6413,6 +6605,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "status",
               "description": null,
               "args": [],
@@ -6632,6 +6840,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -6670,6 +6894,11 @@
             {
               "kind": "OBJECT",
               "name": "Gene",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Revision",
               "ofType": null
             },
             {
@@ -7417,6 +7646,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -7549,6 +7794,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -7784,6 +8045,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -7929,6 +8206,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -8671,6 +8964,18 @@
               "deprecationReason": null
             },
             {
+              "name": "unfilteredCount",
+              "description": "When filtered on a subject, user, or organization, the total number of events for that subject/user/organization, irregardless of other filters. Returns null when there is no subject, user, or organization.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "uniqueParticipants",
               "description": "List of all users that have generated an event on the subject entity.",
               "args": [],
@@ -8754,6 +9059,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -8941,6 +9262,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -9830,6 +10167,22 @@
                 "kind": "OBJECT",
                 "name": "Event",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -11062,6 +11415,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -11633,6 +12002,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -12257,6 +12642,22 @@
                 "kind": "OBJECT",
                 "name": "Event",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -13446,6 +13847,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -16820,6 +17237,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -16920,6 +17353,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -21755,23 +22204,124 @@
           "fields": [
             {
               "name": "comments",
-              "description": null,
-              "args": [],
+              "description": "List and filter comments.",
+              "args": [
+                {
+                  "name": "originatingUserId",
+                  "description": "Limit to comments by a certain user",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sortBy",
+                  "description": "Sort order for the comments. Defaults to most recent.",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DateSort",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "mentionedUserId",
+                  "description": "Limit to comments that mention a certain user",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "mentionedRole",
+                  "description": "Limit to comments that mention a certain user role",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "UserRole",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "mentionedEntity",
+                  "description": "Limit to comments that mention a certain entity",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "TaggableEntityInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Comment",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "OBJECT",
+                  "name": "CommentConnection",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -21975,6 +22525,34 @@
               "deprecationReason": null
             },
             {
+              "name": "lastCommentEvent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Event",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "linkoutData",
               "description": null,
               "args": [],
@@ -22099,6 +22677,22 @@
               "deprecationReason": null
             },
             {
+              "name": "subject",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "EventSubject",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "suggestedValue",
               "description": null,
               "args": [],
@@ -22137,6 +22731,11 @@
             {
               "kind": "INTERFACE",
               "name": "EventOriginObject",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Commentable",
               "ofType": null
             }
           ],
@@ -22961,6 +23560,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -23383,6 +23998,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -23764,6 +24395,22 @@
             },
             {
               "name": "initialComment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
               "description": null,
               "args": [],
               "type": {
@@ -27751,6 +28398,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "myVariantInfo",
               "description": null,
               "args": [],
@@ -28934,6 +29597,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -29353,6 +30032,22 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [],
@@ -29437,6 +30132,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },

--- a/client/src/app/views/assertions/assertions-detail/assertions-detail-routing.module.ts
+++ b/client/src/app/views/assertions/assertions-detail/assertions-detail-routing.module.ts
@@ -10,6 +10,8 @@ import { AssertionsRevisionsModule } from './assertions-revisions/assertions-rev
 import { AssertionsRevisionsPage } from './assertions-revisions/assertions-revisions.page';
 import { AssertionsSummaryModule } from './assertions-summary/assertions-summary.module';
 import { AssertionsSummaryPage } from './assertions-summary/assertions-summary.page';
+import { AssertionsEventsPage } from './assertions-events/assertions-events.page';
+import { AssertionsEventsModule } from './assertions-events/assertions-events.module';
 
 const routes: Routes = [
   {
@@ -23,6 +25,13 @@ const routes: Routes = [
         component: AssertionsSummaryPage,
         data: {
           breadcrumb: 'Summary'
+        }
+      },
+      {
+        path: 'events',
+        component: AssertionsEventsPage,
+        data: {
+          breadcrumb: 'Events'
         }
       },
       {
@@ -57,6 +66,7 @@ const routes: Routes = [
     AssertionsCommentsModule,
     AssertionsRevisionsModule,
     AssertionsFlagsModule,
+    AssertionsEventsModule
   ],
   exports: [RouterModule],
 })

--- a/client/src/app/views/assertions/assertions-detail/assertions-detail.view.ts
+++ b/client/src/app/views/assertions/assertions-detail/assertions-detail.view.ts
@@ -94,6 +94,11 @@ export class AssertionsDetailView implements OnDestroy {
         routeName: 'flags',
         iconName: 'civic-flag',
         tabLabel: 'Flags'
+      },
+      {
+        routeName: 'events',
+        iconName: 'civic-event',
+        tabLabel: 'Events'
       }
     ]
   }

--- a/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.module.ts
+++ b/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AssertionsEventsPage } from './assertions-events.page';
+import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
+
+
+@NgModule({
+  declarations: [AssertionsEventsPage],
+  imports: [
+    CommonModule,
+    CvcEventFeedModule
+  ],
+  exports: [AssertionsEventsPage]
+})
+export class AssertionsEventsModule { }

--- a/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.page.html
+++ b/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.page.html
@@ -1,0 +1,1 @@
+<cvc-event-feed [subscribable]="subscribable" tagDisplay="hideSubject"></cvc-event-feed>

--- a/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.page.less
+++ b/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.page.less
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.page.ts
+++ b/client/src/app/views/assertions/assertions-detail/assertions-events/assertions-events.page.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { SubscribableEntities, SubscribableInput } from '@app/generated/civic.apollo';
+
+@Component({
+  selector: 'cvc-assertions-events',
+  templateUrl: './assertions-events.page.html',
+  styleUrls: ['./assertions-events.page.less'],
+})
+export class AssertionsEventsPage {
+  subscribable: SubscribableInput
+
+  constructor(private route: ActivatedRoute) {
+    const assertionId: number = +this.route.snapshot.params['assertionId'];
+    this.subscribable = {
+      id: assertionId,
+      entityType: SubscribableEntities.Assertion
+    }
+  }
+}

--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.module.ts
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.module.ts
@@ -16,7 +16,6 @@ import { CvcTagListModule } from '@app/components/shared/tag-list/tag-list.modul
 import { CvcDrugTagModule } from '@app/components/drugs/cvc-drug-tag/cvc-drug-tag.module';
 import { CvcEntityTableCardModule } from '@app/components/shared/entity-table-card/entity-table-card.module';
 import { CvcEvidenceTableModule } from '@app/components/evidence/evidence-table/evidence-table.module';
-import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
 import { CvcDiseaseTagModule } from '@app/components/diseases/cvc-disease-tag/cvc-disease-tag.module';
 import { CvcPhenotypeTagModule } from '@app/components/phenotypes/phenotype-tag/phenotype-tag.module';
 
@@ -41,7 +40,6 @@ import { CvcPhenotypeTagModule } from '@app/components/phenotypes/phenotype-tag/
     CvcDrugTagModule,
     CvcEntityTableCardModule,
     CvcEvidenceTableModule,
-    CvcEventFeedModule,
     CvcDiseaseTagModule,
     CvcPhenotypeTagModule,
   ],

--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
@@ -262,10 +262,4 @@
     <i nz-icon nzType="civic:evidence"></i>
     {{ assertion.name }} Evidence
   </ng-template>
-  <nz-row *nzSpaceItem>
-    <nz-col [nzSpan]="24">
-      <cvc-event-feed [subscribable]="subscribable"
-        tagDisplay="hideSubject"></cvc-event-feed>
-    </nz-col>
-  </nz-row>
 </nz-space>

--- a/client/src/app/views/clinical-trials/clinical-trials-detail/clinical-trials-detail.query.gql
+++ b/client/src/app/views/clinical-trials/clinical-trials-detail/clinical-trials-detail.query.gql
@@ -7,5 +7,6 @@ query ClinicalTrialDetail(
     nctId
     description
     url
+    link
   }
 }

--- a/client/src/app/views/diseases/diseases-detail/diseases-detail.query.gql
+++ b/client/src/app/views/diseases/diseases-detail/diseases-detail.query.gql
@@ -8,5 +8,6 @@ query DiseaseDetail(
     diseaseUrl
     displayName
     diseaseAliases
+    link
   }
 }

--- a/client/src/app/views/drugs/drugs-detail/drugs-detail.query.gql
+++ b/client/src/app/views/drugs/drugs-detail/drugs-detail.query.gql
@@ -7,5 +7,6 @@ query DrugDetail(
     ncitId
     drugUrl
     drugAliases
+    link
   }
 }

--- a/client/src/app/views/evidence/evidence-detail/evidence-detail-routing.module.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-detail-routing.module.ts
@@ -10,6 +10,8 @@ import { EvidenceRevisionsModule } from './evidence-revisions/evidence-revisions
 import { EvidenceRevisionsPage } from './evidence-revisions/evidence-revisions.page';
 import { EvidenceSummaryModule } from './evidence-summary/evidence-summary.module';
 import { EvidenceSummaryPage } from './evidence-summary/evidence-summary.page';
+import { EvidenceEventsPage } from './evidence-events/evidence-events.page';
+import { EvidenceEventsModule } from './evidence-events/evidence-events.module';
 
 const routes: Routes = [
   {
@@ -45,6 +47,13 @@ const routes: Routes = [
         data: {
           breadcrumb: 'Flags'
         }
+      },
+      {
+        path: 'events',
+        component: EvidenceEventsPage,
+        data: {
+          breadcrumb: 'Events'
+        }
       }
     ]
   }
@@ -57,6 +66,7 @@ const routes: Routes = [
     EvidenceCommentsModule,
     EvidenceRevisionsModule,
     EvidenceFlagsModule,
+    EvidenceEventsModule
   ],
   exports: [RouterModule],
 })

--- a/client/src/app/views/evidence/evidence-detail/evidence-detail.query.gql
+++ b/client/src/app/views/evidence/evidence-detail/evidence-detail.query.gql
@@ -11,14 +11,17 @@ fragment EvidenceDetailFields on EvidenceItem {
   variant {
     id
     name
+    link
   }
   gene {
     id
     name
+    link
   }
   assertions {
     id
     name
+    link
   }
   flags(state: OPEN) {
     totalCount

--- a/client/src/app/views/evidence/evidence-detail/evidence-detail.view.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-detail.view.ts
@@ -94,7 +94,12 @@ export class EvidenceDetailView implements OnDestroy {
         routeName: 'flags',
         iconName: 'civic-flag',
         tabLabel: 'Flags'
-      }
+      },
+      {
+        routeName: 'events',
+        iconName: 'civic-event',
+        tabLabel: 'Events'
+      },
     ]
   }
 

--- a/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.module.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { EvidenceEventsPage } from './evidence-events.page';
+import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
+
+
+@NgModule({
+  declarations: [EvidenceEventsPage],
+  imports: [
+    CommonModule,
+    CvcEventFeedModule
+  ],
+  exports: [EvidenceEventsPage]
+})
+export class EvidenceEventsModule { }

--- a/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.page.html
+++ b/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.page.html
@@ -1,0 +1,1 @@
+<cvc-event-feed [subscribable]="subscribable" tagDisplay="hideSubject"></cvc-event-feed>

--- a/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.page.less
+++ b/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.page.less
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.page.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-events/evidence-events.page.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { SubscribableEntities, SubscribableInput } from '@app/generated/civic.apollo';
+
+@Component({
+  selector: 'cvc-evidence-events',
+  templateUrl: './evidence-events.page.html',
+  styleUrls: ['./evidence-events.page.less'],
+})
+export class EvidenceEventsPage {
+  subscribable: SubscribableInput
+
+  constructor(private route: ActivatedRoute) {
+    const evidenceId: number = +this.route.snapshot.params['evidenceId'];
+    this.subscribable = {
+      id: evidenceId,
+      entityType: SubscribableEntities.EvidenceItem
+    }
+  }
+}

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.module.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.module.ts
@@ -17,7 +17,6 @@ import { CvcUserTagModule } from '@app/components/users/user-tag/user-tag.module
 import { CvcClinicalTrialTagModule } from '@app/components/clinical-trials/clinical-trial-tag/clinical-trial-tag.module';
 import { CvcPhenotypeTagModule } from '@app/components/phenotypes/phenotype-tag/phenotype-tag.module';
 import { CvcDrugTagModule } from '@app/components/drugs/cvc-drug-tag/cvc-drug-tag.module';
-import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
 import { CvcAssertionsTableModule } from '@app/components/assertions/assertions-table/assertions-table.module';
 import { CvcEntityTableCardModule } from '@app/components/shared/entity-table-card/entity-table-card.module';
 import { CvcSourceTagModule } from '@app/components/sources/source-tag/source-tag.module';
@@ -47,7 +46,6 @@ import { CvcDiseaseTagModule } from '@app/components/diseases/cvc-disease-tag/cv
     CvcSourceTagModule,
     CvcPhenotypeTagModule,
     CvcDrugTagModule,
-    CvcEventFeedModule,
     CvcAssertionsTableModule,
     CvcEntityTableCardModule,
   ]

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
@@ -200,13 +200,6 @@
       </nz-space>
     </nz-col>
   </nz-row>
-  <nz-row *nzSpaceItem>
-    <nz-col [nzSpan]="24">
-      <!-- <ngx-json-viewer [json]="evidence"></ngx-json-viewer> -->
-      <cvc-event-feed [subscribable]="subscribable"
-        tagDisplay="hideSubject"></cvc-event-feed>
-    </nz-col>
-  </nz-row>
   <cvc-entity-table-card [cvcTitle]="assertionsCardTitle" *nzSpaceItem>
     <cvc-assertions-table [evidenceId]="evidence.id"></cvc-assertions-table>
   </cvc-entity-table-card>

--- a/client/src/app/views/genes/genes-detail/genes-detail-routing.module.ts
+++ b/client/src/app/views/genes/genes-detail/genes-detail-routing.module.ts
@@ -3,6 +3,8 @@ import { Routes, RouterModule } from '@angular/router';
 import { GenesCommentsModule } from './genes-comments/genes-comments.module';
 import { GenesCommentsPage } from './genes-comments/genes-comments.page';
 import { GenesDetailView } from './genes-detail.view';
+import { GenesEventsModule } from './genes-events/genes-events.module';
+import { GenesEventsPage } from './genes-events/genes-events.page';
 import { GenesFlagsModule } from './genes-flags/genes-flags.module';
 import { GenesFlagsPage } from './genes-flags/genes-flags.page';
 import { GenesRevisionsModule } from './genes-revisions/genes-revisions.module';
@@ -47,6 +49,13 @@ const routes: Routes = [
           breadcrumb: 'Summary',
         },
       },
+      {
+        path: 'events',
+        component: GenesEventsPage,
+        data: {
+          breadcrumb: 'Events',
+        },
+      },
     ],
   },
 ];
@@ -58,6 +67,7 @@ const routes: Routes = [
     GenesCommentsModule,
     GenesRevisionsModule,
     GenesFlagsModule,
+    GenesEventsModule
   ],
   exports: [RouterModule],
 })

--- a/client/src/app/views/genes/genes-detail/genes-detail.module.ts
+++ b/client/src/app/views/genes/genes-detail/genes-detail.module.ts
@@ -14,6 +14,7 @@ import { CvcTabNavigationModule } from '@app/components/shared/tab-navigation/ta
 import { CvcContributorAvatarsModule } from '@app/components/shared/contributor-avatars/contributor-avatars.module';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcEntitySubscriptionButtonModule } from '@app/components/shared/entity-subscription-button/entity-subscription-button.module';
+import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
 
 @NgModule({
   declarations: [GenesDetailView],
@@ -31,7 +32,8 @@ import { CvcEntitySubscriptionButtonModule } from '@app/components/shared/entity
     CvcFlaggableModule,
     CvcContributorAvatarsModule,
     CvcSectionNavigationModule,
-    CvcEntitySubscriptionButtonModule
+    CvcEntitySubscriptionButtonModule,
+    CvcEventFeedModule
   ]
 })
 export class GenesDetailModule { }

--- a/client/src/app/views/genes/genes-detail/genes-detail.view.ts
+++ b/client/src/app/views/genes/genes-detail/genes-detail.view.ts
@@ -78,6 +78,11 @@ export class GenesDetailView implements OnDestroy {
         routeName: 'flags',
         iconName: 'civic-flag',
         tabLabel: 'Flags'
+      },
+      {
+        routeName: 'events',
+        iconName: 'civic-event',
+        tabLabel: 'Events'
       }
     ]
 

--- a/client/src/app/views/genes/genes-detail/genes-events/genes-events.module.ts
+++ b/client/src/app/views/genes/genes-detail/genes-events/genes-events.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { GenesEventsPage } from './genes-events.page';
+import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
+
+
+@NgModule({
+  declarations: [GenesEventsPage],
+  imports: [
+    CommonModule,
+    CvcEventFeedModule
+  ],
+  exports: [GenesEventsPage]
+})
+export class GenesEventsModule { }

--- a/client/src/app/views/genes/genes-detail/genes-events/genes-events.page.html
+++ b/client/src/app/views/genes/genes-detail/genes-events/genes-events.page.html
@@ -1,0 +1,1 @@
+<cvc-event-feed [subscribable]="subscribable" tagDisplay="hideSubject"></cvc-event-feed>

--- a/client/src/app/views/genes/genes-detail/genes-events/genes-events.page.less
+++ b/client/src/app/views/genes/genes-detail/genes-events/genes-events.page.less
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/client/src/app/views/genes/genes-detail/genes-events/genes-events.page.ts
+++ b/client/src/app/views/genes/genes-detail/genes-events/genes-events.page.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { SubscribableEntities, SubscribableInput } from '@app/generated/civic.apollo';
+
+@Component({
+  selector: 'cvc-genes-events',
+  templateUrl: './genes-events.page.html',
+  styleUrls: ['./genes-events.page.less'],
+})
+export class GenesEventsPage {
+  subscribable: SubscribableInput
+
+  constructor(private route: ActivatedRoute) {
+    const geneId: number = +this.route.snapshot.params['geneId'];
+    this.subscribable = {
+      id: geneId,
+      entityType: SubscribableEntities.Gene
+    }
+  }
+}

--- a/client/src/app/views/genes/genes-detail/genes-summary/genes-summary.module.ts
+++ b/client/src/app/views/genes/genes-detail/genes-summary/genes-summary.module.ts
@@ -11,7 +11,6 @@ import { CvcLinkTagModule } from '@app/components/shared/link-tag/link-tag.modul
 import { NzSpaceModule } from 'ng-zorro-antd/space';
 import { CvcSourceTagModule } from '@app/components/sources/source-tag/source-tag.module';
 import { CvcVariantsMenuModule } from '@app/components/variants/variants-menu/variants-menu.module';
-import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
 import { CvcMyGeneInfoModule } from '@app/components/genes/my-gene-info/my-gene-info.module';
 import { CvcStatusTagModule } from '@app/components/shared/status-tag/status-tag.module';
 import { CvcUserTagModule } from '@app/components/users/user-tag/user-tag.module';
@@ -32,7 +31,6 @@ import { CvcUserTagModule } from '@app/components/users/user-tag/user-tag.module
     CvcStatusTagModule,
     CvcUserTagModule,
     CvcVariantsMenuModule,
-    CvcEventFeedModule,
     CvcMyGeneInfoModule,
   ],
   exports: [GenesSummaryPage]

--- a/client/src/app/views/genes/genes-detail/genes-summary/genes-summary.page.html
+++ b/client/src/app/views/genes/genes-detail/genes-summary/genes-summary.page.html
@@ -102,14 +102,4 @@
         [geneName]="gene.name"></cvc-variant-menu>
     </nz-col>
   </nz-row>
-
-  <!-- event feed row -->
-  <nz-row [nzGutter]="16" *nzSpaceItem>
-    <nz-col [nzSpan]="24">
-      <cvc-event-feed [subscribable]="subscribableEntity"
-        [subscribableName]="gene.name"
-        tagDisplay="hideSubject"></cvc-event-feed>
-    </nz-col>
-  </nz-row>
-
 </nz-space>

--- a/client/src/app/views/organizations/organizations-events/organizations-events.component.html
+++ b/client/src/app/views/organizations/organizations-events/organizations-events.component.html
@@ -1,1 +1,1 @@
-  <cvc-event-feed [organizationId]="organizationId" tagDisplay="hideOrg"></cvc-event-feed>
+  <cvc-event-feed [organizationId]="organizationId" tagDisplay="hideOrg" [mode]="this.mode"></cvc-event-feed>

--- a/client/src/app/views/organizations/organizations-events/organizations-events.component.ts
+++ b/client/src/app/views/organizations/organizations-events/organizations-events.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { EventFeedMode } from '@app/generated/civic.apollo';
 
 @Component({
   selector: 'cvc-organizations-events',
@@ -8,6 +9,7 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class OrganizationsEventsComponent {
   organizationId: number
+  mode = EventFeedMode.Organization
 
   constructor(private route: ActivatedRoute) {
     this.organizationId = +this.route.snapshot.params['organizationId'];

--- a/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.query.gql
+++ b/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.query.gql
@@ -6,5 +6,6 @@ query PhenotypeDetail(
     name
     hpoId
     url
+    link
   }
 }

--- a/client/src/app/views/users/users-events/users-events.component.html
+++ b/client/src/app/views/users/users-events/users-events.component.html
@@ -1,1 +1,1 @@
-  <cvc-event-feed [userId]="userId" tagDisplay="hideUser"></cvc-event-feed>
+  <cvc-event-feed [userId]="userId" tagDisplay="hideUser" [mode]="this.mode"></cvc-event-feed>

--- a/client/src/app/views/users/users-events/users-events.component.ts
+++ b/client/src/app/views/users/users-events/users-events.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { EventFeedMode } from '@app/generated/civic.apollo';
 
 @Component({
   selector: 'cvc-users-events',
@@ -8,6 +9,7 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class UsersEventsComponent {
   userId: number
+  mode = EventFeedMode.User
 
   constructor(private route: ActivatedRoute) {
     this.userId = +this.route.snapshot.params['userId'];

--- a/client/src/app/views/variant-types/variant-types-detail/variant-types-detail.query.gql
+++ b/client/src/app/views/variant-types/variant-types-detail/variant-types-detail.query.gql
@@ -7,5 +7,6 @@ query VariantTypeDetail(
     soid
     description
     url
+    link
   }
 }

--- a/client/src/app/views/variants/variants-detail/variants-detail-routing.module.ts
+++ b/client/src/app/views/variants/variants-detail/variants-detail-routing.module.ts
@@ -9,6 +9,8 @@ import { VariantsRevisionsModule } from './variants-revisions/variants-revisions
 import { VariantsRevisionsPage } from './variants-revisions/variants-revisions.page';
 import { VariantsSummaryModule } from './variants-summary/variants-summary.module';
 import { VariantsSummaryPage } from './variants-summary/variants-summary.page';
+import { VariantsEventsPage } from './variants-events/variants-events.page';
+import { VariantsEventsModule } from './variants-events/variants-events.module';
 
 const routes: Routes = [
   {
@@ -45,6 +47,13 @@ const routes: Routes = [
           breadcrumb: 'Flags',
         },
       },
+      {
+        path: 'events',
+        component: VariantsEventsPage,
+        data: {
+          breadcrumb: 'Events',
+        },
+      },
     ],
   },
 ];
@@ -56,6 +65,7 @@ const routes: Routes = [
     VariantsCommentsModule,
     VariantsRevisionsModule,
     VariantsFlagsModule,
+    VariantsEventsModule,
   ],
   exports: [RouterModule],
 })

--- a/client/src/app/views/variants/variants-detail/variants-detail.view.ts
+++ b/client/src/app/views/variants/variants-detail/variants-detail.view.ts
@@ -88,6 +88,11 @@ export class VariantsDetailView implements OnDestroy {
         routeName: 'flags',
         iconName: 'civic-flag',
         tabLabel: 'Flags'
+      },
+      {
+        routeName: 'events',
+        iconName: 'civic-event',
+        tabLabel: 'Events'
       }
     ]
   }

--- a/client/src/app/views/variants/variants-detail/variants-events/variants-events.module.ts
+++ b/client/src/app/views/variants/variants-detail/variants-events/variants-events.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { VariantsEventsPage } from './variants-events.page';
+import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
+
+
+@NgModule({
+  declarations: [VariantsEventsPage],
+  imports: [
+    CommonModule,
+    CvcEventFeedModule
+  ],
+  exports: [VariantsEventsPage]
+})
+export class VariantsEventsModule { }

--- a/client/src/app/views/variants/variants-detail/variants-events/variants-events.page.html
+++ b/client/src/app/views/variants/variants-detail/variants-events/variants-events.page.html
@@ -1,0 +1,1 @@
+<cvc-event-feed [subscribable]="subscribable" tagDisplay="hideSubject"></cvc-event-feed>

--- a/client/src/app/views/variants/variants-detail/variants-events/variants-events.page.less
+++ b/client/src/app/views/variants/variants-detail/variants-events/variants-events.page.less
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/client/src/app/views/variants/variants-detail/variants-events/variants-events.page.ts
+++ b/client/src/app/views/variants/variants-detail/variants-events/variants-events.page.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { SubscribableEntities, SubscribableInput } from '@app/generated/civic.apollo';
+
+@Component({
+  selector: 'cvc-variants-events',
+  templateUrl: './variants-events.page.html',
+  styleUrls: ['./variants-events.page.less'],
+})
+export class VariantsEventsPage {
+  subscribable: SubscribableInput
+
+  constructor(private route: ActivatedRoute) {
+    const variantId: number = +this.route.snapshot.params['variantId'];
+    this.subscribable = {
+      id: variantId,
+      entityType: SubscribableEntities.Variant
+    }
+  }
+}

--- a/server/app/graphql/mutations/accept_revisions.rb
+++ b/server/app/graphql/mutations/accept_revisions.rb
@@ -70,7 +70,7 @@ class Mutations::AcceptRevisions < Mutations::MutationWithOrg
 
     user_editing_their_own_submission = [ 
       revisions.first.subject.submitter == current_user,
-      revisions.first.subject.status == 'submitted'
+      revisions.first.subject&.status == 'submitted'
     ].all?
     
     if user_editing_their_own_submission

--- a/server/app/graphql/resolvers/events.rb
+++ b/server/app/graphql/resolvers/events.rb
@@ -1,32 +1,35 @@
 require 'search_object'
 require 'search_object/plugin/graphql'
 
-class Resolvers::Events < GraphQL::Schema::Resolver
-  include SearchObject.module(:graphql)
+module Resolvers
 
-  type Types::Entities::EventType.connection_type, null: false
+  class Events < GraphQL::Schema::Resolver
+    include SearchObject.module(:graphql)
 
-  description 'List and filter events for an object'
+    type Types::Entities::EventType.connection_type, null: false
 
-  scope do
-    object.events
-      .preload(:subject, :originating_object)
-      .order('events.created_at DESC')
-  end
+    description 'List and filter events for an object'
 
-  option(:event_type, type: Types::Events::EventActionType) do |scope, value|
-    scope.where(action: value)
-  end
+    scope do
+      object.events
+        .preload(:subject, :originating_object)
+        .order('events.created_at DESC')
+    end
 
-  option(:originating_user_id, type: Int) do |scope, value|
-    scope.where(originating_user_id: value)
-  end
+    option(:event_type, type: Types::Events::EventActionType) do |scope, value|
+      scope.where(action: value)
+    end
 
-  option(:organization_id, type: Int) do |scope, value|
-    scope.where(organization_id: value)
-  end
+    option(:originating_user_id, type: Int) do |scope, value|
+      scope.where(originating_user_id: value)
+    end
 
-  option(:sort_by, type: Types::DateSortType, description: 'Sort order for the events. Defaults to most recent.') do |scope, value|
-    scope.reorder("events.#{value.column} #{value.direction}")
+    option(:organization_id, type: Int) do |scope, value|
+      scope.where(organization_id: value)
+    end
+
+    option(:sort_by, type: Types::DateSortType, description: 'Sort order for the events. Defaults to most recent.') do |scope, value|
+      scope.reorder("events.#{value.column} #{value.direction}")
+    end
   end
 end

--- a/server/app/graphql/resolvers/top_level_events.rb
+++ b/server/app/graphql/resolvers/top_level_events.rb
@@ -4,6 +4,13 @@ require 'search_object/plugin/graphql'
 class Resolvers::TopLevelEvents < GraphQL::Schema::Resolver
   include SearchObject.module(:graphql)
 
+  class EventFeedMode < Types::BaseEnum
+    description 'The context of an event feed, i.e. what is the root subject of the feed. This option is a no-op when accessing events via a parent.'
+    value 'USER', value: :user
+    value 'ORGANIZATION', value: :organization
+    value 'SUBJECT', value: :subject
+  end
+
   type Types::Entities::EventType.connection_type, null: false
 
   description 'List and filter events for an object'
@@ -32,5 +39,9 @@ class Resolvers::TopLevelEvents < GraphQL::Schema::Resolver
 
   option(:sort_by, type: Types::DateSortType, description: 'Sort order for the events. Defaults to most recent.') do |scope, value|
     scope.reorder("events.#{value.column} #{value.direction}")
+  end
+
+  option(:mode, type: EventFeedMode) do |_, _|
+    #accesed in connection, yuck
   end
 end

--- a/server/app/graphql/types/browse_tables/browse_clinical_trial_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_clinical_trial_type.rb
@@ -8,6 +8,7 @@ module Types::BrowseTables
     field :evidence_count, Int, null: false
     field :source_count, Int, null: false
     field :url, String, null: true
+    field :link, String, null: false
 
     def url
       ClinicalTrial.url_for(nct_id: object.nct_id)

--- a/server/app/graphql/types/browse_tables/browse_disease_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_disease_type.rb
@@ -12,6 +12,11 @@ module Types::BrowseTables
     field :evidence_item_count, Int, null: false
     field :assertion_count, Int, null: false
     field :gene_count, Int, null: false
+    field :link, String, null: false
+
+    def link
+      Rails.application.routes.url_helpers.url_for("/diseases/#{object.id}")
+    end
   end
 end
 

--- a/server/app/graphql/types/browse_tables/browse_drug_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_drug_type.rb
@@ -9,6 +9,7 @@ module Types::BrowseTables
     field :evidence_count, Int, null: false
     field :assertion_count, Int, null: false
     field :drug_url, String, null: true
+    field :link, String, null: false
 
     def drug_url
       Drug.url_for(ncit_id: object.ncit_id)

--- a/server/app/graphql/types/browse_tables/browse_gene_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_gene_type.rb
@@ -5,6 +5,7 @@ module Types::BrowseTables
     field :id, Int, null: false
     field :entrez_id, Int, null: false
     field :name, String, null: false
+    field :link, String, null: false
     field :description, String, null: false
     field :gene_aliases, [String], null: true
     field :diseases, [Types::Entities::DiseaseType], null: true
@@ -13,6 +14,10 @@ module Types::BrowseTables
     field :evidence_item_count, Int, null: false
     field :assertion_count, Int, null: false
 
+    def link
+      Rails.application.routes.url_helpers.url_for("/genes/#{object.id}")
+    end
+
     def gene_aliases
       object.alias_names.compact
     end
@@ -20,13 +25,13 @@ module Types::BrowseTables
     def diseases
       Array(object.diseases)
         .sort_by { |d| -d['total'] }
-        .map { |d| { name: d['name'], id: d['id'] } }
+        .map { |d| { name: d['name'], id: d['id'], link: "/diseases/#{d['id']}" } }
     end
 
     def drugs
       Array(object.drugs)
         .sort_by { |d| -d['total'] }
-        .map { |d| { name: d['name'], id: d['id'] } }
+        .map { |d| { name: d['name'], id: d['id'], link: "/drugs/#{d['id']}"  } }
     end
   end
 end

--- a/server/app/graphql/types/browse_tables/browse_phenotype_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_phenotype_type.rb
@@ -8,6 +8,7 @@ module Types::BrowseTables
     field :url, String, null: false
     field :evidence_count, Int, null: false
     field :assertion_count, Int, null: false
+    field :link, String, null: false
 
     def name
       object.hpo_class

--- a/server/app/graphql/types/browse_tables/browse_source_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_source_type.rb
@@ -14,6 +14,7 @@ module Types::BrowseTables
     field :display_type, String, null: false
     field :clinical_trials, [Types::Entities::ClinicalTrialType], null: false
     field :source_url, String, null: false
+    field :link, String, null: false
 
     def citation
       object.description
@@ -35,5 +36,8 @@ module Types::BrowseTables
       Loaders::AssociationLoader.for(SourceBrowseTableRow, :clinical_trials).load(object)
     end
 
+    def link
+      Rails.application.routes.url_helpers.url_for("/sources/#{object.id}")
+    end
   end
 end

--- a/server/app/graphql/types/browse_tables/browse_variant_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_variant_type.rb
@@ -4,14 +4,24 @@ module Types::BrowseTables
 
     field :id, Int, null: false
     field :name, String, null: false
+    field :link, String, null: false
     field :gene_id, Int, null: false
     field :gene_name, String, null: false
+    field :gene_link, String, null: false
     field :diseases, [Types::Entities::DiseaseType], null: false
     field :drugs, [Types::Entities::DrugType], null: false
     field :evidence_item_count, Int, null: false
     field :assertion_count, Int, null: false
     field :evidence_score, Float, null: false
     field :aliases, [Types::Entities::VariantAliasType], null: false
+
+    def link
+      Rails.application.routes.url_helpers.url_for("/variants/#{object.id}")
+    end
+
+    def gene_link
+      Rails.application.routes.url_helpers.url_for("/genes/#{object.gene_id}")
+    end
 
     def aliases
       object.alias_names
@@ -22,13 +32,13 @@ module Types::BrowseTables
     def diseases
       Array(object.diseases)
         .sort_by { |d| -d['total']}
-        .map { |d| { name: d['name'], id: d['id'] } }
+        .map { |d| { name: d['name'], id: d['id'], link: "/disease/#{d['id']}" } }
     end
 
     def drugs
       Array(object.drugs)
         .sort_by { |d| -d['total']}
-        .map { |d| { name: d['name'], id: d['id'] } }
+        .map { |d| { name: d['name'], id: d['id'], link: "/drugs/#{d['id']}" } }
     end
   end
 end

--- a/server/app/graphql/types/browse_tables/browse_variant_type_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_variant_type_type.rb
@@ -7,6 +7,7 @@ module Types::BrowseTables
     field :name, String, null: false
     field :url, String, null: true
     field :variant_count, Int, null: false
+    field :link, String, null: false
 
     def name
       object.display_name

--- a/server/app/graphql/types/commentable/comment_tag_segment.rb
+++ b/server/app/graphql/types/commentable/comment_tag_segment.rb
@@ -4,5 +4,6 @@ module Types::Commentable
     field :display_name, GraphQL::Types::String, null: false
     field :tag_type, Types::Commentable::TaggableEntity, null: false
     field :status, Types::EvidenceStatusType, null: true
+    field :link, GraphQL::Types::String, null: false
   end
 end

--- a/server/app/graphql/types/connections/comments_connection.rb
+++ b/server/app/graphql/types/connections/comments_connection.rb
@@ -37,7 +37,8 @@ module Types::Connections
           {
             entity_id: User.roles[r],
             display_name: r,
-            tag_type: 'ROLE'
+            tag_type: 'ROLE',
+            link: "",
           }
         end
     end
@@ -51,7 +52,8 @@ module Types::Connections
           {
             entity_id: ref.entity.id,
             display_name: ref.entity.name,
-            tag_type: ref.entity.class.to_s.underscore.upcase
+            tag_type: ref.entity.class.to_s.underscore.upcase,
+            link: ref.entity.link
           }
         end
     end

--- a/server/app/graphql/types/connections/events_connection.rb
+++ b/server/app/graphql/types/connections/events_connection.rb
@@ -11,6 +11,9 @@ module Types::Connections
     field :participating_organizations, [Types::Entities::OrganizationType], null: false,
       description: 'List of all organizations who are involved in this event stream.'
 
+    field :unfiltered_count, Int, null: true,
+      description: 'When filtered on a subject, user, or organization, the total number of events for that subject/user/organization, irregardless of other filters. Returns null when there is no subject, user, or organization.'
+
     def unique_participants
       if event_subject
         User.where(id:
@@ -38,6 +41,21 @@ module Types::Connections
                   ).distinct
       else
         Organization.where(id: object.items.except(:order).select(:organization_id)).distinct
+      end
+    end
+
+    def unfiltered_count
+      @comment_subject ||= object.arguments[:subject]
+      if comment_subject
+        subject = comment_subject
+      else
+        subject = parent
+      end
+
+      if subject
+        Comment.where(commentable: subject).count
+      else
+        nil
       end
     end
 

--- a/server/app/graphql/types/entities/clinical_trial_type.rb
+++ b/server/app/graphql/types/entities/clinical_trial_type.rb
@@ -5,6 +5,7 @@ module Types::Entities
     field :name, String, null: false
     field :description, String, null: false
     field :url, String, null: true
+    field :link, String, null: false
 
     def url
       ClinicalTrial.url_for(nct_id: object.nct_id)

--- a/server/app/graphql/types/entities/disease_type.rb
+++ b/server/app/graphql/types/entities/disease_type.rb
@@ -6,6 +6,7 @@ module Types::Entities
     field :doid, Int, null: true
     field :disease_url, String, null: true
     field :disease_aliases, [String], null: false
+    field :link, String, null: false
 
     def disease_aliases
       Loaders::AssociationLoader.for(Disease, :disease_aliases).load(object).then do |disease_aliases|

--- a/server/app/graphql/types/entities/drug_type.rb
+++ b/server/app/graphql/types/entities/drug_type.rb
@@ -5,6 +5,7 @@ module Types::Entities
     field :ncit_id, String, null: true
     field :drug_url, String, null: true
     field :drug_aliases, [String], null: false
+    field :link, String, null: false
 
     def drug_aliases
       Loaders::AssociationLoader.for(Drug, :drug_aliases).load(object).then do |drug_aliases|

--- a/server/app/graphql/types/entities/phenotype_type.rb
+++ b/server/app/graphql/types/entities/phenotype_type.rb
@@ -4,6 +4,7 @@ module Types::Entities
     field :hpo_id, String, null: false
     field :name, String, null: false
     field :url, String, null: false
+    field :link, String, null: false
 
     def name
       object.hpo_class

--- a/server/app/graphql/types/entities/source_suggestion_type.rb
+++ b/server/app/graphql/types/entities/source_suggestion_type.rb
@@ -13,6 +13,7 @@ module Types::Entities
     field :variant_name, String, null: true
     field :initial_comment, String, null: false
     field :status, Types::SourceSuggestionStatusType, null: false
+    field :link, String, null: false
 
     def source
       Loaders::AssociationLoader.for(SourceSuggestion, :source).load(object)
@@ -24,6 +25,10 @@ module Types::Entities
 
     def name
       "SSID#{object.id}"
+    end
+
+    def link
+      ''
     end
   end
 end

--- a/server/app/graphql/types/entities/variant_type.rb
+++ b/server/app/graphql/types/entities/variant_type.rb
@@ -24,6 +24,7 @@ module Types::Entities
     field :clinvar_ids, [String], null: true
     field :hgvs_descriptions, [String], null: true
     field :my_variant_info, Types::Entities::MyVariantInfoType, null: true
+    field :link, String, null: false
 
     def gene
       Loaders::RecordLoader.for(Gene).load(object.gene_id)

--- a/server/app/graphql/types/entities/variant_type_type.rb
+++ b/server/app/graphql/types/entities/variant_type_type.rb
@@ -5,6 +5,7 @@ module Types::Entities
     field :description, String, null: false
     field :soid, String, null: false
     field :url, String, null: false
+    field :link, String, null: false
 
     def name
       object.display_name

--- a/server/app/graphql/types/interfaces/commentable.rb
+++ b/server/app/graphql/types/interfaces/commentable.rb
@@ -5,6 +5,7 @@ module Types::Interfaces
     description 'A CIViC entity that can have comments on it.'
     field :id, Int, null: false
     field :name, String, null: false
+    field :link, String, null: false
 
     field :comments, resolver: Resolvers::Comments
     field :last_comment_event, Types::Entities::EventType, null: true
@@ -21,7 +22,7 @@ module Types::Interfaces
         when Gene
           Types::Entities::GeneType
         when Revision
-          Types::Entities::RevisionType
+          Types::Revisions::RevisionType
         when Source
           Types::Entities::SourceType
         when Variant

--- a/server/app/graphql/types/interfaces/event_origin_object.rb
+++ b/server/app/graphql/types/interfaces/event_origin_object.rb
@@ -11,6 +11,7 @@ module Types::Interfaces
 
     field :id, Int, null: false
     field :name, String, null: false
+    field :link, String, null: false
 
     def name
       "#{object.class.to_s.first}ID#{object.id}"

--- a/server/app/graphql/types/interfaces/event_subject.rb
+++ b/server/app/graphql/types/interfaces/event_subject.rb
@@ -6,6 +6,7 @@ module Types::Interfaces
 
     field :id, Int, null: false
     field :name, String, null: false
+    field :link, String, null: false
 
     field :events, resolver: Resolvers::Events
 

--- a/server/app/graphql/types/interfaces/flaggable.rb
+++ b/server/app/graphql/types/interfaces/flaggable.rb
@@ -6,6 +6,7 @@ module Types::Interfaces
 
     field :id, Int, null: false
     field :name, String, null: false
+    field :link, String, null: false
 
     field :flagged, GraphQL::Types::Boolean, null: false
     field :flags, resolver: Resolvers::Flags

--- a/server/app/graphql/types/revisions/linkout_data.rb
+++ b/server/app/graphql/types/revisions/linkout_data.rb
@@ -84,7 +84,8 @@ module Types::Revisions
           id: obj.id,
           entity_type: obj.class.to_s,
           display_name: obj.display_name,
-          display_type: obj.respond_to?(:display_type) ? obj.display_type : nil
+          display_type: obj.respond_to?(:display_type) ? obj.display_type : nil,
+          link: obj.respond_to?(:link) ? obj.link : ""
         }
       end
 

--- a/server/app/graphql/types/revisions/moderated_field_type.rb
+++ b/server/app/graphql/types/revisions/moderated_field_type.rb
@@ -4,6 +4,7 @@ module Types::Revisions
     field :display_name, String, null: false
     field :display_type, String, null: true
     field :entity_type, String, null: false
+    field :link, String, null: false
   end
 
   class ScalarFieldType < Types::BaseObject

--- a/server/app/graphql/types/revisions/revision_type.rb
+++ b/server/app/graphql/types/revisions/revision_type.rb
@@ -4,13 +4,13 @@ module Types::Revisions
 
     implements Types::Interfaces::EventSubject
     implements Types::Interfaces::EventOriginObject
+    implements Types::Interfaces::Commentable
 
     field :id, Int, null: false
     field :status, Types::Revisions::RevisionStatus, null: false
     field :current_value, GraphQL::Types::JSON, null: true
     field :suggested_value, GraphQL::Types::JSON, null: true
     field :field_name, String, null: false
-    field :comments, [Types::Entities::CommentType], null: false
     field :creation_comment, Types::Entities::CommentType, null: true
     field :resolution_comment, Types::Entities::CommentType, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
@@ -22,6 +22,7 @@ module Types::Revisions
     field :resolver, Types::Entities::UserType, null: true
     field :creation_event, Types::Entities::EventType, null: true
     field :resolving_event, Types::Entities::EventType, null: true
+    field :subject, Types::Interfaces::EventSubject, null: false
 
     def comments
       Loaders::AssociationLoader.for(Revision, :comments).load(object)

--- a/server/app/models/actions/extract_references.rb
+++ b/server/app/models/actions/extract_references.rb
@@ -28,7 +28,8 @@ module Actions
                   entity_id: referenced_item.id,
                   display_name: referenced_item.name,
                   tag_type: tag_type,
-                  status: self.class.status_value_for_referenced_entity(referenced_item)
+                  status: self.class.status_value_for_referenced_entity(referenced_item),
+                  link: referenced_item.link
                 }
               else
                 split_segment

--- a/server/app/models/assertion.rb
+++ b/server/app/models/assertion.rb
@@ -52,6 +52,10 @@ class Assertion < ActiveRecord::Base
     "AID#{self.id}"
   end
 
+  def link
+    Rails.application.routes.url_helpers.url_for("/assertions/#{self.id}")
+  end
+
   def self.timepoint_query
     ->(x) {
       self.where("assertions.status != 'rejected'")

--- a/server/app/models/clinical_trial.rb
+++ b/server/app/models/clinical_trial.rb
@@ -8,4 +8,8 @@ class ClinicalTrial < ActiveRecord::Base
       "https://clinicaltrials.gov/ct2/show/#{nct_id}"
     end
   end
+
+  def link
+    Rails.application.routes.url_helpers.url_for("/clinical-trials/#{self.id}")
+  end
 end

--- a/server/app/models/comment.rb
+++ b/server/app/models/comment.rb
@@ -23,7 +23,7 @@ class Comment < ActiveRecord::Base
     if self.commentable_type == 'Revision' or self.commentable_type == 'Flag'
       self.commentable.link
     else
-      "#{self.commentable.link}/comments"
+      "/#{Constants::DB_TYPE_TO_PATH_SEGMENT[self.commentable_type]}/#{self.commentable_id}/comments"
     end
   end
 

--- a/server/app/models/comment.rb
+++ b/server/app/models/comment.rb
@@ -19,6 +19,14 @@ class Comment < ActiveRecord::Base
 
   alias_attribute :text, :comment
 
+  def link
+    if self.commentable_type == 'Revision' or self.commentable_type == 'Flag'
+      self.commentable.link
+    else
+      "#{self.commentable.link}/comments"
+    end
+  end
+
   private
   def mark_events_unlinkable
     if self.commentable.respond_to?(:events)

--- a/server/app/models/constants.rb
+++ b/server/app/models/constants.rb
@@ -102,4 +102,13 @@ module Constants
   ]
 
   AMP_LEVELS = ['Tier I - Level A', 'Tier I - Level B', 'Tier II - Level C', 'Tier II - Level D', 'Tier III', 'Tier IV', 'Not Applicable']
+  
+  DB_TYPE_TO_PATH_SEGMENT = {
+    'Assertion' => 'assertions',
+    'EvidenceItem' => 'evidence',
+    'Gene' => 'genes',
+    'Variant' => 'variants',
+    'VariantGroup' => 'variant-groups',
+    'Source' => 'sources',
+  }
 end

--- a/server/app/models/disease.rb
+++ b/server/app/models/disease.rb
@@ -10,6 +10,10 @@ class Disease < ApplicationRecord
     Disease.url_for_doid(doid)
   end
 
+  def link
+    Rails.application.routes.url_helpers.url_for("/diseases/#{self.id}")
+  end
+
   def self.url_for_doid(doid)
     if doid.nil?
       nil

--- a/server/app/models/drug.rb
+++ b/server/app/models/drug.rb
@@ -14,15 +14,19 @@ class Drug < ApplicationRecord
     end
   end
 
-    def self.timepoint_query
-      ->(x) {
-        self.joins(:evidence_items)
-          .group('drugs.id')
-          .select('drugs.id')
-          .where("evidence_items.status != 'rejected'")
-          .having('MIN(evidence_items.created_at) >= ?', x)
-          .distinct
-          .count
-      }
-    end
+  def link
+    Rails.application.routes.url_helpers.url_for("/drugs/#{self.id}")
+  end
+
+  def self.timepoint_query
+    ->(x) {
+      self.joins(:evidence_items)
+        .group('drugs.id')
+        .select('drugs.id')
+        .where("evidence_items.status != 'rejected'")
+        .having('MIN(evidence_items.created_at) >= ?', x)
+        .distinct
+        .count
+    }
+  end
 end

--- a/server/app/models/evidence_item.rb
+++ b/server/app/models/evidence_item.rb
@@ -55,6 +55,14 @@ class EvidenceItem < ActiveRecord::Base
     "EID#{self.id}"
   end
 
+  def display_name
+    self.name
+  end
+
+  def link
+    Rails.application.routes.url_helpers.url_for("/evidence/#{self.id}")
+  end
+
   def gene
     self.variant.gene
   end

--- a/server/app/models/flag.rb
+++ b/server/app/models/flag.rb
@@ -12,6 +12,6 @@ class Flag < ActiveRecord::Base
   end
 
   def link
-    "#{self.flaggable.link}/flags"
+    "/#{Constants::DB_TYPE_TO_PATH_SEGMENT[self.flaggable_type]}/#{self.flaggable.id}/flags"
   end
 end

--- a/server/app/models/flag.rb
+++ b/server/app/models/flag.rb
@@ -11,4 +11,7 @@ class Flag < ActiveRecord::Base
     "a flag on #{flaggable.name}"
   end
 
+  def link
+    "#{self.flaggable.link}/flags"
+  end
 end

--- a/server/app/models/gene.rb
+++ b/server/app/models/gene.rb
@@ -23,6 +23,10 @@ class Gene < ActiveRecord::Base
     }
   end
 
+  def link
+    Rails.application.routes.url_helpers.url_for("/genes/#{self.id}")
+  end
+
   def self.timepoint_query
     ->(x) {
       self.joins(variants: [:evidence_items])

--- a/server/app/models/phenotype.rb
+++ b/server/app/models/phenotype.rb
@@ -6,6 +6,10 @@ class Phenotype < ActiveRecord::Base
     self.hpo_class
   end
 
+  def link
+    Rails.application.routes.url_helpers.url_for("/phenotypes/#{self.id}")
+  end
+
   def url
     "https://hpo.jax.org/app/browse/term/#{self.hpo_id}"
   end

--- a/server/app/models/revision.rb
+++ b/server/app/models/revision.rb
@@ -45,6 +45,10 @@ class Revision < ApplicationRecord
     "RID#{self.id}"
   end
 
+  def link
+    "#{self.subject.link}/revisions"
+  end
+
   def self.timepoint_query
     ->(x) {
       Event.where(action: 'revision accepted')

--- a/server/app/models/revision.rb
+++ b/server/app/models/revision.rb
@@ -46,7 +46,7 @@ class Revision < ApplicationRecord
   end
 
   def link
-    "#{self.subject.link}/revisions"
+    "/#{Constants::DB_TYPE_TO_PATH_SEGMENT[self.subject_type]}/#{self.subject_id}/revisions"
   end
 
   def self.timepoint_query

--- a/server/app/models/source.rb
+++ b/server/app/models/source.rb
@@ -27,6 +27,10 @@ class Source < ActiveRecord::Base
     "#{self.display_type}: #{self.citation}"
   end
 
+  def link
+    Rails.application.routes.url_helpers.url_for("/sources/#{self.id}")
+  end
+
   def display_type
     "#{self.source_type}"
   end

--- a/server/app/models/variant.rb
+++ b/server/app/models/variant.rb
@@ -38,7 +38,11 @@ class Variant < ApplicationRecord
     {
       name: name,
       aliases: variant_aliases.map(&:name)
-    } 
+    }
+  end
+
+  def link
+    Rails.application.routes.url_helpers.url_for("/variants/#{self.id}")
   end
 
   def self.timepoint_query

--- a/server/app/models/variant_group.rb
+++ b/server/app/models/variant_group.rb
@@ -15,4 +15,8 @@ class VariantGroup < ActiveRecord::Base
       name: name
     }
   end
+
+  def link
+    Rails.application.routes.url_helpers.url_for("/variant-groups/#{self.id}")
+  end
 end

--- a/server/app/models/variant_type.rb
+++ b/server/app/models/variant_type.rb
@@ -9,6 +9,10 @@ class VariantType < ActiveRecord::Base
       nil
     end
   end
+
+  def link
+    Rails.application.routes.url_helpers.url_for("/variant-types/#{self.id}")
+  end
   #acts_as_nested_set
 
   #def relationship_with(other)


### PR DESCRIPTION
This PR also moves the event filter to a sidebar to bring its behavior in line with the flags/revisions/comments pages. The PR also includes a fix where certain tags in an event feed wouldn't be linkable. It enables filtering of the event feed on the org and user pages. The event feed now also handles situations where there are no events for an entity or no events for the applied filters.