### PR TITLE
updates all section home pages w/ improved header layout & more compact table display

### DIFF
--- a/client/src/app/components/assertions/assertions-table/assertions-table.component.html
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #assertionsTable
+    nzSize="small"
     [nzData]="(assertions$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"
@@ -73,7 +74,8 @@
           [nzColumnKey]="sortColumns.EvidenceItemsCount"
           [nzSortFn]="true"
           nz-tooltip
-          nzTooltipTitle="Evidence Count"><i nz-icon nzType="civic:evidence"></i>
+          nzTooltipTitle="Evidence Count"><i nz-icon
+            nzType="civic:evidence"></i>
         </th>
       </tr>
       <tr>
@@ -221,22 +223,24 @@
         </td>
         <td>
           <ng-container *ngIf="aid.disease.name; else diseaseElse">
-            <cvc-disease-tag [disease]="aid.disease" [truncateLongName]="true"></cvc-disease-tag>
+            <cvc-disease-tag [disease]="aid.disease"
+              [truncateLongName]="true"></cvc-disease-tag>
           </ng-container>
           <ng-template #diseaseElse>
             <i>N/A</i>
           </ng-template>
         </td>
         <td>
-          <p *ngIf="aid.drugs.length > 0; else drugsElse"
-            nz-typography>
-            <span *ngFor="let drug of aid.drugs; last as isLast">
-                        <cvc-drug-tag [drug]="drug" [truncateLongName]="true"></cvc-drug-tag>
-                      </span>
+          <div *ngIf="aid.drugs.length > 0; else drugsElse">
+            <cvc-tag-list>
+              <span *ngFor="let drug of aid.drugs; last as isLast">
+                <cvc-drug-tag [drug]="drug" [truncateLongName]="true"></cvc-drug-tag>
+              </span>
+            </cvc-tag-list>
             <span *ngIf="aid.drugs.length > 1">
-                        ({{ aid.drugInteractionType | titlecase }})
-                      </span>
-          </p>
+              ({{ aid.drugInteractionType | titlecase }})
+            </span>
+          </div>
           <ng-template #drugsElse>
             <i>N/A</i>
           </ng-template>
@@ -300,18 +304,22 @@
 </nz-card>
 
 <ng-template #titleTemplate>
-  <i nz-icon nzType="civic:assertion"></i>
+  <i nz-icon
+    nzType="civic:assertion"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>
   <ng-container *ngIf="this.cvcTitle">
     {{ this.cvcTitle }}
   </ng-container>
-  <span *ngIf="(filteredCount$ | ngrxPush) as filteredCount; else noData" nz-typography nzType="secondary">
+  <span *ngIf="(filteredCount$ | ngrxPush) as filteredCount; else noData"
+    nz-typography
+    nzType="secondary">
     ({{totalCount}} total, showing {{visibleCount}}<span *ngIf="totalCount && filteredCount < totalCount"> of {{filteredCount}} filtered</span>)
   </span>
   <ng-template #noData>
-    <span nz-typography nzType="secondary">
+    <span nz-typography
+      nzType="secondary">
       (0 total)
     </span>
   </ng-template>

--- a/client/src/app/components/assertions/assertions-table/assertions-table.component.less
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.component.html
+++ b/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #clinicalTrialsTable
+    nzSize="small"
     [nzData]="(clinicalTrials$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"

--- a/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.component.less
+++ b/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/diseases/diseases-table/diseases-table.component.html
+++ b/client/src/app/components/diseases/diseases-table/diseases-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #diseasesTable
+    nzSize="small"
     [nzData]="(diseases$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"

--- a/client/src/app/components/diseases/diseases-table/diseases-table.component.less
+++ b/client/src/app/components/diseases/diseases-table/diseases-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/drugs/drugs-table/drugs-table.component.html
+++ b/client/src/app/components/drugs/drugs-table/drugs-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #drugsTable
+    nzSize="small"
     [nzData]="(drugs$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"

--- a/client/src/app/components/drugs/drugs-table/drugs-table.component.less
+++ b/client/src/app/components/drugs/drugs-table/drugs-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.html
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #evidenceTable
+    nzSize="small"
     [nzData]="(evidence$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"
@@ -299,8 +300,7 @@
           </ng-template>
         </td>
         <td>
-          <p *ngIf="eid.drugs.length > 0; else drugsElse"
-            nz-typography>
+          <div *ngIf="eid.drugs.length > 0; else drugsElse">
             <cvc-tag-list>
               <span *ngFor="let drug of eid.drugs">
                 <cvc-drug-tag [drug]="drug"></cvc-drug-tag>
@@ -309,7 +309,7 @@
             <span *ngIf="eid.drugs.length > 1">
               ({{ eid.drugInteractionType | titlecase }})
             </span>
-          </p>
+          </div>
           <ng-template #drugsElse>
             <i>N/A</i>
           </ng-template>

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.less
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/genes/genes-table/genes-table.component.html
+++ b/client/src/app/components/genes/genes-table/genes-table.component.html
@@ -1,6 +1,7 @@
 <nz-card [nzTitle]="titleTemplate">
   <ng-container *ngIf="{ value: data$ | ngrxPush } as data">
     <nz-table #genesTable
+      nzSize="small"
       [nzData]="(genes$ | ngrxPush)"
       [nzLoading]="(isLoading$ | ngrxPush)"
       [nzFrontPagination]="false"

--- a/client/src/app/components/genes/genes-table/genes-table.component.less
+++ b/client/src/app/components/genes/genes-table/genes-table.component.less
@@ -1,0 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
+:host {
+  display: block;
+}

--- a/client/src/app/components/layout/login-button/login-button.component.html
+++ b/client/src/app/components/layout/login-button/login-button.component.html
@@ -3,7 +3,7 @@
   nzType="primary"
   nzValue="small"
   (click)="showAuth()">
-  <span>Sign In</span>
+  <span>Sign In / Sign Up</span>
 </button>
 <nz-modal [(nzVisible)]="authVisible"
   [nzTitle]="loginModalTitle"
@@ -15,7 +15,7 @@
   </ng-container>
 </nz-modal>
 <ng-template #loginModalTitle>
-  Sign In
+  Sign In / Sign Up
 </ng-template>
 
 <ng-template #loginModalFooter>

--- a/client/src/app/components/organizations/organizations-table/organizations-table.component.html
+++ b/client/src/app/components/organizations/organizations-table/organizations-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #organizationsTable
+    nzSize="small"
     [nzData]="(organizations$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"

--- a/client/src/app/components/organizations/organizations-table/organizations-table.component.less
+++ b/client/src/app/components/organizations/organizations-table/organizations-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.component.html
+++ b/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #phenotypesTable
+    nzSize="small"
     [nzData]="(phenotypes$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"

--- a/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.component.less
+++ b/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.component.less
@@ -1,1 +1,5 @@
-@import 'themes/overrides/entity-page-header.overrides.less';
+@import "themes/overrides/card-table.overrides.less";
+
+:host {
+  display: block;
+}

--- a/client/src/app/components/source-suggestions/source-suggestions-table/source-suggestions-table.component.html
+++ b/client/src/app/components/source-suggestions/source-suggestions-table/source-suggestions-table.component.html
@@ -1,6 +1,7 @@
 <nz-card [nzTitle]="titleTemplate">
   <ng-container  *ngrxLet="viewer$ as viewer">
     <nz-table #sourceSuggestionsTable
+      nzSize="small"
       [nzData]="(sourceSuggestions$ | ngrxPush)"
       [nzLoading]="(isLoading$ | ngrxPush)"
       [nzFrontPagination]="false"

--- a/client/src/app/components/source-suggestions/source-suggestions-table/source-suggestions-table.component.less
+++ b/client/src/app/components/source-suggestions/source-suggestions-table/source-suggestions-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/sources/sources-table/sources-table.component.html
+++ b/client/src/app/components/sources/sources-table/sources-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #sourcesTable
+    nzSize="small"
     [nzData]="(sources$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"

--- a/client/src/app/components/sources/sources-table/sources-table.component.less
+++ b/client/src/app/components/sources/sources-table/sources-table.component.less
@@ -1,3 +1,4 @@
+@import "themes/overrides/card-table.overrides.less";
 :host {
   display: block;
 }

--- a/client/src/app/components/users/user-tag/user-tag.component.ts
+++ b/client/src/app/components/users/user-tag/user-tag.component.ts
@@ -26,7 +26,6 @@ export class CvcUserTagComponent implements OnInit {
       throw new Error('cvc-user-tag component requires valid user input.')
     }
 
