### PR TITLE
display version and release notes on homepage

### DIFF
--- a/client/src/app/views/welcome/welcome.component.html
+++ b/client/src/app/views/welcome/welcome.component.html
@@ -115,4 +115,13 @@
       </nz-card>
     </nz-col>
   </nz-row>
+  <ng-container *ngIf="this.release$ | async as release">
+    <nz-row *nzSpaceItem nzAlign="middle" nzJustify="center">
+      <div id="release-info" nz-typography>
+        CIViC {{release.name}} ({{release.published_at | date}}) &bull; 
+        <a [href]="release.html_url" target="_blank">Release Notes</a> &bull; 
+        <a href="https://github.com/griffithlab/civic-v2/releases/" target="_blank">History</a>
+      </div>
+    </nz-row>
+  </ng-container>
 </nz-space>

--- a/client/src/app/views/welcome/welcome.component.less
+++ b/client/src/app/views/welcome/welcome.component.less
@@ -38,6 +38,14 @@
   color: white
 }
 
+#release-info {
+  color: white;
+  a {
+    color: white;
+    text-decoration: underline;
+  }
+}
+
 // .space-align-container {
 //   display: flex;
 //   align-item: flex-start;

--- a/client/src/app/views/welcome/welcome.component.ts
+++ b/client/src/app/views/welcome/welcome.component.ts
@@ -1,5 +1,14 @@
+import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
-import { EventFeedMode } from '@app/generated/civic.apollo';
+import { EventFeedMode, Maybe } from '@app/generated/civic.apollo';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+interface GithubRelease {
+  html_url: string
+  name: string
+  published_at: string
+}
 
 @Component({
   selector: 'app-welcome',
@@ -8,13 +17,18 @@ import { EventFeedMode } from '@app/generated/civic.apollo';
 })
 export class WelcomeComponent implements OnInit {
 
+  release$?: Observable<GithubRelease>;
+
   feedMode =  EventFeedMode.Unscoped
 
-  constructor() {
+  constructor(private http: HttpClient) {
   }
 
 
   ngOnInit() {
+    this.release$ = this.http.get<GithubRelease[]>("https://api.github.com/repos/griffithlab/civic-v2/releases?per_page=1").pipe(
+      map((data => data[0]))
+    )
   }
 
 }


### PR DESCRIPTION
We can revisit this later if we want something more detailed or a whole page dedicated to the changelog in the future.

closes #459 

<img width="1680" alt="Screen Shot 2022-04-28 at 11 13 11 AM" src="https://user-images.githubusercontent.com/13370/165797877-3957a625-e91a-4a9d-99bd-2f27491f4ed4.png">

