### PR TITLE
filter out civicbot events on homepage/main activity feed

### DIFF
--- a/client/src/app/components/events/event-feed/event-feed.component.ts
+++ b/client/src/app/components/events/event-feed/event-feed.component.ts
@@ -40,6 +40,7 @@ export class CvcEventFeedComponent implements OnInit, OnDestroy {
   @Input() showFilters: boolean = true
   @Input() pageSize = 15
   @Input() pollForNewEvents: boolean = true
+  @Input() includeAutomatedEvents: boolean = true
 
   private queryRef!: QueryRef<EventFeedQuery, EventFeedQueryVariables>;
   private results$!: Observable<ApolloQueryResult<EventFeedQuery>>;
@@ -70,7 +71,8 @@ export class CvcEventFeedComponent implements OnInit, OnDestroy {
       originatingUserId: this.userId,
       first: this.pageSize,
       mode: this.mode,
-      showFilters: this.showFilters
+      showFilters: this.showFilters,
+      includeAutomatedEvents: this.includeAutomatedEvents 
     }
 
     this.queryRef = this.gql.watch(this.initialQueryVars);

--- a/client/src/app/components/events/event-feed/event-feed.gql
+++ b/client/src/app/components/events/event-feed/event-feed.gql
@@ -7,6 +7,7 @@ query EventFeedCount(
     $originatingUserId: Int,
     $organizationId: Int,
     $eventType: EventAction,
+    $includeAutomatedEvents: Boolean,
     $mode: EventFeedMode,
 ) {
     events (
@@ -18,7 +19,8 @@ query EventFeedCount(
         originatingUserId: $originatingUserId,
         organizationId: $organizationId,
         eventType: $eventType,
-        mode: $mode
+        mode: $mode,
+        includeAutomatedEvents: $includeAutomatedEvents
     ) {
         unfilteredCount
     }
@@ -34,7 +36,8 @@ query EventFeed (
     $organizationId: Int,
     $eventType: EventAction,
     $mode: EventFeedMode,
-    $showFilters: Boolean!
+    $includeAutomatedEvents: Boolean = true,
+    $showFilters: Boolean!,
 ){
 events (
     subject: $subject,
@@ -45,6 +48,7 @@ events (
     originatingUserId: $originatingUserId,
     organizationId: $organizationId,
     eventType: $eventType,
+    includeAutomatedEvents: $includeAutomatedEvents
     mode: $mode
 ) { ...eventFeed }
 

--- a/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.ts
+++ b/client/src/app/components/events/homepage-event-feed/homepage-event-feed.component.ts
@@ -47,7 +47,8 @@ export class CvcHomepageEventFeedComponent implements OnInit {
     this.initialQueryVars = {
       first: this.pageSize,
       mode: this.mode,
-      showFilters: this.showFilters
+      showFilters: this.showFilters,
+      includeAutomatedEvents: false
     }
 
     if(environment.production) {

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -2788,6 +2788,7 @@ export type QueryEventsArgs = {
   before?: Maybe<Scalars['String']>;
   eventType?: Maybe<EventAction>;
   first?: Maybe<Scalars['Int']>;
+  includeAutomatedEvents?: Maybe<Scalars['Boolean']>;
   last?: Maybe<Scalars['Int']>;
   mode?: Maybe<EventFeedMode>;
   organizationId?: Maybe<Scalars['Int']>;
@@ -4955,6 +4956,7 @@ export type EventFeedCountQueryVariables = Exact<{
   originatingUserId?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   eventType?: Maybe<EventAction>;
+  includeAutomatedEvents?: Maybe<Scalars['Boolean']>;
   mode?: Maybe<EventFeedMode>;
 }>;
 
@@ -4977,6 +4979,7 @@ export type EventFeedQueryVariables = Exact<{
   organizationId?: Maybe<Scalars['Int']>;
   eventType?: Maybe<EventAction>;
   mode?: Maybe<EventFeedMode>;
+  includeAutomatedEvents?: Maybe<Scalars['Boolean']>;
   showFilters: Scalars['Boolean'];
 }>;
 
@@ -10687,7 +10690,7 @@ export const DrugsBrowseDocument = gql`
     }
   }
 export const EventFeedCountDocument = gql`
-    query EventFeedCount($subject: SubscribableQueryInput, $first: Int, $last: Int, $before: String, $after: String, $originatingUserId: Int, $organizationId: Int, $eventType: EventAction, $mode: EventFeedMode) {
+    query EventFeedCount($subject: SubscribableQueryInput, $first: Int, $last: Int, $before: String, $after: String, $originatingUserId: Int, $organizationId: Int, $eventType: EventAction, $includeAutomatedEvents: Boolean, $mode: EventFeedMode) {
   events(
     subject: $subject
     first: $first
@@ -10698,6 +10701,7 @@ export const EventFeedCountDocument = gql`
     organizationId: $organizationId
     eventType: $eventType
     mode: $mode
+    includeAutomatedEvents: $includeAutomatedEvents
   ) {
     unfilteredCount
   }
@@ -10715,7 +10719,7 @@ export const EventFeedCountDocument = gql`
     }
   }
 export const EventFeedDocument = gql`
-    query EventFeed($subject: SubscribableQueryInput, $first: Int, $last: Int, $before: String, $after: String, $originatingUserId: Int, $organizationId: Int, $eventType: EventAction, $mode: EventFeedMode, $showFilters: Boolean!) {
+    query EventFeed($subject: SubscribableQueryInput, $first: Int, $last: Int, $before: String, $after: String, $originatingUserId: Int, $organizationId: Int, $eventType: EventAction, $mode: EventFeedMode, $includeAutomatedEvents: Boolean = true, $showFilters: Boolean!) {
   events(
     subject: $subject
     first: $first
@@ -10725,6 +10729,7 @@ export const EventFeedDocument = gql`
     originatingUserId: $originatingUserId
     organizationId: $organizationId
     eventType: $eventType
+    includeAutomatedEvents: $includeAutomatedEvents
     mode: $mode
   ) {
     ...eventFeed

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -4377,6 +4377,7 @@ type Query {
     Returns the first _n_ elements from the list.
     """
     first: Int
+    includeAutomatedEvents: Boolean
 
     """
     Returns the last _n_ elements from the list.

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -19750,6 +19750,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "includeAutomatedEvents",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "mode",
                   "description": null,
                   "type": {

--- a/client/src/app/views/curation/curation-activity/curation-timeline/curation-timeline.page.html
+++ b/client/src/app/views/curation/curation-activity/curation-timeline/curation-timeline.page.html
@@ -1,3 +1,3 @@
 <cvc-event-feed [showFilters]="true"
   [mode]="feedMode"
-  [pageSize]="17"></cvc-event-feed>
+  [pageSize]="17" [includeAutomatedEvents]="false"></cvc-event-feed>

--- a/server/app/graphql/resolvers/top_level_events.rb
+++ b/server/app/graphql/resolvers/top_level_events.rb
@@ -42,6 +42,14 @@ class Resolvers::TopLevelEvents < GraphQL::Schema::Resolver
     scope.reorder("events.#{value.column} #{value.direction}")
   end
 
+  option(:include_automated_events, type: Boolean, default_value: true) do |scope, value|
+    if !include_automated_events
+      scope.where.not(originating_user_id: Constants::CIVICBOT_USER_ID)
+    else
+      scope
+    end
+  end
+
   option(:mode, type: EventFeedMode) do |_, _|
     #accesed in connection, yuck
   end

--- a/server/app/models/constants.rb
+++ b/server/app/models/constants.rb
@@ -111,4 +111,6 @@ module Constants
     'VariantGroup' => 'variant-groups',
     'Source' => 'sources',
   }
+
+  CIVICBOT_USER_ID = 385
 end


### PR DESCRIPTION
They will still be shown on the event feeds for individual entities.