### PR TITLE
Fix drug typeahead

### DIFF
--- a/client/src/app/forms/config/types/drug-input/drug-input.type.html
+++ b/client/src/app/forms/config/types/drug-input/drug-input.type.html
@@ -43,7 +43,7 @@
     <ng-container *ngIf="this.to.searchString !== '' && this.to.searchString.length >= 5">
         <cvc-form-errors-alert *ngIf="this.errorMessages.length > 0" [errors]="errorMessages"> </cvc-form-errors-alert>
         <button *ngIf="this.errorMessages.length == 0" nz-button nzSize="small" [nzLoading]="this.loading" (click)="addDrug(to.searchString)">
-          <i nz-icon nzType="plus" nzTheme="outline"></i>No Existing CIViC Drug&nbsp;<strong>{{ to.searchString }}</strong>&nbsp;found. Create A New Disease?
+          <i nz-icon nzType="plus" nzTheme="outline"></i>No Existing CIViC Drug&nbsp;<strong>{{ to.searchString }}</strong>&nbsp;found. Create A New Drug?
         </button>
     </ng-container>
   </ng-container>

--- a/server/app/graphql/types/queries/typeahead_queries.rb
+++ b/server/app/graphql/types/queries/typeahead_queries.rb
@@ -53,19 +53,33 @@ module Types::Queries
       end
 
       def disease_typeahead(query_term:)
-        scope = Disease.eager_load(:disease_aliases)
-        scope.where("diseases.name ILIKE ?", "%#{query_term}%")
-          .or(scope.where("disease_aliases.name ILIKE ?", "%#{query_term}%"))
+        results = Disease.where("diseases.name ILIKE ?", "%#{query_term}%")
           .order("LENGTH(diseases.name) ASC")
           .limit(10)
+        if results.size < 10
+          secondary_results = Disease.eager_load(:disease_aliases)
+            .where("disease_aliases.name ILIKE ?", "%#{query_term}%")
+            .order("LENGTH(diseases.name) ASC")
+            .limit(10-results.size)
+          return results + secondary_results
+        else
+          return results
+        end
       end
 
       def drug_typeahead(query_term:)
-        scope = Drug.eager_load(:drug_aliases)
-        scope.where("drugs.name ILIKE ?", "%#{query_term}%")
-          .or(scope.where("drug_aliases.name ILIKE ?", "%#{query_term}%"))
+        results = Drug.where("drugs.name ILIKE ?", "%#{query_term}%")
           .order("LENGTH(drugs.name) ASC")
           .limit(10)
+        if results.size < 10
+          secondary_results = Drug.eager_load(:drug_aliases)
+            .where("drug_aliases.name ILIKE ?", "%#{query_term}%")
+            .order("LENGTH(drugs.name) ASC")
+            .limit(10-results.size)
+          return results + secondary_results
+        else
+          return results
+        end
       end
 
       def gene_typeahead(query_term:)

--- a/server/app/graphql/types/queries/typeahead_queries.rb
+++ b/server/app/graphql/types/queries/typeahead_queries.rb
@@ -64,7 +64,7 @@ module Types::Queries
         scope = Drug.eager_load(:drug_aliases)
         scope.where("drugs.name ILIKE ?", "%#{query_term}%")
           .or(scope.where("drug_aliases.name ILIKE ?", "%#{query_term}%"))
-          .order("drugs.name")
+          .order("LENGTH(drugs.name) ASC")
           .limit(10)
       end
 


### PR DESCRIPTION
Closes #338.
Closes #342 

This PR also makes a change to the drug and disease typeahead that would prioritize direct name matches over alias matches. This change leads to a larger number of queries though since alias tables will be queried separately.