### PR TITLE
viewer-button Your Profile link extends to entire menu-item area

### DIFF
--- a/client/src/app/components/layout/viewer-button/viewer-button.component.html
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.html
@@ -66,19 +66,20 @@
           nz-button
           nzType="primary"
           nzShape="round"
-          nzSize="small" nzDanger nzBlock>
-          <i nz-icon nzType="exclamation-circle"></i>
-          Please update COI statement
+          nzSize="small"
+          nzDanger
+          nzBlock>
+          <i nz-icon
+            nzType="exclamation-circle"></i> Please update COI statement
         </button>
       </li>
       <li nz-menu-divider
-        *ngIf="viewer.invalidCoi">
-      <li nz-menu-item>
-        <a routerLink="/users/{{viewer.id}}">
-          Your Profile
-        </a>
+        *ngIf="viewer.invalidCoi"></li>
+      <li [routerLink]="['/users', viewer.id]"
+        nz-menu-item>
+        Your Profile
       </li>
-      <li nz-menu-item
+      <li nz-menu-item href="/admin"
         *ngIf="viewer.isAdmin">
         <a href="/admin">
           Admin Console


### PR DESCRIPTION
The `Your Profile` menu item only linked the actual `Your Profile` text, so anywhere else besides the text did nothing. This PR moves the routerLink to the list element so clicking anywhere on the list item will invoke the route change.

Closes #406.