### PR TITLE
fix organization select button and its field type

### DIFF
--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
@@ -14,7 +14,7 @@
       <ng-container *ngTemplateOutlet="submitButton"></ng-container>
 
       <button type="button" nz-button [nzType]="buttonType" [nzDanger]="this.nzDanger" class="org-dropdown-btn"
-        [disabled]="disabled"
+        [disabled]="isDisabled$ | ngrxPush"
         nz-dropdown [nzDropdownMenu]="orgMenu">
         <nz-space nzDirection="horizontal" [nzSize]="4">
           <span>for</span>

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.module.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.module.ts
@@ -6,11 +6,13 @@ import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { ReactiveComponentModule } from '@ngrx/component';
 
 @NgModule({
   declarations: [CvcOrgSelectorBtnDirective, CvcOrgSelectorBtnGroupComponent],
   imports: [
     CommonModule,
+    ReactiveComponentModule,
     NzButtonModule,
     NzAvatarModule,
     NzDropDownModule,

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
@@ -5,10 +5,8 @@ import {
   OnDestroy,
   Output
 } from '@angular/core';
-import { Maybe } from '@app/generated/civic.apollo';
-import { from, Observable, merge, Observer, Subject } from 'rxjs';
-import { tag } from 'rxjs-spy/cjs/operators';
-import { map, filter, takeUntil, distinctUntilChanged } from 'rxjs/operators';
+import { from, Observable, Subject } from 'rxjs';
+import { filter, map, takeUntil } from 'rxjs/operators';
 
 export interface ButtonMutation {
   type: 'disabled' | 'classList'
@@ -22,28 +20,17 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
   @Output()
   public domChange = new EventEmitter();
 
-  public disabled!: boolean;
-  private observer: MutationObserver;
   private changes: MutationObserver;
   private mutation$!: Observable<MutationRecord>
   private disabledChange$!: Observable<ButtonMutation>
-  private classChange$!: Observable<ButtonMutation>
 
   private destroy$ = new Subject()
 
   constructor(private el: ElementRef) {
-    this.observer = new MutationObserver(([record]) => {
-      return this.disabled = (record.target as HTMLInputElement).disabled
-    });
-    this.observer.observe(this.el.nativeElement, {
-      attributeFilter: ['disabled', 'class'],
-      childList: false,
-      subtree: false
-    });
-
+    // observe DOM mutations on attributes defined in attributeFilter
+    // TODO: handle classList updates to coordinate nz-button types, styles.
     this.changes = new MutationObserver((mutations: MutationRecord[]) => {
       this.mutation$ = from(mutations)
-        // .pipe(tag('org-selector-btn from(mutations)'))
 
       this.disabledChange$ = this.mutation$
         .pipe(filter(mr => mr.attributeName === 'disabled'),
@@ -52,50 +39,14 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
             return { type: 'disabled', change: t.disabled }
           }));
 
-      merge(this.disabledChange$, this.classChange$)
+      this.disabledChange$
         .pipe(takeUntil(this.destroy$))
         .subscribe((m: ButtonMutation) => {
           this.domChange.emit(m)
         })
-
-      // const isClassChanged = (prev: MutationRecord, current: MutationRecord) => {
-      //   const t1 = prev.target as HTMLInputElement
-      //   const t2 = current.target as HTMLInputElement
-      //   return t1.classList.value === t2.classList.value
-      // }
-
-      // this.classChange$ = this.mutation$
-      //   .pipe(filter(mr => mr.attributeName === 'class'),
-      //     // distinctUntilChanged(isClassChanged),
-      //     map(mr => {
-      //       const t = mr.target as HTMLInputElement
-      //       return { type: 'classList', change: t.classList }
-      //     }));
-
-        // from(mutations)
-      // map((r: MutationRecord) => {
-      //   const attr = r.attributeName
-      //   if (attr === 'class') {
-      //     const t = r.target as HtmlInputElement
-      //     return
-      //   } else { return r }
-      // })
-      // mutations.forEach((record: MutationRecord) => {
-      //   const target = record.target as HTMLInputElement
-      //   const attr = record.attributeName
-      //   let mutation: ButtonMutation = {}
-      //   if (target && attr) {
-      //     if (attr === 'disabled') {
-      //       mutation.disabled = target.disabled
-      //     }
-      //     if (attr === 'class') {
-      //       mutation.classList = target.classList
-      //     }
-      //     this.domChange.emit(mutation)
-      //   }
-      // });
     });
-    this.changes.observe(el.nativeElement, {
+
+    this.changes.observe(this.el.nativeElement, {
       attributeFilter: ['disabled'],
       // attributes: true,
       childList: false,
@@ -105,7 +56,7 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.observer.disconnect();
+    this.changes.disconnect();
     this.destroy$.next()
     this.destroy$.unsubscribe()
   }

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
@@ -1,31 +1,112 @@
 import {
   Directive,
   ElementRef,
-  OnDestroy
+  EventEmitter,
+  OnDestroy,
+  Output
 } from '@angular/core';
+import { Maybe } from '@app/generated/civic.apollo';
+import { from, Observable, merge, Observer, Subject } from 'rxjs';
+import { tag } from 'rxjs-spy/cjs/operators';
+import { map, filter, takeUntil, distinctUntilChanged } from 'rxjs/operators';
+
+export interface ButtonMutation {
+  type: 'disabled' | 'classList'
+  change: boolean | DOMTokenList
+}
 
 @Directive({
   selector: 'button[cvcOrgSelectorBtn]',
-  host: {
-    '[class.ant-btn-dangerous]': `nzDanger`
-  }
 })
 export class CvcOrgSelectorBtnDirective implements OnDestroy {
+  @Output()
+  public domChange = new EventEmitter();
+
   public disabled!: boolean;
   private observer: MutationObserver;
+  private changes: MutationObserver;
+  private mutation$!: Observable<MutationRecord>
+  private disabledChange$!: Observable<ButtonMutation>
+  private classChange$!: Observable<ButtonMutation>
+
+  private destroy$ = new Subject()
 
   constructor(private el: ElementRef) {
     this.observer = new MutationObserver(([record]) => {
       return this.disabled = (record.target as HTMLInputElement).disabled
     });
     this.observer.observe(this.el.nativeElement, {
-      attributeFilter: ['disabled'],
+      attributeFilter: ['disabled', 'class'],
       childList: false,
       subtree: false
     });
+
+    this.changes = new MutationObserver((mutations: MutationRecord[]) => {
+      this.mutation$ = from(mutations)
+        // .pipe(tag('org-selector-btn from(mutations)'))
+
+      this.disabledChange$ = this.mutation$
+        .pipe(filter(mr => mr.attributeName === 'disabled'),
+          map(mr => {
+            const t = mr.target as HTMLInputElement
+            return { type: 'disabled', change: t.disabled }
+          }));
+
+      merge(this.disabledChange$, this.classChange$)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((m: ButtonMutation) => {
+          this.domChange.emit(m)
+        })
+
+      // const isClassChanged = (prev: MutationRecord, current: MutationRecord) => {
+      //   const t1 = prev.target as HTMLInputElement
+      //   const t2 = current.target as HTMLInputElement
+      //   return t1.classList.value === t2.classList.value
+      // }
+
+      // this.classChange$ = this.mutation$
+      //   .pipe(filter(mr => mr.attributeName === 'class'),
+      //     // distinctUntilChanged(isClassChanged),
+      //     map(mr => {
+      //       const t = mr.target as HTMLInputElement
+      //       return { type: 'classList', change: t.classList }
+      //     }));
+
+        // from(mutations)
+      // map((r: MutationRecord) => {
+      //   const attr = r.attributeName
+      //   if (attr === 'class') {
+      //     const t = r.target as HtmlInputElement
+      //     return
+      //   } else { return r }
+      // })
+      // mutations.forEach((record: MutationRecord) => {
+      //   const target = record.target as HTMLInputElement
+      //   const attr = record.attributeName
+      //   let mutation: ButtonMutation = {}
+      //   if (target && attr) {
+      //     if (attr === 'disabled') {
+      //       mutation.disabled = target.disabled
+      //     }
+      //     if (attr === 'class') {
+      //       mutation.classList = target.classList
+      //     }
+      //     this.domChange.emit(mutation)
+      //   }
+      // });
+    });
+    this.changes.observe(el.nativeElement, {
+      attributeFilter: ['disabled'],
+      // attributes: true,
+      childList: false,
+      subtree: false
+    });
+
   }
 
   ngOnDestroy(): void {
     this.observer.disconnect();
+    this.destroy$.next()
+    this.destroy$.unsubscribe()
   }
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,11 +1,27 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { create, CyclePlugin } from 'rxjs-spy';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
+} else {
+  //we enable RXjs Spy on non production bulds only
+  const spy = create();
+  // deactivate CyclePlugin, which spams console w/
+  // an alert about a next cycle in table-scroll.directive.
+  // Re-activate to troubleshoot if a call stack exceeded
+  // error occurs.
+  spy.unplug(spy.find(CyclePlugin) as CyclePlugin);
+  // we call show for two purposes: first is to log to
+  // the console an empty snapshot so we can see that
+  // everything is working as expected, then to suppress
+  // unused variable usage (a convention)
+  spy.show();
+  // log everything, provide tag name to focus log on a single observable
+  spy.log()
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule)


### PR DESCRIPTION
The organizations-select-button component  is used all over the place to append a dropdown to various curation action buttons. It has an issue coordinating the state of its 'for [org icon]' dropdown menu button and the transcluded button after which it is appended:
<img width="252" alt="Screen Shot 2022-05-26 at 12 15 03" src="https://user-images.githubusercontent.com/132909/170540224-d408a1c5-e1a1-42b5-be2b-3b73c23f0096.png">

Additionally, the form field type `org-submit-button` has an issue updating its disabled state based on the current state of the form model, sometimes requiring the user to create a UI event (mouse movement, tabbing out of a text field) to cause the submit button to display as enabled.

This PR:
- fixes disabled state coordination between org-select-btn's appended select button and its embedded button
- forces the the `org-submit-button` field type to perform a view refresh on all validity events from the form. Now it will instantly update whenever the form can be submitted.

Fixes #443 
Fixes #440 