### PR TITLE
Consistent capitalization of "CIViC".

### DIFF
--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -3094,7 +3094,7 @@ type Mutation {
   ): AddDrugPayload
 
   """
-  Add a stub record for an external source that is not yet in CiVIC.
+  Add a stub record for an external source that is not yet in CIViC.
   This is for adding a new Source inline while performing other curation activities
   such as adding new evidence items and is distinct from suggesting a source for curation.
   """

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -14116,7 +14116,7 @@
             },
             {
               "name": "addRemoteCitation",
-              "description": "Add a stub record for an external source that is not yet in CiVIC.\nThis is for adding a new Source inline while performing other curation activities\nsuch as adding new evidence items and is distinct from suggesting a source for curation.\n",
+              "description": "Add a stub record for an external source that is not yet in CIViC.\nThis is for adding a new Source inline while performing other curation activities\nsuch as adding new evidence items and is distinct from suggesting a source for curation.\n",
               "args": [
                 {
                   "name": "input",

--- a/client/src/app/views/pages/pages-help/pages-help.page.html
+++ b/client/src/app/views/pages/pages-help/pages-help.page.html
@@ -56,8 +56,8 @@
                 <nz-card nzType="inner"
                   nzTitle="News and Updates"
                   style="width: 100%">
-                  Please follow our twitter account <a href="https://twitter.com/CIViCdb"
-                    target="_blank">@CIVICdb</a>.
+                  Please follow our Twitter account <a href="https://twitter.com/CIViCdb"
+                    target="_blank">@CIViCdb</a>.
                 </nz-card>
               </nz-col>
               <nz-col [nzSpan]="8">

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -4,7 +4,7 @@ introspection:
   schemaFile: ./client/src/app/generated/server.model.graphql
 
 info:
-  title: CiVIC 2 API Documentation
+  title: CIViC 2 API Documentation
   description: Documentation for the CIViC GraphQL API
   contact:
     name:  The CIViC Development Team

--- a/server/app/graphql/mutations/add_remote_citation.rb
+++ b/server/app/graphql/mutations/add_remote_citation.rb
@@ -1,6 +1,6 @@
 class Mutations::AddRemoteCitation < Mutations::BaseMutation
   description <<~DOC
-    Add a stub record for an external source that is not yet in CiVIC.
+    Add a stub record for an external source that is not yet in CIViC.
     This is for adding a new Source inline while performing other curation activities
     such as adding new evidence items and is distinct from suggesting a source for curation.
   DOC


### PR DESCRIPTION
* Convert instances of `CiVIC` to `CIViC`.
* Bonus capitalization of `Twitter` and revise the `@CIViCdb` handle to match how it appears on Twitter.