### PR TITLE
Improve form clarity when reparenting EIDs

### DIFF
--- a/client/src/app/forms/config/types/variant-input/variant-input.module.ts
+++ b/client/src/app/forms/config/types/variant-input/variant-input.module.ts
@@ -10,6 +10,8 @@ import { CvcFormErrorsAlertModule } from '../../components/form-errors-alert/for
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { CvcPipesModule } from '@app/core/pipes/pipes.module';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
 @NgModule({
   declarations: [VariantInputType],
@@ -21,6 +23,8 @@ import { CvcPipesModule } from '@app/core/pipes/pipes.module';
     NzSelectModule,
     NzButtonModule,
     NzIconModule,
+    NzSpaceModule,
+    NzTypographyModule,
     CvcVariantTagModule,
     CvcFormErrorsAlertModule,
     CvcPipesModule

--- a/client/src/app/forms/config/types/variant-input/variant-input.query.gql
+++ b/client/src/app/forms/config/types/variant-input/variant-input.query.gql
@@ -9,6 +9,7 @@ query VariantTypeahead($name: String!, $geneId: Int) {
 fragment VariantTypeaheadFields on Variant {
   id
   name
+  variantAliases
 }
 
 mutation AddVariant($name: String!, $geneId: Int!) {

--- a/client/src/app/forms/config/types/variant-input/variant-input.type.html
+++ b/client/src/app/forms/config/types/variant-input/variant-input.type.html
@@ -11,7 +11,16 @@
       <nz-option *ngFor="let opt of variants$ | ngrxPush"
         nzCustomContent
         [nzValue]="opt.variant">
-        <span [innerHtml]="opt.label | highlightTypeahead: this.to.searchString"></span>
+        <nz-space>
+          <span *nzSpaceItem [innerHtml]="opt.label | highlightTypeahead: this.to.searchString"></span>
+          <span *nzSpaceItem nz-typography nzType="secondary">
+            ID: {{opt.variant.id}}
+            <span *ngIf="opt.variant.variantAliases.length > 0">
+              - Aliases:&nbsp;
+            </span>
+            <span [innerHtml]="opt.variant.variantAliases.join(', ')  | highlightTypeahead: this.to.searchString"></span>
+          </span>
+        </nz-space>
       </nz-option>
   </nz-select>
   <ng-template #sourceLoader>

--- a/client/src/app/forms/evidence-revise/evidence-revise.form.ts
+++ b/client/src/app/forms/evidence-revise/evidence-revise.form.ts
@@ -28,6 +28,7 @@ import { takeUntil } from 'rxjs/operators';
 import { MutatorWithState } from '@app/core/utilities/mutation-state-wrapper';
 import { NetworkErrorsService } from '@app/core/services/network-errors.service';
 import { EvidenceState } from '@app/forms/config/states/evidence.state';
+import { FormGene } from '../forms.interfaces';
 
 
 interface FormSource {
@@ -118,6 +119,7 @@ interface FormModel {
     evidenceRating: Maybe<number>;
     source: FormSource[];
     variant: FormVariant[];
+    gene: FormGene[];
     variantOrigin: VariantOrigin;
     comment: Maybe<string>,
     organization: Maybe<Organization>
@@ -166,6 +168,14 @@ export class EvidenceReviseForm implements OnInit, AfterViewInit, OnDestroy {
             key: 'id',
             type: 'input',
             hide: true
+          },
+          {
+            key: 'gene',
+            type: 'gene-array',
+            templateOptions: {
+              maxCount: 1,
+              required: true
+            }
           },
           {
             key: 'variant',
@@ -345,6 +355,7 @@ export class EvidenceReviseForm implements OnInit, AfterViewInit, OnDestroy {
     return {
       fields: {
         ...evidence,
+        gene: [evidence.gene],
         variant: [evidence.variant],
         source: [evidence.source], // wrapping an array so multi-field will display source properly until we write a single-source option
         drugs: evidence.drugs.length > 0 ? evidence.drugs : [],

--- a/client/src/app/forms/evidence-revise/evidence-revise.module.ts
+++ b/client/src/app/forms/evidence-revise/evidence-revise.module.ts
@@ -35,6 +35,7 @@ import { CvcVariantArrayTypeModule } from '../config/types/variant-array/variant
 import { CvcFormContainerWrapperModule } from '../config/wrappers/form-container/form-container.module';
 import { CvcCancelButtonModule } from '../config/types/cancel-button/cancel-button.module';
 import { CvcFormFieldWrapperModule } from '../config/wrappers/form-field/form-field.module';
+import { CvcGeneArrayTypeModule } from '../config/types/gene-array/gene-array.module';
 
 @NgModule({
   declarations: [EvidenceReviseForm],
@@ -74,7 +75,8 @@ import { CvcFormFieldWrapperModule } from '../config/wrappers/form-field/form-fi
     CvcVariantArrayTypeModule,
     CvcFormContainerWrapperModule,
     CvcFormFieldWrapperModule,
-    CvcCancelButtonModule
+    CvcCancelButtonModule,
+    CvcGeneArrayTypeModule
   ],
   exports: [EvidenceReviseForm]
 })

--- a/client/src/app/forms/evidence-revise/evidence-revise.query.gql
+++ b/client/src/app/forms/evidence-revise/evidence-revise.query.gql
@@ -6,6 +6,11 @@ query EvidenceItemRevisableFields($evidenceId: Int!) {
 
 fragment RevisableEvidenceFields on EvidenceItem {
   id
+  gene {
+    id
+    name
+    link
+  }
   variant {
     id
     name

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -6758,7 +6758,7 @@ export type VariantTypeaheadQuery = (
 
 export type VariantTypeaheadFieldsFragment = (
   { __typename: 'Variant' }
-  & Pick<Variant, 'id' | 'name'>
+  & Pick<Variant, 'id' | 'name' | 'variantAliases'>
 );
 
 export type AddVariantMutationVariables = Exact<{
@@ -6835,7 +6835,10 @@ export type EvidenceItemRevisableFieldsQuery = (
 export type RevisableEvidenceFieldsFragment = (
   { __typename: 'EvidenceItem' }
   & Pick<EvidenceItem, 'id' | 'variantOrigin' | 'description' | 'clinicalSignificance' | 'drugInteractionType' | 'evidenceDirection' | 'evidenceLevel' | 'evidenceType' | 'evidenceRating'>
-  & { variant: (
+  & { gene: (
+    { __typename: 'Gene' }
+    & Pick<Gene, 'id' | 'name' | 'link'>
+  ), variant: (
     { __typename: 'Variant' }
     & Pick<Variant, 'id' | 'name' | 'link'>
   ), disease?: Maybe<(
@@ -9410,6 +9413,7 @@ export const VariantTypeaheadFieldsFragmentDoc = gql`
     fragment VariantTypeaheadFields on Variant {
   id
   name
+  variantAliases
 }
     `;
 export const AddVariantFieldsFragmentDoc = gql`
@@ -9431,6 +9435,11 @@ export const VariantSelectFieldsFragmentDoc = gql`
 export const RevisableEvidenceFieldsFragmentDoc = gql`
     fragment RevisableEvidenceFields on EvidenceItem {
   id
+  gene {
+    id
+    name
+    link
+  }
   variant {
     id
     name


### PR DESCRIPTION

On the Variant Revise form, the gene will now be explicitly displayed and the variant typeahead will be scoped to the selected gene.

If you wish to move the EID to an entirely different gene, you will need to select that explicitly, then the variant.

Additionally, the variant typeahead will now display the variant's ID as well as any aliases to help ensure the correct variant is selected.

closes #522 