### PR TITLE
Various bugfixes

### DIFF
--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -51,6 +51,10 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, OnDestroy {
     this.selectedOrgChange.emit(org);
   }
 
+  refreshViewer() {
+    setTimeout(() => { this.viewerService.refetch(); }, 2500)
+  }
+
   ngOnInit() {
     this.organizations$ = this.viewerService.viewer$
       .pipe(map((v: Viewer) => v.organizations));

--- a/client/src/app/forms/config/types/submit-button/submit-button.module.ts
+++ b/client/src/app/forms/config/types/submit-button/submit-button.module.ts
@@ -5,11 +5,13 @@ import { CvcFormButtonsModule } from '../../components/form-buttons/form-buttons
 import { CvcOrgSelectorBtnGroupModule } from '../../components/org-selector-btn-group/org-selector-btn-group.module';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { FormlyModule } from '@ngx-formly/core';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [SubmitButtonComponent],
   imports: [
     CommonModule,
+    ReactiveFormsModule,
     FormlyModule.forChild({ types: [SubmitButtonTypeOption] }),
     NzButtonModule,
     CvcFormButtonsModule,

--- a/client/src/app/forms/config/types/submit-button/submit-button.type.html
+++ b/client/src/app/forms/config/types/submit-button/submit-button.type.html
@@ -1,7 +1,8 @@
 <cvc-form-buttons>
-  <cvc-org-selector-btn-group [(selectedOrg)]="selectedOrg"
+  <cvc-org-selector-btn-group #orgButton [(selectedOrg)]="selectedOrg"
     [nzSize]="to.submitSize">
     <button type="submit"
+      (click)="orgButton.refreshViewer();"
       nz-button
       cvcOrgSelectorBtn
       nzType="primary"

--- a/client/src/app/forms/variant-group-submit/variant-group-submit.form.ts
+++ b/client/src/app/forms/variant-group-submit/variant-group-submit.form.ts
@@ -96,6 +96,7 @@ export class VariantGroupSubmitForm implements OnDestroy{
             wrappers: ['form-field'],
             templateOptions: {
               label: 'Variants',
+              required: true,
               helpText: 'Specify the variants that comprise this Variant Group.',
               addText: 'Add a Variant ',
             },
@@ -171,7 +172,7 @@ export class VariantGroupSubmitForm implements OnDestroy{
         description: model.fields.description,
         name: model.fields.name,
         organizationId: model.fields.organization?.id,
-        sourceIds: model.fields.sources.map(s => s.id).filter(isDefined),
+        sourceIds: model.fields.sources ? model.fields.sources.map(s => s.id).filter(isDefined) : [],
         variantIds: model.fields.variants.map(v => v.id).filter(isDefined)
       }
 

--- a/server/app/graphql/mutations/submit_evidence_item.rb
+++ b/server/app/graphql/mutations/submit_evidence_item.rb
@@ -32,7 +32,7 @@ class Mutations::SubmitEvidenceItem< Mutations::MutationWithOrg
     return true
   end
 
-  def resolve(fields:, organization_id: nil, comment:)
+  def resolve(fields:, organization_id: nil, comment: nil)
     evidence_item = InputAdaptors::EvidenceItemInputAdaptor.new(evidence_input_object: fields).perform
 
 


### PR DESCRIPTION
The viewer service caches the most recent org id. This will cause a refetch/refresh every time a form is submitted that uses the org-selector component.

This is obviously a little hacky, in the future we'll want to investigate pushing changes to the viewer automatically after a mutation runs. 