### PR TITLE
Remove auto-refresh from full activity feed

### DIFF
--- a/client/src/app/components/events/event-feed/event-feed.component.ts
+++ b/client/src/app/components/events/event-feed/event-feed.component.ts
@@ -66,11 +66,8 @@ export class CvcEventFeedComponent implements OnInit {
       showFilters: this.showFilters
     }
 
-    if(environment.production) {
-      this.queryRef = this.gql.watch(this.initialQueryVars, {pollInterval: 30000});
-    } else {
-      this.queryRef = this.gql.watch(this.initialQueryVars);
-    }
+    this.queryRef = this.gql.watch(this.initialQueryVars);
+
     this.results$ = this.queryRef.valueChanges;
 
     this.pageInfo$ = this.results$.pipe(

--- a/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.html
+++ b/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.html
@@ -1,0 +1,27 @@
+<ng-container *ngIf="this.unfilteredCount$ | ngrxPush as count; else noEvents">
+  <nz-row [nzGutter]="16">
+    <nz-col nzSpan="24">
+      <nz-space nzDirection="vertical" style="width: 100%">
+        <nz-card [nzTitle]="undefined" *nzSpaceItem>
+          <ng-container *ngIf="events$ | ngrxPush as events">
+            <nz-row [nzGutter]="16">
+              <nz-col nzSpan="24" class="timeline">
+                <ng-container *ngIf="events.length; else noEvents">
+                  <cvc-event-timeline [events]="events" [tagDisplay]="tagDisplay"></cvc-event-timeline>
+                </ng-container>
+                <ng-container *ngIf="pageInfo$ | ngrxPush as pageInfo">
+                  <button nz-button nzType="default" nzSize="small" nzBlock
+                    routerLink="/curation/activity">See Full Activity Feed
+                  </button>
+                </ng-container>
+              </nz-col>
+            </nz-row>
+          </ng-container>
+        </nz-card>
+      </nz-space>
+    </nz-col>
+  </nz-row>
+</ng-container>
+<ng-template #noEvents>
+  <nz-empty nzNotFoundImage="simple" nzNotFoundContent="No Events"></nz-empty>
+</ng-template>

--- a/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.less
+++ b/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.less
@@ -1,0 +1,25 @@
+:host {
+  display: block;
+}
+
+.timeline {
+  // timeline's base styles pull it up and left of its container,
+  // this padding adds them back b/c in the event feed card it looks to cramped
+  padding-top: 6px;
+  padding-left: 6px;
+}
+
+#event-filters {
+  // all form items get a right margin which creates an unsightly gap on the right :(
+  // so we remove that here
+  nz-form-item:last-child {
+    margin-right: 0;
+  }
+  // need to specify selector widths or else item names clipped
+  #participant-filter {
+    width: 200px;
+  }
+  #organization-filter {
+    width: 250px;
+  }
+}

--- a/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.ts
+++ b/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.ts
@@ -1,0 +1,76 @@
+import { Component, Input, OnInit } from "@angular/core";
+import {
+  EventAction,
+  EventFeedGQL,
+  EventFeedMode,
+  EventFeedNodeFragment,
+  EventFeedQuery,
+  EventFeedQueryVariables,
+  Maybe,
+  PageInfo,
+} from "@app/generated/civic.apollo";
+import { QueryRef } from "apollo-angular";
+import { ApolloQueryResult } from "@apollo/client/core";
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from "environments/environment";
+
+interface SelectableAction { id: EventAction }
+
+export type EventDisplayOption = "hideSubject" | "hideUser" | "hideOrg" | "displayAll"
+
+@Component({
+  selector: 'cvc-homepage-event-feed',
+  templateUrl: './homepage-event-feed.component.html',
+  styleUrls: ['./homepage-event-feed.component.less'],
+})
+export class CvcHomepageEventFeedComponent implements OnInit {
+  @Input() pageSize = 15
+
+  mode: EventFeedMode = EventFeedMode.Unscoped
+  tagDisplay: EventDisplayOption = "hideOrg"
+  showFilters: boolean = false
+
+  private queryRef!: QueryRef<EventFeedQuery, EventFeedQueryVariables>;
+  private results$!: Observable<ApolloQueryResult<EventFeedQuery>>;
+
+  private initialQueryVars?: EventFeedQueryVariables;
+
+  events$?: Observable<Maybe<EventFeedNodeFragment>[]>;
+  pageInfo$?: Observable<PageInfo>;
+  unfilteredCount$?: Observable<number>
+
+  constructor(private gql: EventFeedGQL) {
+  }
+
+  ngOnInit() {
+    this.initialQueryVars = {
+      first: this.pageSize,
+      mode: this.mode,
+      showFilters: this.showFilters
+    }
+
+    if(environment.production) {
+      this.queryRef = this.gql.watch(this.initialQueryVars, {pollInterval: 30000});
+    } else {
+      this.queryRef = this.gql.watch(this.initialQueryVars);
+    }
+    this.results$ = this.queryRef.valueChanges;
+
+    this.pageInfo$ = this.results$.pipe(
+      map(({ data }) => data.events.pageInfo)
+    )
+
+    this.events$ = this.results$.pipe(
+      map(({ data }) => {
+        return data.events.edges.map(e => e.node)
+      })
+    )
+
+    this.unfilteredCount$ = this.results$.pipe(
+      map(({data}) => {
+        return data.events.unfilteredCount
+      })
+    )
+  }
+}

