### PR TITLE
cache user stats hash

### DIFF
--- a/server/app/graphql/types/entities/user_type.rb
+++ b/server/app/graphql/types/entities/user_type.rb
@@ -106,5 +106,11 @@ module Types::Entities
     def most_recent_event
       Loaders::AssociationLoader.for(User, :most_recent_event).load(object)
     end
+
+    def stats_hash
+      Rails.cache.fetch("user_stats_#{object.id}", expires_in: 1.hour) do 
+        object.stats_hash
+      end
+    end
   end
 end


### PR DESCRIPTION
This acts as a stopgap to speed up the "contributors" table in the short term. Longer term we'll likely want to make it a materialized view, or incorporate it into the community page somehow.