-    console.log(this.user.role)
     switch(this.user.role) {
       case 'ADMIN':
         this.icon = 'civic-admin';

--- a/client/src/app/components/users/users-table/users-table.component.html
+++ b/client/src/app/components/users/users-table/users-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #userTable
+    nzSize="small"
     [nzData]="(users$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"
@@ -7,35 +8,35 @@
     <thead (nzSortOrderChange)="onSortChanged($event)">
       <tr>
         <th nzWidth="5%">
-            Username
+          Username
         </th>
         <th nzWidth="15%"
-            [nzColumnKey]="sortColumns.Name"
-            [nzSortFn]="true">
-            Name
+          [nzColumnKey]="sortColumns.Name"
+          [nzSortFn]="true">
+          Name
         </th>
         <th>
-            Organizations
+          Organizations
         </th>
-        <th
-            [nzColumnKey]="sortColumns.Role"
-            [nzSortFn]="true">
-            Role
+        <th [nzColumnKey]="sortColumns.Role"
+          [nzSortFn]="true">
+          Role
         </th>
         <th nzRight
           nz-tooltip
           nzTooltipTitle="Evidence Count">
-          <i nz-icon nzType="civic:evidence"></i>
+          <i nz-icon
+            nzType="civic:evidence"></i>
         </th>
         <th nzRight
           nz-tooltip
           nzTooltipTitle="Revision Count">
-          <i nz-icon nzType="civic:revision"></i>
+          <i nz-icon
+            nzType="civic:revision"></i>
         </th>
-        <th
-          [nzColumnKey]="sortColumns.LastAction"
+        <th [nzColumnKey]="sortColumns.LastAction"
           [nzSortFn]="true">
-            Last Action
+          Last Action
         </th>
       </tr>
       <tr>
@@ -56,9 +57,12 @@
             [nzDropdownMatchSelectWidth]="false"
             (ngModelChange)="onModelChanged()"
             [(ngModel)]="roleInput">
-            <nz-option nzValue="ADMIN" nzLabel="ADMIN"></nz-option>
-            <nz-option nzValue="CURATOR" nzLabel="CURATOR"></nz-option>
-            <nz-option nzValue="EDITOR" nzLabel="EDITOR"></nz-option>
+            <nz-option nzValue="ADMIN"
+              nzLabel="ADMIN"></nz-option>
+            <nz-option nzValue="CURATOR"
+              nzLabel="CURATOR"></nz-option>
+            <nz-option nzValue="EDITOR"
+              nzLabel="EDITOR"></nz-option>
           </nz-select>
         </th>
         <th></th>
@@ -80,12 +84,13 @@
           </ng-template>
         </td>
         <td>
-          <p *ngIf="user.organizations.length > 0; else orgElse"
-            nz-typography>
-            <span *ngFor="let org of user.organizations; last as isLast">
+          <div *ngIf="user.organizations.length > 0; else orgElse">
+            <cvc-tag-list>
+              <span *ngFor="let org of user.organizations; last as isLast">
               <cvc-organization-tag [org]="org"></cvc-organization-tag>
             </span>
-          </p>
+            </cvc-tag-list>
+          </div>
           <ng-template #orgElse>
             <i>--</i>
           </ng-template>
@@ -124,18 +129,22 @@
 </nz-card>
 
 <ng-template #titleTemplate>
-  <i nz-icon nzType="civic:user"></i>
+  <i nz-icon
+    nzType="civic:user"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>
   <ng-container *ngIf="this.cvcTitle">
     {{ this.cvcTitle }}
   </ng-container>
-  <span *ngIf="(filteredCount$ | ngrxPush) as filteredCount; else noData" nz-typography nzType="secondary">
+  <span *ngIf="(filteredCount$ | ngrxPush) as filteredCount; else noData"
+    nz-typography
+    nzType="secondary">
     ({{totalCount}} total, showing {{visibleCount}}<span *ngIf="totalCount && filteredCount < totalCount"> of {{filteredCount}} filtered</span>)
   </span>
   <ng-template #noData>
-    <span nz-typography nzType="secondary">
+    <span nz-typography
+      nzType="secondary">
       (0 total)
     </span>
   </ng-template>

--- a/client/src/app/components/users/users-table/users-table.component.less
+++ b/client/src/app/components/users/users-table/users-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/users/users-table/users-table.module.ts
+++ b/client/src/app/components/users/users-table/users-table.module.ts
@@ -17,6 +17,7 @@ import { CivicTimeagoFormatter } from "@app/core/utilities/timeago-formatter";
 import { TimeagoFormatter, TimeagoModule } from "ngx-timeago";
 import { NzCardModule } from "ng-zorro-antd/card";
 import { NzTypographyModule } from "ng-zorro-antd/typography";
+import { CvcTagListModule } from "@app/components/shared/tag-list/tag-list.module";
 
 @NgModule({
   declarations: [CvcUsersTableComponent],
@@ -31,6 +32,7 @@ import { NzTypographyModule } from "ng-zorro-antd/typography";
     NzSelectModule,
     NzCardModule,
     NzTypographyModule,
+    CvcTagListModule,
     CvcClearableInputFilterModule,
     CvcLinkTagModule,
     CvcUserTagModule,

--- a/client/src/app/components/variant-groups/variant-groups-table/variant-groups-table.component.html
+++ b/client/src/app/components/variant-groups/variant-groups-table/variant-groups-table.component.html
@@ -1,6 +1,7 @@
 <nz-card [nzTitle]="titleTemplate">
   <ng-container *ngIf="{ value: data$ | ngrxPush } as data">
     <nz-table #variantGroupsTable
+      nzSize="small"
       [nzData]="(variantGroups$ | ngrxPush)"
       [nzLoading]="(isLoading$ | ngrxPush)"
       [nzFrontPagination]="false"

--- a/client/src/app/components/variant-groups/variant-groups-table/variant-groups-table.component.less
+++ b/client/src/app/components/variant-groups/variant-groups-table/variant-groups-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/variant-types/variant-types-table/variant-types-table.component.html
+++ b/client/src/app/components/variant-types/variant-types-table/variant-types-table.component.html
@@ -1,5 +1,6 @@
 <nz-card [nzTitle]="titleTemplate">
   <nz-table #variantTypesTable
+    nzSize="small"
     [nzData]="(variantTypes$ | ngrxPush)"
     [nzLoading]="(isLoading$ | ngrxPush)"
     [nzFrontPagination]="false"

--- a/client/src/app/components/variant-types/variant-types-table/variant-types-table.component.less
+++ b/client/src/app/components/variant-types/variant-types-table/variant-types-table.component.less
@@ -1,3 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
 :host {
   display: block;
 }

--- a/client/src/app/components/variants/variants-table/variants-table.component.html
+++ b/client/src/app/components/variants/variants-table/variants-table.component.html
@@ -1,6 +1,7 @@
 <nz-card [nzTitle]="titleTemplate">
   <ng-container *ngIf="{ value: data$ | ngrxPush } as data">
     <nz-table #variantsTable
+      nzSize="small"
       [nzData]="(variants$ | ngrxPush)"
       [nzLoading]="(isLoading$ | ngrxPush)"
       [nzFrontPagination]="false"

--- a/client/src/app/components/variants/variants-table/variants-table.component.less
+++ b/client/src/app/components/variants/variants-table/variants-table.component.less
@@ -1,0 +1,5 @@
+@import "themes/overrides/card-table.overrides.less";
+
+:host {
+  display: block;
+}

--- a/client/src/app/layout/layout-routing.module.ts
+++ b/client/src/app/layout/layout-routing.module.ts
@@ -80,7 +80,7 @@ const routes: Routes = [
       { path: 'users',
         loadChildren: () => import('@app/views/users/users.module').then(m => m.UsersModule),
         data: {
-          breadcrumb: 'Users'
+          breadcrumb: 'Contributors'
         }
       },
       { path: 'variant-groups',

--- a/client/src/app/views/assertions/assertions-home/assertions-home.module.ts
+++ b/client/src/app/views/assertions/assertions-home/assertions-home.module.ts
@@ -11,6 +11,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { RouterModule } from '@angular/router';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
 
 @NgModule({
   declarations: [AssertionsHomePage],
@@ -24,6 +25,7 @@ import { RouterModule } from '@angular/router';
     NzGridModule,
     NzSwitchModule,
     NzButtonModule,
+    NzSpaceModule,
     CvcAssertionsTableModule,
     CvcSectionNavigationModule
   ],

--- a/client/src/app/views/assertions/assertions-home/assertions-home.page.html
+++ b/client/src/app/views/assertions/assertions-home/assertions-home.page.html
@@ -12,16 +12,50 @@
 </ng-template>
 
 <nz-page-header class="site-page-header">
-  <nz-page-header-title>
-    <i nz-icon
-      nzType="civic:assertion"></i> Assertions
-  </nz-page-header-title>
-
   <nz-page-header-content>
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:assertion"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Assertions</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">A CIViC Assertion summarizes a collection of Evidence Items that cover predictive/therapeutic, diagnostic, prognostic or predisposing clinical information for a variant in a specific cancer context.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical" class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/assertions.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Assertion Model Docs
+        </a>
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/curating/assertions.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Assertion Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <nz-row>
       <nz-col [nzSpan]="24">
         <div class="content">
-          <cvc-assertions-table cvcTitle="Browse Assertions"></cvc-assertions-table>
+          <cvc-assertions-table cvcTitle="Browse All Assertions"></cvc-assertions-table>
         </div>
       </nz-col>
     </nz-row>

--- a/client/src/app/views/assertions/assertions-home/assertions-home.page.html
+++ b/client/src/app/views/assertions/assertions-home/assertions-home.page.html
@@ -13,6 +13,7 @@
 
 <nz-page-header class="site-page-header">
   <nz-page-header-content>
+    <!-- title, description, docs links -->
     <nz-row class="header-content">
       <nz-col nzFlex="64px"
         class="header-icon">

--- a/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.module.ts
+++ b/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.module.ts
@@ -7,6 +7,9 @@ import { ReactiveComponentModule } from '@ngrx/component';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcClinicalTrialsTableModule } from '@app/components/clinical-trials/clinical-trials-table/clinical-trials-table.module';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
 @NgModule({
   declarations: [ClinicalTrialsHomePage],
@@ -16,6 +19,9 @@ import { CvcSectionNavigationModule } from '@app/components/shared/section-navig
     NzGridModule,
     NzPageHeaderModule,
     NzIconModule,
+    NzButtonModule,
+    NzTypographyModule,
+    NzSpaceModule,
     CvcClinicalTrialsTableModule,
     CvcSectionNavigationModule,
   ],

--- a/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.page.html
+++ b/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.page.html
@@ -1,15 +1,49 @@
 <cvc-section-navigation> </cvc-section-navigation>
 <nz-page-header class="site-page-header">
-  <nz-page-header-title>
-    <i nz-icon nzType="audit"></i>
-    Clinical Trials
-  </nz-page-header-title>
 
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="audit"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Clinical Trials</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">
+          CIViC automatically associates a Clinical Trial to an Evidence Item if its associated Source's PubMed record provides a clinical trial ID. This ID is not directly curatable.
+        </p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical"
+          class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence/clinical_trial.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Clinical Trial Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
+
+    <!-- browse table-->
     <div nz-row>
-      <div nz-col [nzSpan]="24">
+      <div nz-col
+        [nzSpan]="24">
         <div class="content">
-          <cvc-clinical-trials-table cvcTitle="Browse Clinical Trials"></cvc-clinical-trials-table>
+          <cvc-clinical-trials-table cvcTitle="Browse All Clinical Trials"></cvc-clinical-trials-table>
         </div>
       </div>
     </div>

--- a/client/src/app/views/curation/curation-activity/curation-activity.module.ts
+++ b/client/src/app/views/curation/curation-activity/curation-activity.module.ts
@@ -8,6 +8,9 @@ import { NzPageHeaderModule } from 'ng-zorro-antd/page-header';
 import { CvcTabNavigationModule } from '@app/components/shared/tab-navigation/tab-navigation.module';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { CurationTimelineModule } from './curation-timeline/curation-timeline.module';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzGridModule } from 'ng-zorro-antd/grid';
 
 @NgModule({
   declarations: [CurationActivityView],
@@ -17,6 +20,9 @@ import { CurationTimelineModule } from './curation-timeline/curation-timeline.mo
     CurationTimelineModule,
     NzPageHeaderModule,
     NzIconModule,
+    NzSpaceModule,
+    NzTypographyModule,
+    NzGridModule,
     CvcSectionNavigationModule,
     CvcTabNavigationModule,
   ]

--- a/client/src/app/views/curation/curation-activity/curation-activity.view.html
+++ b/client/src/app/views/curation/curation-activity/curation-activity.view.html
@@ -3,20 +3,38 @@
 
 <nz-page-header class="site-page-header">
 
-  <!-- title -->
-  <nz-page-header-title>
-    <i nz-icon nzType="civic-event"></i>
-    Curation Activity
-  </nz-page-header-title>
-
-
-  <!-- header action btns, actions menu -->
-  <nz-page-header-extra></nz-page-header-extra>
 
   <nz-page-header-content>
-    <cvc-tab-navigation [tabs]="this.tabs"> </cvc-tab-navigation>
-    <div class="content">
-      <router-outlet></router-outlet>
-    </div>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:event"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Curation Event Timeline</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">All CIViC curation activity is logged and publicly available, thus esablishing the provenance of its assertions, summaries, associations, and acknowledging the work of collaborators.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+      </nz-col>
+    </nz-row>
+    <nz-row>
+      <nz-col [nzSpan]="24">
+        <cvc-tab-navigation [tabs]="this.tabs"> </cvc-tab-navigation>
+      </nz-col>
+    </nz-row>
+    <nz-row>
+      <nz-col [nzSpan]="24">
+        <div class="content">
+          <router-outlet></router-outlet>
+        </div>
+      </nz-col>
+    </nz-row>
   </nz-page-header-content>
 </nz-page-header>

--- a/client/src/app/views/curation/curation-activity/curation-activity.view.html
+++ b/client/src/app/views/curation/curation-activity/curation-activity.view.html
@@ -2,8 +2,6 @@
 </cvc-section-navigation>
 
 <nz-page-header class="site-page-header">
-
-
   <nz-page-header-content>
     <!-- title, description, docs links -->
     <nz-row class="header-content">

--- a/client/src/app/views/curation/curation-queues/curation-queues.module.ts
+++ b/client/src/app/views/curation/curation-queues/curation-queues.module.ts
@@ -8,6 +8,9 @@ import { NzPageHeaderModule } from 'ng-zorro-antd/page-header';
 import { ReactiveComponentModule } from '@ngrx/component';
 import { CvcTabNavigationModule } from '@app/components/shared/tab-navigation/tab-navigation.module';
 import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzGridModule } from 'ng-zorro-antd/grid';
 
 
 @NgModule({
@@ -20,6 +23,9 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     CurationQueuesRoutingModule,
     NzPageHeaderModule,
     NzIconModule,
+    NzSpaceModule,
+    NzTypographyModule,
+    NzGridModule,
     CvcSectionNavigationModule,
     CvcTabNavigationModule,
   ]

--- a/client/src/app/views/curation/curation-queues/curation-queues.view.html
+++ b/client/src/app/views/curation/curation-queues/curation-queues.view.html
@@ -2,21 +2,37 @@
 </cvc-section-navigation>
 
 <nz-page-header class="site-page-header">
-
-  <!-- title -->
-  <nz-page-header-title>
-    <i nz-icon nzType="file-add"></i>
-    Curation Queues
-  </nz-page-header-title>
-
-
-  <!-- header action btns, actions menu -->
-  <nz-page-header-extra></nz-page-header-extra>
-
   <nz-page-header-content>
-    <cvc-tab-navigation [tabs]="this.tabs"> </cvc-tab-navigation>
-    <div class="content">
-      <router-outlet></router-outlet>
-    </div>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="file-add"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Curation Queues</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">New submitted Evidence, Assertions, and Source Suggestions must be accepted by a CIViC Editor. These Curation Queues list items in need of Editor moderation.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+      </nz-col>
+    </nz-row>
+    <nz-row>
+      <nz-col [nzSpan]="24">
+        <cvc-tab-navigation [tabs]="this.tabs"> </cvc-tab-navigation>
+      </nz-col>
+    </nz-row>
+    <nz-row>
+      <nz-col [nzSpan]="24">
+        <div class="content">
+          <router-outlet></router-outlet>
+        </div>
+      </nz-col>
+    </nz-row>
   </nz-page-header-content>
 </nz-page-header>

--- a/client/src/app/views/diseases/diseases-home/diseases-home.module.ts
+++ b/client/src/app/views/diseases/diseases-home/diseases-home.module.ts
@@ -6,6 +6,9 @@ import { NzPageHeaderModule } from 'ng-zorro-antd/page-header';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcDiseasesTableModule } from '@app/components/diseases/diseases-table/diseases-table.module';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
 
 @NgModule({
   declarations: [DiseasesHomePage],
@@ -14,6 +17,9 @@ import { CvcSectionNavigationModule } from '@app/components/shared/section-navig
     NzIconModule,
     NzPageHeaderModule,
     NzGridModule,
+    NzButtonModule,
+    NzTypographyModule,
+    NzSpaceModule,
     CvcSectionNavigationModule,
     CvcDiseasesTableModule,
   ],

--- a/client/src/app/views/diseases/diseases-home/diseases-home.page.html
+++ b/client/src/app/views/diseases/diseases-home/diseases-home.page.html
@@ -1,18 +1,58 @@
 <cvc-section-navigation> </cvc-section-navigation>
 <nz-page-header class="site-page-header">
 
-  <!--title-->
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:disease"></i>
-    Diseases
-  </nz-page-header-title>
-
   <!--content-->
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:disease"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Diseases</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">
+          All CIViC Evidence Items are associated with a Disease included in the Disease Ontology database.
+        </p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical"
+          class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence/disease.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Disease Attribute Docs
+        </a>
+          <a nz-button href="https://civic.readthedocs.io/en/latest/model/evidence/disease.html#curating-diseases"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Disease Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <div nz-row>
-      <div nz-col [nzSpan]="24">
+      <div nz-col
+        [nzSpan]="24">
         <div class="content">
-          <cvc-diseases-table cvcTitle="Browse Diseases"></cvc-diseases-table>
+          <cvc-diseases-table cvcTitle="Browse All Diseases"></cvc-diseases-table>
         </div>
       </div>
     </div>

--- a/client/src/app/views/drugs/drugs-home/drugs-home.module.ts
+++ b/client/src/app/views/drugs/drugs-home/drugs-home.module.ts
@@ -6,6 +6,9 @@ import { NzPageHeaderModule } from 'ng-zorro-antd/page-header';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcDrugsTableModule } from '@app/components/drugs/drugs-table/drugs-table.module';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzButtonModule } from 'ng-zorro-antd/button';
 
 @NgModule({
   declarations: [DrugsHomePage],
@@ -14,6 +17,9 @@ import { CvcSectionNavigationModule } from '@app/components/shared/section-navig
     NzIconModule,
     NzPageHeaderModule,
     NzGridModule,
+    NzTypographyModule,
+    NzSpaceModule,
+    NzButtonModule,
     CvcSectionNavigationModule,
     CvcDrugsTableModule,
   ],

--- a/client/src/app/views/drugs/drugs-home/drugs-home.page.html
+++ b/client/src/app/views/drugs/drugs-home/drugs-home.page.html
@@ -1,16 +1,56 @@
 <cvc-section-navigation> </cvc-section-navigation>
 <nz-page-header class="site-page-header">
-  <nz-page-header-title>
-    <i nz-icon
-      nzType="civic:intervention"></i> Drugs
-  </nz-page-header-title>
 
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:intervention"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Drugs</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">CIViC Drugs are associated with Predictive Evidence Types, and describe the sensitivity, resistance or adverse response to treatment. Drugs may also be used to describe more general treatment types and regimes, such as FOLFOX or Radiation.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical"
+          class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence/drug.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Drug Attribute Docs
+        </a>
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence/drug.html#curating-drugs"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Drug Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <div nz-row>
       <div nz-col
         [nzSpan]="24">
         <div class="content">
-          <cvc-drugs-table cvcTitle="Browse Drugs"></cvc-drugs-table>
+          <cvc-drugs-table cvcTitle="Browse All Drugs"></cvc-drugs-table>
         </div>
       </div>
     </div>

--- a/client/src/app/views/evidence/evidence-home/evidence-home.module.ts
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.module.ts
@@ -11,6 +11,7 @@ import { ReactiveComponentModule } from '@ngrx/component';
 import { NzSwitchModule } from 'ng-zorro-antd/switch';
 import { RouterModule } from '@angular/router';
 import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
 
 @NgModule({
   declarations: [EvidenceHomePage],
@@ -23,6 +24,7 @@ import { NzButtonModule } from 'ng-zorro-antd/button';
     NzPageHeaderModule,
     NzGridModule,
     NzIconModule,
+    NzSpaceModule,
     CvcSectionNavigationModule,
     CvcGeneTagModule,
     CvcEvidenceTableModule,

--- a/client/src/app/views/evidence/evidence-home/evidence-home.module.ts
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.module.ts
@@ -12,6 +12,7 @@ import { NzSwitchModule } from 'ng-zorro-antd/switch';
 import { RouterModule } from '@angular/router';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
 @NgModule({
   declarations: [EvidenceHomePage],
@@ -25,6 +26,7 @@ import { NzSpaceModule } from 'ng-zorro-antd/space';
     NzGridModule,
     NzIconModule,
     NzSpaceModule,
+    NzTypographyModule,
     CvcSectionNavigationModule,
     CvcGeneTagModule,
     CvcEvidenceTableModule,

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.html
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.html
@@ -5,28 +5,68 @@
       *ngIf="viewer.signedIn"
       nz-button
       nzSize="small">
-      <i nz-icon nzType="plus-circle"></i>
-      Submit New Evidence
+      <i nz-icon
+        nzType="plus-circle"></i> Submit New Evidence
     </button>
   </ng-container>
 </ng-template>
 <nz-page-header class="site-page-header">
-  <nz-page-header-title>
-    <i nz-icon
-      nzType="civic:evidence"></i> CIViC Evidence
-  </nz-page-header-title>
-  <!-- TODO: refactor card card toggle, components -->
-  <!-- <nz-page-header-extra>
-       Card View
-       <nz-switch [(ngModel)]="tableView"
-       (ngModelChange)="refresh()"></nz-switch> Table View
-       </nz-page-header-extra> -->
-
+  <!-- <nz-avatar nz-page-header-avatar>
+       <i nz-icon class="header-icon"
+       nzType="civic:evidence"></i>
+       </nz-avatar>
+       <nz-page-header-title>
+       Evidence Items
+       </nz-page-header-title>
+       <nz-page-header-subtitle>
+       At the heart of CIViC is the clinical evidence statement. The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.
+       </nz-page-header-subtitle> -->
   <nz-page-header-content>
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:evidence"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Evidence Items</h2>
+        <p>The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            Knowledge Model Docs
+        </a>
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/curating/evidence.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
+
     <nz-row *ngIf="tableView">
-      <div nz-col [nzSpan]="24">
+      <div nz-col
+        [nzSpan]="24">
         <div class="content">
-          <cvc-evidence-table cvcTitle="Browse Evidence"></cvc-evidence-table>
+          <cvc-evidence-table cvcTitle="Browse All Evidence"></cvc-evidence-table>
         </div>
       </div>
     </nz-row>
@@ -35,9 +75,9 @@
          nz-row>
          <div nz-col -->
     <!-- [nzSpan]="24"> -->
-        <!-- <ng-container *ngFor="let evidence of evidence$ | ngrxPush"> -->
-        <!-- <cvc-evidence-card [evidence]="evidence"></cvc-evidence-card> -->
-        <!-- </ng-container> -->
+    <!-- <ng-container *ngFor="let evidence of evidence$ | ngrxPush"> -->
+    <!-- <cvc-evidence-card [evidence]="evidence"></cvc-evidence-card> -->
+    <!-- </ng-container> -->
     <!-- </div>
          </div> -->
   </nz-page-header-content>

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.html
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.html
@@ -11,16 +11,6 @@
   </ng-container>
 </ng-template>
 <nz-page-header class="site-page-header">
-  <!-- <nz-avatar nz-page-header-avatar>
-       <i nz-icon class="header-icon"
-       nzType="civic:evidence"></i>
-       </nz-avatar>
-       <nz-page-header-title>
-       Evidence Items
-       </nz-page-header-title>
-       <nz-page-header-subtitle>
-       At the heart of CIViC is the clinical evidence statement. The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.
-       </nz-page-header-subtitle> -->
   <nz-page-header-content>
     <nz-row class="header-content">
       <nz-col nzFlex="64px"

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.html
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.html
@@ -31,11 +31,11 @@
       <nz-col nzFlex="600px"
         class="header-description">
         <h2>Evidence Items</h2>
-        <p>The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.</p>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.</p>
       </nz-col>
       <nz-col nzFlex="auto"
         class="header-links">
-        <nz-space nzDirection="vertical">
+        <nz-space nzDirection="vertical" class="docs-buttons">
           <a nz-button
             href="https://civic.readthedocs.io/en/latest/model/evidence.html"
             target="_blank"
@@ -45,7 +45,7 @@
             <i nz-icon
               nzType="link"
               nzTheme="outline"></i>
-            Knowledge Model Docs
+            View Evidence Model Docs
         </a>
           <a nz-button
             href="https://civic.readthedocs.io/en/latest/curating/evidence.html"
@@ -56,7 +56,7 @@
             <i nz-icon
               nzType="link"
               nzTheme="outline"></i>
-            Curation Docs
+            View Evidence Curation Docs
         </a>
         </nz-space>
       </nz-col>

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.html
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.html
@@ -12,6 +12,7 @@
 </ng-template>
 <nz-page-header class="site-page-header">
   <nz-page-header-content>
+    <!-- title, description, docs links -->
     <nz-row class="header-content">
       <nz-col nzFlex="64px"
         class="header-icon">

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.less
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.less
@@ -1,1 +1,4 @@
 @import 'themes/overrides/entity-page-header.overrides.less';
+::host {
+  position: relative;
+}

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.less
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.less
@@ -2,3 +2,5 @@
 ::host {
   position: relative;
 }
+
+

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.less
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.less
@@ -2,5 +2,3 @@
 ::host {
   position: relative;
 }
-
-

--- a/client/src/app/views/genes/genes-home/genes-home.module.ts
+++ b/client/src/app/views/genes/genes-home/genes-home.module.ts
@@ -6,6 +6,9 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcGenesTableModule } from '@app/components/genes/genes-table/genes-table.module';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
 import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzButtonModule } from 'ng-zorro-antd/button';
 
 @NgModule({
   declarations: [GenesHomePage],
@@ -13,7 +16,10 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     CommonModule,
     CvcSectionNavigationModule,
     CvcGenesTableModule,
+    NzButtonModule,
     NzIconModule,
+    NzSpaceModule,
+    NzTypographyModule,
     NzPageHeaderModule,
     NzGridModule
   ],

--- a/client/src/app/views/genes/genes-home/genes-home.page.html
+++ b/client/src/app/views/genes/genes-home/genes-home.page.html
@@ -3,6 +3,7 @@
 
   <!--content-->
   <nz-page-header-content>
+    <!-- title, description, docs links -->
     <nz-row class="header-content">
       <nz-col nzFlex="64px"
         class="header-icon">

--- a/client/src/app/views/genes/genes-home/genes-home.page.html
+++ b/client/src/app/views/genes/genes-home/genes-home.page.html
@@ -1,18 +1,55 @@
 <cvc-section-navigation> </cvc-section-navigation>
 <nz-page-header class="site-page-header">
 
-  <!--title-->
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:gene"></i>
-    Genes
-  </nz-page-header-title>
-
   <!--content-->
   <nz-page-header-content>
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:gene"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Genes</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">CIViC Genes include a gene-level summary, a link to the Druge Gene Interation Database, and extensive gene details from MyGene.info.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical"
+          class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/genes.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Gene Model Docs
+        </a>
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/curating/genes.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Gene Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <nz-row>
       <nz-col [nzSpan]="24">
         <div class="content">
-          <cvc-genes-table cvcTitle="Browse Genes"></cvc-genes-table>
+          <cvc-genes-table cvcTitle="Browse All Genes"></cvc-genes-table>
         </div>
       </nz-col>
     </nz-row>

--- a/client/src/app/views/genes/genes-home/genes-home.page.html
+++ b/client/src/app/views/genes/genes-home/genes-home.page.html
@@ -16,7 +16,7 @@
         <p nz-typography
           nzEllipsis
           nzExpandable
-          [nzEllipsisRows]="2">CIViC Genes include a gene-level summary, a link to the Druge Gene Interation Database, and extensive gene details from MyGene.info.</p>
+          [nzEllipsisRows]="2">CIViC Genes include a gene-level summary, a link to the Drug Gene Interation Database, and extensive gene details from MyGene.info.</p>
       </nz-col>
       <nz-col nzFlex="auto"
         class="header-links">

--- a/client/src/app/views/organizations/organizations-home/organizations-home.module.ts
+++ b/client/src/app/views/organizations/organizations-home/organizations-home.module.ts
@@ -6,6 +6,10 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
 
 import { OrganizationsHomePage } from './organizations-home.page';
 import { CvcOrganizationsTableModule } from '@app/components/organizations/organizations-table/organizations-table.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
 
 @NgModule({
   declarations: [OrganizationsHomePage],
@@ -14,6 +18,10 @@ import { CvcOrganizationsTableModule } from '@app/components/organizations/organ
     NzPageHeaderModule,
     NzIconModule,
     NzGridModule,
+    NzButtonModule,
+    NzSpaceModule,
+    NzTypographyModule,
+    CvcSectionNavigationModule,
     CvcOrganizationsTableModule
   ],
 })

--- a/client/src/app/views/organizations/organizations-home/organizations-home.page.html
+++ b/client/src/app/views/organizations/organizations-home/organizations-home.page.html
@@ -1,15 +1,43 @@
+<cvc-section-navigation></cvc-section-navigation>
 <nz-page-header class="site-page-header">
-
-  <!--title-->
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:organization"></i>
-    Organizations
-  </nz-page-header-title>
-
   <!--content-->
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:organization"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Organizations</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">Users may be included in Organizations, primarily in order to keep track of an organization’s contributions to CIViC curation. A User’s organization affiliation is displayed in their profile and user card.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical"
+          class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/using/organizations.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Organization Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <div nz-row>
-      <div nz-col [nzSpan]="24">
+      <div nz-col
+        [nzSpan]="24">
         <div class="content">
           <cvc-organizations-table cvcTitle="Browse Organizations"></cvc-organizations-table>
         </div>

--- a/client/src/app/views/phenotypes/phenotypes-home/phenotypes-home.module.ts
+++ b/client/src/app/views/phenotypes/phenotypes-home/phenotypes-home.module.ts
@@ -6,6 +6,9 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
 import { PhenotypesHomePage } from './phenotypes-home.page';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
 @NgModule({
   declarations: [PhenotypesHomePage],
@@ -14,6 +17,9 @@ import { PhenotypesHomePage } from './phenotypes-home.page';
     NzPageHeaderModule,
     NzIconModule,
     NzGridModule,
+    NzButtonModule,
+    NzSpaceModule,
+    NzTypographyModule,
     CvcSectionNavigationModule,
     CvcPhenotypesTableModule
   ],

--- a/client/src/app/views/phenotypes/phenotypes-home/phenotypes-home.page.html
+++ b/client/src/app/views/phenotypes/phenotypes-home/phenotypes-home.page.html
@@ -1,15 +1,52 @@
 <cvc-section-navigation></cvc-section-navigation>
 <nz-page-header class="site-page-header">
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:phenotype"></i>
-    Phenotypes
-  </nz-page-header-title>
-
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:phenotype"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Associated Phenotypes</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">Phenotypes are symptoms or abnormalities that are encountered in human disease, optionally associated with Evidence Items and known to the Human Phenotype Ontology database.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical" class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence/associated_phenotype.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Associated Phenotype Docs
+        </a>
+        <a nz-button
+          href="https://civic.readthedocs.io/en/latest/model/evidence/associated_phenotype.html#curating-associated-phenotypes"
+          target="_blank"
+          nzSize="small"
+          nzBlock
+          *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Phenotype Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
+
+    <!-- table -->
     <div nz-row>
       <div nz-col [nzSpan]="24">
         <div class="content">
-          <cvc-phenotypes-table cvcTitle="Browse Phenotypes"></cvc-phenotypes-table>
+          <cvc-phenotypes-table cvcTitle="Browse All Associated Phenotypes"></cvc-phenotypes-table>
         </div>
       </div>
     </div>

--- a/client/src/app/views/releases/releases-main/releases-main.component.html
+++ b/client/src/app/views/releases/releases-main/releases-main.component.html
@@ -1,105 +1,151 @@
+<cvc-section-navigation></cvc-section-navigation>
 <nz-page-header class="site-page-header">
 
   <!--title-->
-  <nz-page-header-title>
-    <i nz-icon nzType="download"></i>
-    Data Releases
-  </nz-page-header-title>
+  <!-- <nz-page-header-title>
+       <i nz-icon nzType="download"></i>
+       Data Releases
+       </nz-page-header-title> -->
 
   <!--content-->
   <nz-page-header-content>
-    <nz-space nzDirection="vertical" nzSpace="large">
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="download"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Data Releases</h2>
+        <p nz-typography
+          nzEllipsis
+          nzExpandable
+          [nzEllipsisRows]="2">The CIViC server produces nightly and monthly releases that include a subset of all primary entity records.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical"
+          class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/using/data_releases.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Data Releases Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
+    <nz-space nzDirection="vertical"
+      nzSpace="large">
       <nz-row *nzSpaceItem>
-        <nz-alert 
-        nzType="info" 
-        nzMessage="Please Note" 
-        nzDescription="TSV and VCF releases of CIViC data are provided at regular intervals for the convenience of those who require the use of a static file. For most users, we recomend utilizing our API which. Using the API will provide you with the richest metadata about CIViC entries as well as the most current versions of all evidence statements. In fact, the entire CIViC web frontend runs off the exact same API that is available for public use.">
+        <nz-alert nzType="info"
+          nzMessage="Please Note"
+          nzDescription="TSV and VCF releases of CIViC data are provided at regular intervals for the convenience of those who require the use of a static file. For most users, we recomend utilizing our API which. Using the API will provide you with the richest metadata about CIViC entries as well as the most current versions of all evidence statements. In fact, the entire CIViC web frontend runs off the exact same API that is available for public use.">
         </nz-alert>
       </nz-row>
       <nz-row *nzSpaceItem>
-          <p nz-typography>
-            The CIViC server produces nightly and monthly releases that include a subset of all primary entity records (Genes, Variants, Evidence, Variant Groups, and Assertions). Both TSV and VCF versions are provided below - just locate the specific entity type and data format you wish to obtain, then click on the relevant button to download.
-          </p>
-          <p nz-typography>
-            These records do not contain user profile data, discussion and commentary, data provenance and revision history, or information dynamically obtained from resources external to CIViC (e.g. MyVariant.Info, MyGene.Info). Variant TSV releases only include variant records with accepted evidence records. Variant TSV releases from before August 2020 include all variant records, irregardless of the status of the associated evidence items. Evidence TSV releases only include accepted evidence items and exclude pending or rejected evidence items. Assertion TSV releases only include accepted assertions. Accepted VCF releases include only variants with accepted evidence items and/or accepted assertions. Accepted & Submitted VCF releases include Variants with accepted and/or submitted evidence items and/or assertions.
-          </p>
-          <p nz-typography>
-            In order to comply with the VCF specification, the VCFs can only include variants with complete coordinates. By contrast, the TSV variants file may contain variants with coordinates that have not been fully curated in CIViC. Additional variants are of types that can not be properly represented in VCF format. Thus, the number of variants will be lower in the VCFs compared to the number of variants in the TSV.
-          </p>
-          <p nz-typography>
-            As with all curated evidence and interpretations of CIViC, the contents of these files are made freely available, without restriction under the CC0 license (<a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank">Creative Commons Public Domain Dedication, CC0 1.0 Universal</a>).
-          </p>
-          <p nz-typography>
-            If you use CIViC content, please consider citing the <a href="http://www.nature.com/ng/journal/v49/n2/full/ng.3774.html" target="_blank">CIViC publication</a>.
-          </p>
+        <p nz-typography>
+          The CIViC server produces nightly and monthly releases that include a subset of all primary entity records (Genes, Variants, Evidence, Variant Groups, and Assertions). Both TSV and VCF versions are provided below - just locate the specific entity type and data format you wish to obtain, then click on the relevant button to download.
+        </p>
+        <p nz-typography>
+          These records do not contain user profile data, discussion and commentary, data provenance and revision history, or information dynamically obtained from resources external to CIViC (e.g. MyVariant.Info, MyGene.Info). Variant TSV releases only include variant records with accepted evidence records. Variant TSV releases from before August 2020 include all variant records, irregardless of the status of the associated evidence items. Evidence TSV releases only include accepted evidence items and exclude pending or rejected evidence items. Assertion TSV releases only include accepted assertions. Accepted VCF releases include only variants with accepted evidence items and/or accepted assertions. Accepted & Submitted VCF releases include Variants with accepted and/or submitted evidence items and/or assertions.
+        </p>
+        <p nz-typography>
+          In order to comply with the VCF specification, the VCFs can only include variants with complete coordinates. By contrast, the TSV variants file may contain variants with coordinates that have not been fully curated in CIViC. Additional variants are of types that can not be properly represented in VCF format. Thus, the number of variants will be lower in the VCFs compared to the number of variants in the TSV.
+        </p>
+        <p nz-typography>
+          As with all curated evidence and interpretations of CIViC, the contents of these files are made freely available, without restriction under the CC0 license (<a href="https://creativecommons.org/publicdomain/zero/1.0/"
+            target="_blank">Creative Commons Public Domain Dedication, CC0 1.0 Universal</a>).
+        </p>
+        <p nz-typography>
+          If you use CIViC content, please consider citing the <a href="http://www.nature.com/ng/journal/v49/n2/full/ng.3774.html"
+            target="_blank">CIViC publication</a>.
+        </p>
       </nz-row>
       <nz-row *nzSpaceItem>
         <nz-col [nzSpan]="24">
           <div class="content">
-            <nz-table #releasesTable
-            [nzData]="releases$ | ngrxPush"
-            [nzLoading]="loading$ | ngrxPush"
-            [nzFrontPagination]="true"
-            [nzShowPagination]="true"
-            [nzPageSize]="5"
-            >
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Genes</th>
-                <th>Variants</th>
-                <th>Evidence</th>
-                <th>Variant Groups</th>
-                <th>Assertions</th>
-                <th>Accepted Variants VCF</th>
-                <th>Accepted & Submitted Variants VCF</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr *ngFor="let release of releasesTable.data">
-                <td>{{release.name }}</td>
-                <td *ngIf="release.geneTsv; else noData">
-                  <cvc-link-tag [href]="release.geneTsv.path" iconName="download">
-                    Genes TSV
-                  </cvc-link-tag>
-                </td>
-                <td *ngIf="release.variantTsv; else noData">
-                  <cvc-link-tag [href]="release.variantTsv.path" iconName="download">
-                    Variants TSV
-                  </cvc-link-tag>
-                </td>
-                <td *ngIf="release.evidenceTsv; else noData">
-                  <cvc-link-tag [href]="release.evidenceTsv.path" iconName="download">
-                    Evidence TSV
-                  </cvc-link-tag>
-                </td>
-                <td *ngIf="release.variantGroupTsv; else noData">
-                  <cvc-link-tag [href]="release.variantGroupTsv.path" iconName="download">
-                    Variant Groups TSV
-                  </cvc-link-tag>
-                </td>
-                <td *ngIf="release.assertionTsv; else noData">
-                  <cvc-link-tag [href]="release.assertionTsv.path" iconName="download">
-                    Assertions TSV
-                  </cvc-link-tag>
-                </td>
-                <td *ngIf="release.acceptedVariantsVcf; else noData">
-                  <cvc-link-tag [href]="release.acceptedVariantsVcf.path" iconName="download">
-                    Accepted Variants VCF
-                  </cvc-link-tag>
-                </td>
-                <td *ngIf="release.acceptedAndSubmittedVariantsVcf; else noData">
-                  <cvc-link-tag [href]="release.acceptedAndSubmittedVariantsVcf.path" iconName="download">
-                    Accepted & Submitted Variants VCF
-                  </cvc-link-tag>
-                </td>
-              </tr>
-              <ng-template #noData>
-                <td nz-typography nzType="secondary">--</td>
-              </ng-template>
-            </tbody>
+            <nz-card nzTitle="Browse All Data Releases">
+              <nz-table #releasesTable
+                nzSize="small"
+                [nzData]="releases$ | ngrxPush"
+                [nzLoading]="loading$ | ngrxPush"
+                [nzFrontPagination]="true"
+                [nzShowPagination]="true"
+                [nzPageSize]="5">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Genes</th>
+                    <th>Variants</th>
+                    <th>Evidence</th>
+                    <th>Variant Groups</th>
+                    <th>Assertions</th>
+                    <th>Accepted Variants VCF</th>
+                    <th>Accepted & Submitted Variants VCF</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let release of releasesTable.data">
+                    <td>{{release.name }}</td>
+                    <td *ngIf="release.geneTsv; else noData">
+                      <cvc-link-tag [href]="release.geneTsv.path"
+                        iconName="download">
+                        Genes TSV
+                      </cvc-link-tag>
+                    </td>
+                    <td *ngIf="release.variantTsv; else noData">
+                      <cvc-link-tag [href]="release.variantTsv.path"
+                        iconName="download">
+                        Variants TSV
+                      </cvc-link-tag>
+                    </td>
+                    <td *ngIf="release.evidenceTsv; else noData">
+                      <cvc-link-tag [href]="release.evidenceTsv.path"
+                        iconName="download">
+                        Evidence TSV
+                      </cvc-link-tag>
+                    </td>
+                    <td *ngIf="release.variantGroupTsv; else noData">
+                      <cvc-link-tag [href]="release.variantGroupTsv.path"
+                        iconName="download">
+                        Variant Groups TSV
+                      </cvc-link-tag>
+                    </td>
+                    <td *ngIf="release.assertionTsv; else noData">
+                      <cvc-link-tag [href]="release.assertionTsv.path"
+                        iconName="download">
+                        Assertions TSV
+                      </cvc-link-tag>
+                    </td>
+                    <td *ngIf="release.acceptedVariantsVcf; else noData">
+                      <cvc-link-tag [href]="release.acceptedVariantsVcf.path"
+                        iconName="download">
+                        Accepted Variants VCF
+                      </cvc-link-tag>
+                    </td>
+                    <td *ngIf="release.acceptedAndSubmittedVariantsVcf; else noData">
+                      <cvc-link-tag [href]="release.acceptedAndSubmittedVariantsVcf.path"
+                        iconName="download">
+                        Accepted & Submitted Variants VCF
+                      </cvc-link-tag>
+                    </td>
+                  </tr>
+                  <ng-template #noData>
+                    <td nz-typography
+                      nzType="secondary">--</td>
+                  </ng-template>
+                </tbody>
 
-            </nz-table>
+              </nz-table>
+            </nz-card>
           </div>
         </nz-col>
       </nz-row>

--- a/client/src/app/views/releases/releases-main/releases-main.component.less
+++ b/client/src/app/views/releases/releases-main/releases-main.component.less
@@ -1,1 +1,2 @@
 @import 'themes/overrides/entity-page-header.overrides.less';
+@import "themes/overrides/card-table.overrides.less";

--- a/client/src/app/views/releases/releases-main/releases-main.module.ts
+++ b/client/src/app/views/releases/releases-main/releases-main.module.ts
@@ -9,18 +9,26 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzTableModule } from 'ng-zorro-antd/table';
 import { CvcLinkTagModule } from '@app/components/shared/link-tag/link-tag.module';
 import { NzAlertModule } from 'ng-zorro-antd/alert';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzCardModule } from 'ng-zorro-antd/card';
 
 @NgModule({
   declarations: [ReleasesMainComponent],
   imports: [
     CommonModule,
     ReactiveComponentModule,
-    NzSpaceModule,
+    NzButtonModule,
     NzPageHeaderModule,
     NzGridModule,
     NzIconModule,
     NzTableModule,
+    NzSpaceModule,
+    NzTypographyModule,
     NzAlertModule,
+    NzCardModule,
+    CvcSectionNavigationModule,
     CvcLinkTagModule,
   ]
 })

--- a/client/src/app/views/sources/sources-home/sources-home.module.ts
+++ b/client/src/app/views/sources/sources-home/sources-home.module.ts
@@ -9,6 +9,8 @@ import { CvcSectionNavigationModule } from '@app/components/shared/section-navig
 import { ReactiveComponentModule } from '@ngrx/component';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { RouterModule } from '@angular/router';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
 
 @NgModule({
   declarations: [SourcesHomePage],
@@ -20,6 +22,8 @@ import { RouterModule } from '@angular/router';
     NzIconModule,
     NzGridModule,
     NzButtonModule,
+    NzTypographyModule,
+    NzSpaceModule,
     CvcSectionNavigationModule,
     CvcSourcesTableModule,
   ],

--- a/client/src/app/views/sources/sources-home/sources-home.page.html
+++ b/client/src/app/views/sources/sources-home/sources-home.page.html
@@ -12,14 +12,50 @@
 </ng-template>
 <nz-page-header class="site-page-header">
 
-  <!--title-->
-  <nz-page-header-title>
-    <i nz-icon
-      nzType="civic:source"></i> Sources
-  </nz-page-header-title>
-
   <!--content-->
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:source"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Associated Sources</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">
+          Each Evidence Item is associated with a Source which supports the Item's clinical claims. CIViC accepts publications known to PubMed or abstracts published through the American Society of Clinical Oncology.
+        </p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical" class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence/source.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Associated Source Docs
+        </a>
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence/source.html#curating-source"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Source Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <div nz-row>
       <div nz-col
         [nzSpan]="24">

--- a/client/src/app/views/sources/sources-home/sources-home.page.html
+++ b/client/src/app/views/sources/sources-home/sources-home.page.html
@@ -23,7 +23,7 @@
       </nz-col>
       <nz-col nzFlex="600px"
         class="header-description">
-        <h2>Associated Sources</h2>
+        <h2>Sources</h2>
         <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">
           Each Evidence Item is associated with a Source which supports the Item's clinical claims. CIViC accepts publications known to PubMed or abstracts published through the American Society of Clinical Oncology.
         </p>
@@ -40,7 +40,7 @@
             <i nz-icon
               nzType="link"
               nzTheme="outline"></i>
-            View Associated Source Docs
+            View Source Docs
         </a>
           <a nz-button
             href="https://civic.readthedocs.io/en/latest/model/evidence/source.html#curating-source"

--- a/client/src/app/views/users/users-home/users-home.module.ts
+++ b/client/src/app/views/users/users-home/users-home.module.ts
@@ -6,6 +6,9 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcUsersTableModule } from '@app/components/users/users-table/users-table.module';
 import { UsersHomePage } from './users-home.page';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
 @NgModule({
   declarations: [UsersHomePage],
@@ -14,6 +17,9 @@ import { CvcSectionNavigationModule } from '@app/components/shared/section-navig
     NzPageHeaderModule,
     NzIconModule,
     NzGridModule,
+    NzButtonModule,
+    NzSpaceModule,
+    NzTypographyModule,
     CvcSectionNavigationModule,
     CvcUsersTableModule,
   ],

--- a/client/src/app/views/users/users-home/users-home.page.html
+++ b/client/src/app/views/users/users-home/users-home.page.html
@@ -1,18 +1,41 @@
 <cvc-section-navigation></cvc-section-navigation>
 <nz-page-header class="site-page-header">
 
-  <!--title-->
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:user"></i>
-    CIViC Users
-  </nz-page-header-title>
-
   <!--content-->
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:user"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Contributors</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">CIViC depends on its users to add to its knowledgebase and curate its content. Anyone may join CIViC as a Curator and begin contributing.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical" class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/using/users.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Contributor Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <div nz-row>
       <div nz-col [nzSpan]="24">
         <div class="content">
-          <cvc-users-table cvcTitle="Browse Contributors"></cvc-users-table>
+          <cvc-users-table cvcTitle="Browse All Contributors"></cvc-users-table>
         </div>
       </div>
     </div>

--- a/client/src/app/views/users/users-routing.module.ts
+++ b/client/src/app/views/users/users-routing.module.ts
@@ -1,12 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-import { UsersAssertionsComponent } from './users-assertions/users-assertions.component';
-import { UsersDetailComponent } from './users-detail/users-detail.component';
-import { UsersEventsComponent } from './users-events/users-events.component';
-import { UsersEvidenceComponent } from './users-evidence/users-evidence.component';
 import { UsersHomePage } from './users-home/users-home.page';
-import { UsersNotificationsComponent } from './users-notifications/users-notifications.component';
-import { UsersSourceSuggestionsComponent } from './users-source-suggestions/users-source-suggestions.component';
 
 import { UsersComponent } from './users.component';
 
@@ -14,6 +8,7 @@ const routes: Routes = [
   {
     path: '',
     component: UsersComponent,
+    data: { displayName: 'Contributors' },
     children: [
       { path: '', redirectTo: 'home', pathMatch: 'full' },
       {

--- a/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.module.ts
+++ b/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.module.ts
@@ -9,6 +9,8 @@ import { CvcSectionNavigationModule } from '@app/components/shared/section-navig
 import { ReactiveComponentModule } from '@ngrx/component';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { RouterModule } from '@angular/router';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
 
 @NgModule({
   declarations: [VariantGroupsHomePage],
@@ -20,7 +22,8 @@ import { RouterModule } from '@angular/router';
     NzGridModule,
     NzPageHeaderModule,
     NzIconModule,
-    NzIconModule,
+    NzTypographyModule,
+    NzSpaceModule,
     CvcVariantGroupsTableModule,
     CvcSectionNavigationModule,
   ],

--- a/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
+++ b/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
@@ -18,18 +18,18 @@
       <nz-col nzFlex="64px"
         class="header-icon">
         <i nz-icon
-          nzType="civic:evidence"></i>
+          nzType="civic:variantgroup"></i>
       </nz-col>
       <nz-col nzFlex="600px"
         class="header-description">
-        <h2>Evidence Items</h2>
-        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.</p>
+        <h2>Variant Groups</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">Variant Groups provide user-defined grouping of Variants within and between genes based on unifying characteristics.</p>
       </nz-col>
       <nz-col nzFlex="auto"
         class="header-links">
         <nz-space nzDirection="vertical" class="docs-buttons">
           <a nz-button
-            href="https://civic.readthedocs.io/en/latest/model/evidence.html"
+            href="https://civic.readthedocs.io/en/latest/model/variant_groups.html"
             target="_blank"
             nzSize="small"
             nzBlock
@@ -37,18 +37,18 @@
             <i nz-icon
               nzType="link"
               nzTheme="outline"></i>
-            View Evidence Model Docs
+            View Variant Group Model Docs
         </a>
-          <a nz-button
-            href="https://civic.readthedocs.io/en/latest/curating/evidence.html"
-            target="_blank"
-            nzSize="small"
-            nzBlock
-            *nzSpaceItem>
+        <a nz-button
+          href="https://civic.readthedocs.io/en/latest/model/variant_groups.html#curating-variant-groups"
+          target="_blank"
+          nzSize="small"
+          nzBlock
+          *nzSpaceItem>
             <i nz-icon
               nzType="link"
               nzTheme="outline"></i>
-            View Evidence Curation Docs
+            View Variant Group Curation Docs
         </a>
         </nz-space>
       </nz-col>

--- a/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
+++ b/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
@@ -11,19 +11,53 @@
   </ng-container>
 </ng-template>
 <nz-page-header class="site-page-header">
-
-  <!--title-->
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:variantgroup"></i>
-    Variant Groups
-  </nz-page-header-title>
-
   <!--content-->
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:evidence"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Evidence Items</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical" class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/evidence.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Evidence Model Docs
+        </a>
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/curating/evidence.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Evidence Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
+    <!-- variant groups table -->
     <div nz-row>
       <div nz-col [nzSpan]="24">
         <div class="content">
-          <cvc-variant-groups-table cvcTitle="Browse Variant Groups"></cvc-variant-groups-table>
+          <cvc-variant-groups-table cvcTitle="Browse All Variant Groups"></cvc-variant-groups-table>
         </div>
       </div>
     </div>

--- a/client/src/app/views/variant-types/variant-types-home/variant-types-home.module.ts
+++ b/client/src/app/views/variant-types/variant-types-home/variant-types-home.module.ts
@@ -6,6 +6,9 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { CvcVariantTypesTableModule } from '@app/components/variant-types/variant-types-table/variant-types-table.module';
 import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
 @NgModule({
   declarations: [VariantTypesHomePage],
@@ -14,6 +17,9 @@ import { CvcSectionNavigationModule } from '@app/components/shared/section-navig
     NzPageHeaderModule,
     NzIconModule,
     NzGridModule,
+    NzButtonModule,
+    NzSpaceModule,
+    NzTypographyModule,
     CvcSectionNavigationModule,
     CvcVariantTypesTableModule,
   ],

--- a/client/src/app/views/variant-types/variant-types-home/variant-types-home.page.html
+++ b/client/src/app/views/variant-types/variant-types-home/variant-types-home.page.html
@@ -1,15 +1,51 @@
 <cvc-section-navigation> </cvc-section-navigation>
 <nz-page-header class="site-page-header">
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:varianttype"></i>
-    Variant Types
-  </nz-page-header-title>
 
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:varianttype"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Variant Types</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">Variant Types are used to classify CIViC variants by Sequence Ontology terms, permitting advanced searching for categories of variants downstream semantic analyses.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical" class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/variants/types.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Variant Type Docs
+        </a>
+        <a nz-button
+          href="https://civic.readthedocs.io/en/latest/model/variants/types.html#curating-variant-types"
+          target="_blank"
+          nzSize="small"
+          nzBlock
+          *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Variant Type Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <div nz-row>
       <div nz-col [nzSpan]="24">
         <div class="content">
-          <cvc-variant-types-table cvcTitle="Browse Variant Types"></cvc-variant-types-table>
+          <cvc-variant-types-table cvcTitle="Browse All Variant Types"></cvc-variant-types-table>
         </div>
       </div>
     </div>

--- a/client/src/app/views/variants/variants-home/variants-home.module.ts
+++ b/client/src/app/views/variants/variants-home/variants-home.module.ts
@@ -7,6 +7,9 @@ import { NzGridModule } from 'ng-zorro-antd/grid';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { CvcVariantsTableModule } from '@app/components/variants/variants-table/variants-table.module';
 import { CvcGeneTagModule } from '@app/components/genes/gene-tag/gene-tag.module';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
 
 @NgModule({
   declarations: [VariantsHomePage],
@@ -15,6 +18,9 @@ import { CvcGeneTagModule } from '@app/components/genes/gene-tag/gene-tag.module
     NzPageHeaderModule,
     NzGridModule,
     NzIconModule,
+    NzTypographyModule,
+    NzButtonModule,
+    NzSpaceModule,
     CvcSectionNavigationModule,
     CvcGeneTagModule,
     CvcVariantsTableModule,

--- a/client/src/app/views/variants/variants-home/variants-home.page.html
+++ b/client/src/app/views/variants/variants-home/variants-home.page.html
@@ -1,18 +1,52 @@
 <cvc-section-navigation> </cvc-section-navigation>
 <nz-page-header class="site-page-header">
 
-  <!--title-->
-  <nz-page-header-title>
-    <i nz-icon nzType="civic:variant"></i>
-    CIViC Variants
-  </nz-page-header-title>
-
   <!--content-->
   <nz-page-header-content>
+    <!-- title, description, docs links -->
+    <nz-row class="header-content">
+      <nz-col nzFlex="64px"
+        class="header-icon">
+        <i nz-icon
+          nzType="civic:variant"></i>
+      </nz-col>
+      <nz-col nzFlex="600px"
+        class="header-description">
+        <h2>Variants</h2>
+        <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">CIViC variants are usually genomic alterations, including single nucleotide variants, insertion/deletion events, copy number alterations, structural variants, and other events that differ from the "normal" genome.</p>
+      </nz-col>
+      <nz-col nzFlex="auto"
+        class="header-links">
+        <nz-space nzDirection="vertical" class="docs-buttons">
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/model/variants.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Variant Model Docs
+        </a>
+          <a nz-button
+            href="https://civic.readthedocs.io/en/latest/curating/variants.html"
+            target="_blank"
+            nzSize="small"
+            nzBlock
+            *nzSpaceItem>
+            <i nz-icon
+              nzType="link"
+              nzTheme="outline"></i>
+            View Variant Curation Docs
+        </a>
+        </nz-space>
+      </nz-col>
+    </nz-row>
     <nz-row>
       <nz-col [nzSpan]="24">
         <div class="content">
-          <cvc-variants-table cvcTitle="Browse Variants"></cvc-variants-table>
+          <cvc-variants-table cvcTitle="Browse All Variants"></cvc-variants-table>
         </div>
       </nz-col>
     </nz-row>

--- a/client/src/themes/overrides/card-table.overrides.less
+++ b/client/src/themes/overrides/card-table.overrides.less
@@ -1,0 +1,8 @@
+:host ::ng-deep {
+  .ant-card-body {
+    // remove card body padding
+    padding: 0;
+    // card title has a -1 bottom margin for some reason, partially occluding nz-description's top border
+    margin-top: 1px;
+  }
+}

--- a/client/src/themes/overrides/entity-page-header.overrides.less
+++ b/client/src/themes/overrides/entity-page-header.overrides.less
@@ -1,4 +1,4 @@
-@import 'themes/global-variables.less';
+@import "themes/global-variables.less";
 
 :host {
   display: block;
@@ -8,6 +8,49 @@
   background-color: white;
 
   border-radius: @border-radius-md;
+  .header-content {
+    background-color: #f0f0f0;
+    border-top-left-radius: @border-radius-md;
+    border-top-right-radius: @border-radius-md;
+    margin-top: -@default-padding-md;
+    margin-left: -@default-padding-md;
+    margin-right: -@default-padding-md;
+    margin-bottom: @default-padding-md;
+    border-bottom: 1px solid #bfbfbf;
+    .header-icon {
+      padding: @default-padding-sm;
+      padding-right: 0;
+      i {
+        width: 100%;
+        ::ng-deep svg {
+          width: 100%;
+          height: 100%;
+        }
+      }
+    }
+    .header-description {
+      padding: @default-padding-sm;
+      // adjust headline and desctiption to fit nicely with
+      // the larger icon
+      h2 {
+        color: #262626;
+        margin: 0;
+        margin-top: -8px;
+        font-weight: 500;
+      }
+      p {
+        color: #262626;
+        margin: -2px 0 0 0;
+        padding: 0;
+        font-size: 95%;
+        line-height: 1.5em;
+      }
+    }
+    .header-links {
+      text-align: right;
+      padding: @default-padding-sm;
+    }
+  }
 
   .card-list {
     nz-card {
@@ -19,11 +62,12 @@
   }
 
   nz-page-header-title.flagged {
-    padding-left: .75em;
+    padding-left: 0.75em;
   }
 
   .ant-page-header-content {
     padding-top: 0;
+    padding-bottom: @default-padding-sm;
   }
 
   .ant-page-header-heading-extra {

--- a/client/src/themes/overrides/entity-page-header.overrides.less
+++ b/client/src/themes/overrides/entity-page-header.overrides.less
@@ -49,6 +49,8 @@
     .header-links {
       text-align: right;
       padding: @default-padding-sm;
+      .docs-buttons {
+      }
     }
   }
 

--- a/client/src/themes/overrides/entity-page-header.overrides.less
+++ b/client/src/themes/overrides/entity-page-header.overrides.less
@@ -12,7 +12,7 @@
     background-color: #f0f0f0;
     border-top-left-radius: @border-radius-md;
     border-top-right-radius: @border-radius-md;
-    margin-top: -@default-padding-md;
+    margin-top: -12px;
     margin-left: -@default-padding-md;
     margin-right: -@default-padding-md;
     margin-bottom: @default-padding-md;

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -887,29 +887,6 @@ ActiveRecord::Schema.define(version: 2022_03_31_153354) do
        JOIN evidence_items ei ON (((v.id = ei.variant_id) AND (ei.deleted = false))))
     GROUP BY v.id;
   SQL
-  create_view "evidence_browse_table_rows", sql_definition: <<-SQL
-      SELECT evidence_items.id,
-      genes.name AS gene_name,
-      variants.name AS variant_name,
-      diseases.name AS disease_name,
-      array_agg(DISTINCT drugs.name ORDER BY drugs.name) AS drug_names,
-      evidence_items.status,
-      evidence_items.description,
-      evidence_items.evidence_direction,
-      evidence_items.evidence_level,
-      evidence_items.rating AS evidence_rating,
-      evidence_items.evidence_type,
-      evidence_items.variant_origin,
-      evidence_items.clinical_significance
-     FROM (((((evidence_items
-       JOIN variants ON ((evidence_items.variant_id = variants.id)))
-       JOIN genes ON ((variants.gene_id = genes.id)))
-       LEFT JOIN diseases ON ((diseases.id = evidence_items.disease_id)))
-       LEFT JOIN drugs_evidence_items ON ((drugs_evidence_items.evidence_item_id = evidence_items.id)))
-       LEFT JOIN drugs ON ((drugs.id = drugs_evidence_items.drug_id)))
-    WHERE ((evidence_items.status)::text <> 'rejected'::text)
-    GROUP BY evidence_items.id, evidence_items.status, evidence_items.description, evidence_items.evidence_direction, evidence_items.evidence_level, evidence_items.rating, evidence_items.evidence_type, evidence_items.variant_origin, evidence_items.clinical_significance, genes.name, variants.name, diseases.name;
-  SQL
   create_view "variant_group_browse_table_rows", materialized: true, sql_definition: <<-SQL
       SELECT variant_groups.id,
       variant_groups.name,


### PR DESCRIPTION
Updated headers include nicer headers w/ larger icon, a short description of its entity/user/artifact, and links to model/curation documentation when available:

*New Assertion home*
<img width="1281" alt="Screen Shot 2022-04-08 at 14 23 50" src="https://user-images.githubusercontent.com/132909/162510504-47125a60-a4aa-45fd-9013-c1e587290138.png">

*New Evidence home*
<img width="1280" alt="Screen Shot 2022-04-08 at 14 24 31" src="https://user-images.githubusercontent.com/132909/162510573-d106c403-532b-4df3-b425-1a99c923920c.png">

*New Curation Queues home*
<img width="1287" alt="Screen Shot 2022-04-08 at 14 24 53" src="https://user-images.githubusercontent.com/132909/162510626-d439ebc0-d8cc-4378-be8f-2e9cfb7214b3.png">

