### PR TITLE
include gene name in variant quick search results and indexing.;

### DIFF
--- a/client/src/app/components/layout/quicksearch/quicksearch-component.html
+++ b/client/src/app/components/layout/quicksearch/quicksearch-component.html
@@ -13,8 +13,7 @@
     <a [routerLink]="urlForResult(res)">
       <nz-auto-option (click)="searchQuery = ''; refresh()" [nzValue]="urlForResult(res)">
         <span>
-          <i nz-icon [nzType]="iconNameForResult(res)"></i>
-          <span innerHTML={{res.name}}></span><br />
+          <i nz-icon [nzType]="iconNameForResult(res)"></i> &nbsp; <span innerHTML={{res.name}}></span><br />
           <span innerHTML={{res.matchingText}}></span>
         </span>
       </nz-auto-option>

--- a/server/app/graphql/resolvers/quicksearch.rb
+++ b/server/app/graphql/resolvers/quicksearch.rb
@@ -9,7 +9,7 @@ class Resolvers::Quicksearch < GraphQL::Schema::Resolver
       models: [Gene, Variant, EvidenceItem, Assertion, VariantGroup, Revision],
       highlight: { tag: '<strong>' },
       limit: 10,
-      fields: ['id^10', 'name', 'aliases']
+      fields: ['id^10', 'name', 'aliases', 'gene']
     ).with_highlights(multiple: true)
 
     results.map do |res, highlights|

--- a/server/app/models/variant.rb
+++ b/server/app/models/variant.rb
@@ -33,12 +33,13 @@ class Variant < ApplicationRecord
   }, allow_nil: true
 
   searchkick highlight: [:name, :aliases]
-  scope :search_import, -> { includes(:variant_aliases) }
+  scope :search_import, -> { includes(:variant_aliases, :gene) }
 
   def search_data
     {
-      name: name,
-      aliases: variant_aliases.map(&:name)
+      name: "#{gene.name} - #{name}",
+      gene: gene.name,
+      aliases: variant_aliases.map(&:name),
     }
   end
 


### PR DESCRIPTION
We will likely want to tweak and tune the quicksearch in general to be intuitive across all the data types and to search all the fields users are interested in but for the immediate case, this closes #378 