### PR TITLE
Include suggeston count in source browse table

### DIFF
--- a/client/src/app/components/sources/sources-table/sources-table.component.html
+++ b/client/src/app/components/sources/sources-table/sources-table.component.html
@@ -82,6 +82,16 @@
           <i nz-icon
             nzType="civic:evidence"></i> Count
         </th>
+        <th nzWidth="75px"
+          nzRight
+          nzAlign="right"
+          [nzColumnKey]="sortColumns.SuggestionCount"
+          [nzSortFn]="true"
+          [nzSortDirections]="['descend', 'ascend', null]"
+          nz-tooltip
+          nzTooltipTitle="Suggestion Count">
+          <i nz-icon nzType="civic-queue"></i> Count
+        </th>
       </tr>
       <tr class="filter-row">
         <th nzLeft></th>
@@ -123,6 +133,7 @@
             [onInputChanged]="textInputCallback"></cvc-clearable-input-filter>
         </th>
         <th nzRight></th>
+        <th nzRight></th>
       </tr>
     </thead>
     <tbody>
@@ -157,6 +168,8 @@
           </td>
           <td nzAlign="right"
             nzRight>{{source.evidenceItemCount}}</td>
+          <td nzAlign="right"
+            nzRight>{{source.sourceSuggestionCount}}</td>
         </tr>
       </ng-template>
     </tbody>

--- a/client/src/app/components/sources/sources-table/sources-table.component.html
+++ b/client/src/app/components/sources/sources-table/sources-table.component.html
@@ -90,7 +90,7 @@
           [nzSortDirections]="['descend', 'ascend', null]"
           nz-tooltip
           nzTooltipTitle="Suggestion Count">
-          <i nz-icon nzType="civic-queue"></i> Count
+          <i nz-icon nzType="civic:queue"></i> Count
         </th>
       </tr>
       <tr class="filter-row">