--- a/client/src/app/components/events/homepage-event-feed/homepage-event-feed.module.ts
+++ b/client/src/app/components/events/homepage-event-feed/homepage-event-feed.module.ts
@@ -1,0 +1,45 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CvcHomepageEventFeedComponent } from './homepage-event-feed.component';
+import { ReactiveComponentModule } from '@ngrx/component';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzFormModule } from 'ng-zorro-antd/form';
+import { FormsModule } from '@angular/forms';
+import { NzSwitchModule } from 'ng-zorro-antd/switch';
+import { NzGridModule } from 'ng-zorro-antd/grid';
+import { NzSelectModule } from 'ng-zorro-antd/select';
+import { CvcEventTimelineModule } from '../event-timeline/event-timeline.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { CvcPipesModule } from '@app/core/pipes/pipes.module';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { CvcParticipantListModule } from '@app/components/shared/participant-list/participant-list.module';
+import { NzAvatarModule } from 'ng-zorro-antd/avatar';
+import { NzEmptyModule } from 'ng-zorro-antd/empty';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  declarations: [CvcHomepageEventFeedComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveComponentModule,
+    RouterModule,
+    NzButtonModule,
+    NzCardModule,
+    NzIconModule,
+    NzFormModule,
+    NzSelectModule,
+    NzSwitchModule,
+    NzGridModule,
+    NzSpaceModule,
+    NzEmptyModule,
+    NzAvatarModule,
+    CvcEventTimelineModule,
+    CvcPipesModule,
+    CvcParticipantListModule,
+    CvcPipesModule
+  ],
+  exports: [CvcHomepageEventFeedComponent]
+})
+export class CvcHomepageEventFeedModule { }

--- a/client/src/app/views/curation/curation-activity/curation-timeline/curation-timeline.page.html
+++ b/client/src/app/views/curation/curation-activity/curation-timeline/curation-timeline.page.html
@@ -1,3 +1,3 @@
 <cvc-event-feed [showFilters]="true"
   [mode]="feedMode"
-  [pageSize]="12"></cvc-event-feed>
+  [pageSize]="17"></cvc-event-feed>

--- a/client/src/app/views/welcome/welcome.component.html
+++ b/client/src/app/views/welcome/welcome.component.html
@@ -101,7 +101,7 @@
         style="min-height: 600px"
         nzSize="small"
         class="home-card">
-        <cvc-event-feed [showFilters]="false" [mode]="feedMode" [pageSize]="12" tagDisplay="hideOrg"></cvc-event-feed>
+        <cvc-homepage-event-feed [pageSize]="12"></cvc-homepage-event-feed>
       </nz-card>
     </nz-col>
   </nz-row>

--- a/client/src/app/views/welcome/welcome.module.ts
+++ b/client/src/app/views/welcome/welcome.module.ts
@@ -17,7 +17,7 @@ import { NzTypographyModule } from 'ng-zorro-antd/typography';
 import { NgxJsonViewerModule } from 'ngx-json-viewer';
 import { ReactiveComponentModule } from '@ngrx/component';
 import { CvcSiteStatsCardModule } from '@app/components/shared/site-stats-card/site-stats-card.module';
-import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed.module';
+import { CvcHomepageEventFeedModule } from '@app/components/events/homepage-event-feed/homepage-event-feed.module';
 
 @NgModule({
   imports: [
@@ -35,7 +35,7 @@ import { CvcEventFeedModule } from '@app/components/events/event-feed/event-feed
     NzTypographyModule,
     WelcomeRoutingModule,
     CvcSiteStatsCardModule,
-    CvcEventFeedModule,
+    CvcHomepageEventFeedModule,
     NgxJsonViewerModule,
   ],
   declarations: [


### PR DESCRIPTION
Closes #448 

This PR introduces a new component for the homepage activity feed which continues to have auto-refresh enabled but instead of a "load more" button it adds a link to the full activity feed.

The full activity feed (and the event feed on user/org profiles) will no longer auto-refresh. Ultimately, we will add a button on these feeds to show when new events are available and to reload the feed manually.