### PR TITLE
null is a valid value for ensembl version

### DIFF
--- a/client/src/app/forms/config/types/ensembl-input/ensembl-input.type.ts
+++ b/client/src/app/forms/config/types/ensembl-input/ensembl-input.type.ts
@@ -26,7 +26,7 @@ export class EnsemblInputType extends FieldType {
 export const ensemblVersionValidator: ValidatorOption = {
   name: 'ensembl-version',
   validation: (c: AbstractControl, f: FormlyFieldConfig): ValidationErrors | null => {
-    if (c.value === undefined) {
+    if (c.value === undefined || c.value === null) {
       return null;
     } else {
       let versionNum = +c.value;


### PR DESCRIPTION
Fixes the issue where the variant revise form was forcing people to select an ensembl version