--- a/client/src/app/components/sources/sources-table/sources-table.query.gql
+++ b/client/src/app/components/sources/sources-table/sources-table.query.gql
@@ -49,6 +49,7 @@ fragment BrowseSourceRowFields on BrowseSource {
   authors
   citationId
   evidenceItemCount
+  sourceSuggestionCount
   journal
   name
   publicationYear

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -618,6 +618,7 @@ export type BrowseSource = {
   link: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   publicationYear?: Maybe<Scalars['Int']>;
+  sourceSuggestionCount: Scalars['Int'];
   sourceType: SourceSource;
   sourceUrl: Scalars['String'];
 };
@@ -3521,6 +3522,7 @@ export enum SourcesSortColumns {
   Journal = 'JOURNAL',
   Name = 'NAME',
   SourceType = 'SOURCE_TYPE',
+  SuggestionCount = 'SUGGESTION_COUNT',
   Year = 'YEAR'
 }
 
@@ -5963,7 +5965,7 @@ export type BrowseSourcesQuery = (
 
 export type BrowseSourceRowFieldsFragment = (
   { __typename: 'BrowseSource' }
-  & Pick<BrowseSource, 'id' | 'authors' | 'citationId' | 'evidenceItemCount' | 'journal' | 'name' | 'publicationYear' | 'sourceType' | 'citation' | 'displayType' | 'link'>
+  & Pick<BrowseSource, 'id' | 'authors' | 'citationId' | 'evidenceItemCount' | 'sourceSuggestionCount' | 'journal' | 'name' | 'publicationYear' | 'sourceType' | 'citation' | 'displayType' | 'link'>
 );
 
 export type UserPopoverQueryVariables = Exact<{
@@ -9077,6 +9079,7 @@ export const BrowseSourceRowFieldsFragmentDoc = gql`
   authors
   citationId
   evidenceItemCount
+  sourceSuggestionCount
   journal
   name
   publicationYear

--- a/client/src/app/generated/server.field-policies.ts
+++ b/client/src/app/generated/server.field-policies.ts
@@ -226,7 +226,7 @@ export type BrowsePhenotypeEdgeFieldPolicy = {
 	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
 	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type BrowseSourceKeySpecifier = ('authors' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'evidenceItemCount' | 'id' | 'journal' | 'link' | 'name' | 'publicationYear' | 'sourceType' | 'sourceUrl' | BrowseSourceKeySpecifier)[];
+export type BrowseSourceKeySpecifier = ('authors' | 'citation' | 'citationId' | 'clinicalTrials' | 'displayType' | 'evidenceItemCount' | 'id' | 'journal' | 'link' | 'name' | 'publicationYear' | 'sourceSuggestionCount' | 'sourceType' | 'sourceUrl' | BrowseSourceKeySpecifier)[];
 export type BrowseSourceFieldPolicy = {
 	authors?: FieldPolicy<any> | FieldReadFunction<any>,
 	citation?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -239,6 +239,7 @@ export type BrowseSourceFieldPolicy = {
 	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	publicationYear?: FieldPolicy<any> | FieldReadFunction<any>,
+	sourceSuggestionCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	sourceType?: FieldPolicy<any> | FieldReadFunction<any>,
 	sourceUrl?: FieldPolicy<any> | FieldReadFunction<any>
 };

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -1026,6 +1026,7 @@ type BrowseSource {
   link: String!
   name: String
   publicationYear: Int
+  sourceSuggestionCount: Int!
   sourceType: SourceSource!
   sourceUrl: String!
 }
@@ -5778,6 +5779,7 @@ enum SourcesSortColumns {
   JOURNAL
   NAME
   SOURCE_TYPE
+  SUGGESTION_COUNT
   YEAR
 }
 

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -4477,6 +4477,22 @@
               "deprecationReason": null
             },
             {
+              "name": "sourceSuggestionCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "sourceType",
               "description": null,
               "args": [],
@@ -25726,6 +25742,12 @@
             },
             {
               "name": "EVIDENCE_COUNT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUGGESTION_COUNT",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/server/app/graphql/resolvers/browse_sources.rb
+++ b/server/app/graphql/resolvers/browse_sources.rb
@@ -57,6 +57,8 @@ class Resolvers::BrowseSources < GraphQL::Schema::Resolver
       scope.order("title #{value.direction}")
     when "EVIDENCE_COUNT"
       scope.order("evidence_item_count #{value.direction}")
+    when "SUGGESTION_COUNT"
+      scope.order("source_suggestion_count #{value.direction}")
     end
   end
 end

--- a/server/app/graphql/types/browse_tables/browse_source_type.rb
+++ b/server/app/graphql/types/browse_tables/browse_source_type.rb
@@ -10,6 +10,7 @@ module Types::BrowseTables
     field :journal, String, null: true
     field :name, String, null: true
     field :evidence_item_count, Int, null: false
+    field :source_suggestion_count, Int, null: false
     field :citation, String, null: false
     field :display_type, String, null: false
     field :clinical_trials, [Types::Entities::ClinicalTrialType], null: false

--- a/server/app/graphql/types/browse_tables/sources_sort_columns.rb
+++ b/server/app/graphql/types/browse_tables/sources_sort_columns.rb
@@ -7,5 +7,6 @@ module Types::BrowseTables
     value "JOURNAL"
     value "NAME"
     value "EVIDENCE_COUNT"
+    value "SUGGESTION_COUNT"
   end
 end

--- a/server/app/graphql/types/entities/variant_type.rb
+++ b/server/app/graphql/types/entities/variant_type.rb
@@ -37,6 +37,10 @@ module Types::Entities
       Loaders::AssociationLoader.for(Variant, :evidence_items).load(object)
     end
 
+    def variant_types
+      Loaders::AssociationLoader.for(Variant, :variant_types).load(object)
+    end
+
     def primary_coordinates
       if (object.representative_transcript.blank? && object.chromosome.blank? && object.start.blank? && object.stop.blank?)
         return nil

--- a/server/app/jobs/refresh_materialized_views.rb
+++ b/server/app/jobs/refresh_materialized_views.rb
@@ -1,7 +1,7 @@
 class RefreshMaterializedViews < ApplicationJob
 
   def perform(kwargs)
-    views = kwargs['views']
+    views = kwargs.with_indifferent_access['views']
     to_refresh = if views == 'all'
                    [
                      DiseaseBrowseTableRow,

--- a/server/db/migrate/20220505150407_update_source_browse_table_rows_to_version_4.rb
+++ b/server/db/migrate/20220505150407_update_source_browse_table_rows_to_version_4.rb
@@ -1,0 +1,5 @@
+class UpdateSourceBrowseTableRowsToVersion4 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :source_browse_table_rows, version: 4, revert_to_version: 3, materialized: true
+  end
+end

--- a/server/db/migrate/20220511200531_update_source_browse_table_rows_to_version_5.rb
+++ b/server/db/migrate/20220511200531_update_source_browse_table_rows_to_version_5.rb
@@ -1,0 +1,5 @@
+class UpdateSourceBrowseTableRowsToVersion5 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :source_browse_table_rows, version: 5, revert_to_version: 4, materialized: true
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_05_150407) do
+ActiveRecord::Schema.define(version: 2022_05_11_200531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1043,7 +1043,7 @@ ActiveRecord::Schema.define(version: 2022_05_05_150407) do
       count(DISTINCT source_suggestions.id) AS source_suggestion_count
      FROM ((((sources
        LEFT JOIN authors_sources ON ((sources.id = authors_sources.source_id)))
-       JOIN authors ON ((authors.id = authors_sources.author_id)))
+       LEFT JOIN authors ON ((authors.id = authors_sources.author_id)))
        LEFT JOIN evidence_items ON ((evidence_items.source_id = sources.id)))
        LEFT JOIN source_suggestions ON ((source_suggestions.source_id = sources.id)))
     WHERE (((evidence_items.status)::text <> 'rejected'::text) OR ((source_suggestions.status = 'new'::text) OR (source_suggestions.status IS NULL)))

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_11_143250) do
+ActiveRecord::Schema.define(version: 2022_05_05_150407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1039,13 +1039,16 @@ ActiveRecord::Schema.define(version: 2022_04_11_143250) do
       sources.journal,
       sources.title,
       sources.description,
-      count(DISTINCT evidence_items.id) AS evidence_item_count
-     FROM (((sources
+      count(DISTINCT evidence_items.id) AS evidence_item_count,
+      count(DISTINCT source_suggestions.id) AS source_suggestion_count
+     FROM ((((sources
        LEFT JOIN authors_sources ON ((sources.id = authors_sources.source_id)))
        JOIN authors ON ((authors.id = authors_sources.author_id)))
        LEFT JOIN evidence_items ON ((evidence_items.source_id = sources.id)))
-    WHERE ((evidence_items.status)::text <> 'rejected'::text)
-    GROUP BY sources.id, sources.source_type, sources.publication_year, sources.journal, sources.title;
+       LEFT JOIN source_suggestions ON ((source_suggestions.source_id = sources.id)))
+    WHERE (((evidence_items.status)::text <> 'rejected'::text) OR ((source_suggestions.status = 'new'::text) OR (source_suggestions.status IS NULL)))
+    GROUP BY sources.id, sources.source_type, sources.publication_year, sources.journal, sources.title
+   HAVING ((count(DISTINCT evidence_items.id) > 0) OR (count(DISTINCT evidence_items.id) > 0));
   SQL
   add_index "source_browse_table_rows", ["id"], name: "index_source_browse_table_rows_on_id", unique: true
 

--- a/server/db/views/source_browse_table_rows_v04.sql
+++ b/server/db/views/source_browse_table_rows_v04.sql
@@ -1,0 +1,18 @@
+SELECT sources.id,
+  sources.source_type,
+  sources.citation_id,
+  array_agg(DISTINCT(CONCAT(authors.last_name, ', ', authors.fore_name))) as authors,
+  sources.publication_year,
+  sources.journal,
+  sources.title,
+  sources.description,
+  COUNT(DISTINCT(evidence_items.id)) as evidence_item_count,
+  COUNT(DISTINCT(source_suggestions.id)) as source_suggestion_count
+FROM sources
+LEFT OUTER JOIN authors_sources on sources.id = authors_sources.source_id
+INNER JOIN authors on authors.id = authors_sources.author_id
+LEFT OUTER JOIN evidence_items on evidence_items.source_id = sources.id
+LEFT OUTER JOIN source_suggestions on source_suggestions.source_id = sources.id
+WHERE (evidence_items.status != 'rejected' OR (source_suggestions.status = 'new' OR source_suggestions.status is NULL))
+GROUP BY sources.id, sources.source_type, sources.publication_year, sources.journal, sources.title
+HAVING COUNT(DISTINCT(evidence_items.id)) > 0 OR COUNT(DISTINCT(evidence_items.id)) > 0;

--- a/server/db/views/source_browse_table_rows_v05.sql
+++ b/server/db/views/source_browse_table_rows_v05.sql
@@ -1,0 +1,18 @@
+SELECT sources.id,
+  sources.source_type,
+  sources.citation_id,
+  array_agg(DISTINCT(CONCAT(authors.last_name, ', ', authors.fore_name))) as authors,
+  sources.publication_year,
+  sources.journal,
+  sources.title,
+  sources.description,
+  COUNT(DISTINCT(evidence_items.id)) as evidence_item_count,
+  COUNT(DISTINCT(source_suggestions.id)) as source_suggestion_count
+FROM sources
+LEFT OUTER JOIN authors_sources on sources.id = authors_sources.source_id
+LEFT OUTER JOIN authors on authors.id = authors_sources.author_id
+LEFT OUTER JOIN evidence_items on evidence_items.source_id = sources.id
+LEFT OUTER JOIN source_suggestions on source_suggestions.source_id = sources.id
+WHERE (evidence_items.status != 'rejected' OR (source_suggestions.status = 'new' OR source_suggestions.status is NULL))
+GROUP BY sources.id, sources.source_type, sources.publication_year, sources.journal, sources.title
+HAVING COUNT(DISTINCT(evidence_items.id)) > 0 OR COUNT(DISTINCT(evidence_items.id)) > 0;


### PR DESCRIPTION
The source browse table now includes "open" suggestion count as a column. Furthermore the view returns sources that have at least 1 non-rejected evidence item OR one new source suggestion.