### PR TITLE
diseases-summary page now properly displays evidence & assertions tables

### DIFF
--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -7436,6 +7436,24 @@ export type DiseaseDetailQuery = (
   )> }
 );
 
+export type DiseasesSummaryQueryVariables = Exact<{
+  diseaseId: Scalars['Int'];
+}>;
+
+
+export type DiseasesSummaryQuery = (
+  { __typename: 'Query' }
+  & { disease?: Maybe<(
+    { __typename: 'Disease' }
+    & DiseasesSummaryFieldsFragment
+  )> }
+);
+
+export type DiseasesSummaryFieldsFragment = (
+  { __typename: 'Disease' }
+  & Pick<Disease, 'id' | 'name' | 'doid' | 'diseaseUrl' | 'displayName' | 'diseaseAliases' | 'link'>
+);
+
 export type DrugDetailQueryVariables = Exact<{
   drugId: Scalars['Int'];
 }>;
@@ -9713,6 +9731,17 @@ export const AssertionSummaryFieldsFragmentDoc = gql`
       profileImagePath(size: 32)
     }
   }
+}
+    `;
+export const DiseasesSummaryFieldsFragmentDoc = gql`
+    fragment DiseasesSummaryFields on Disease {
+  id
+  name
+  doid
+  diseaseUrl
+  displayName
+  diseaseAliases
+  link
 }
     `;
 export const DrugsSummaryFieldsFragmentDoc = gql`
@@ -12885,6 +12914,24 @@ export const DiseaseDetailDocument = gql`
   })
   export class DiseaseDetailGQL extends Apollo.Query<DiseaseDetailQuery, DiseaseDetailQueryVariables> {
     document = DiseaseDetailDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const DiseasesSummaryDocument = gql`
+    query DiseasesSummary($diseaseId: Int!) {
+  disease(id: $diseaseId) {
+    ...DiseasesSummaryFields
+  }
+}
+    ${DiseasesSummaryFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class DiseasesSummaryGQL extends Apollo.Query<DiseasesSummaryQuery, DiseasesSummaryQueryVariables> {
+    document = DiseasesSummaryDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);

--- a/client/src/app/views/diseases/diseases-detail/diseases-detail.component.html
+++ b/client/src/app/views/diseases/diseases-detail/diseases-detail.component.html
@@ -13,15 +13,6 @@
     </nz-page-header-extra>
     <nz-page-header-content>
       <div class="content">
-        <nz-descriptions nzSize="small"
-          [nzColumn]="1"
-          nzBordered="true">
-          <nz-descriptions-item *ngIf="disease.diseaseAliases.length > 0"
-            nzTitle="Aliases"
-            nzSpan="2">
-            {{ disease.diseaseAliases.join(", ") }}
-          </nz-descriptions-item>
-        </nz-descriptions>
         <router-outlet></router-outlet>
       </div>
     </nz-page-header-content>

--- a/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.component.html
+++ b/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.component.html
@@ -1,8 +1,33 @@
-<nz-space nzSize="middle" *ngIf="diseaseId" nzDirection="vertical" class="space-align-block">
-
-  <!-- assertions table card -->
-  <cvc-assertions-table [diseaseId]="diseaseId" cvcTitle="Disease Assertions" *nzSpaceItem></cvc-assertions-table>
-
-  <!-- evidence table card -->
-  <cvc-evidence-table [diseaseId]="diseaseId" cvcTitle="Disease Evidence" *nzSpaceItem></cvc-evidence-table>
-</nz-space>
+<div class="summary-container">
+  <ng-container *ngIf="disease$ | ngrxPush as disease">
+    <nz-row [nzGutter]="[8,16]">
+      <nz-col [nzSpan]="24">
+       <!-- disease aliases -->
+        <nz-descriptions nzSize="small"
+          [nzColumn]="2"
+          nzBordered="true">
+          <nz-descriptions-item nzTitle="Aliases">
+            <ng-container *ngIf="disease.diseaseAliases.length > 0; else noAliases">
+              {{ disease.diseaseAliases.join(", ") }}
+            </ng-container>
+            <ng-template #noAliases>
+              <span nz-typography
+                nzType="secondary">None specified.</span>
+            </ng-template>
+          </nz-descriptions-item>
+        </nz-descriptions>
+      </nz-col>
+      <!-- disease evidence table -->
+      <nz-col [nzSpan]="24">
+        <cvc-evidence-table [diseaseId]="diseaseId"
+          cvcHeight="400px"
+          cvcTitle="{{disease.displayName}} Evidence"></cvc-evidence-table>
+      </nz-col>
+      <!-- disease assertions table -->
+      <nz-col [nzSpan]="24">
+        <cvc-assertions-table [diseaseId]="diseaseId"
+          cvcTitle="{{disease.displayName}} Assertions"></cvc-assertions-table>
+      </nz-col>
+    </nz-row>
+  </ng-container>
+</div>

--- a/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.component.ts
+++ b/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { DiseaseDetailGQL, DiseasesSummaryFieldsFragment, DiseasesSummaryQuery, DiseasesSummaryQueryVariables, Maybe } from '@app/generated/civic.apollo';
+import { QueryRef } from 'apollo-angular/query-ref';
+import { Observable, Subscription } from 'rxjs';
+import { pluck, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'cvc-diseases-summary',
@@ -10,10 +13,24 @@ import { Subscription } from 'rxjs';
 export class DiseasesSummaryComponent implements OnDestroy {
   routeSub: Subscription;
   diseaseId?: number;
+  loading$?: Observable<boolean>;
+  queryRef?: QueryRef<DiseasesSummaryQuery, DiseasesSummaryQueryVariables>
+  disease$?: Observable<Maybe<DiseasesSummaryFieldsFragment>>
 
-  constructor(private route: ActivatedRoute) {
+  constructor(private route: ActivatedRoute, private gql: DiseaseDetailGQL) {
     this.routeSub = this.route.params.subscribe((params) => {
       this.diseaseId = +params.diseaseId;
+      this.queryRef = this.gql
+        .watch({ diseaseId: this.diseaseId });
+
+      let observable = this.queryRef.valueChanges
+      this.loading$ = observable
+        .pipe(pluck('loading'),
+          startWith(true));
+
+      this.disease$ = observable
+        .pipe(pluck('data', 'disease'));
+
     })
   }
 

--- a/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.module.ts
+++ b/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.module.ts
@@ -1,15 +1,21 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DiseasesSummaryComponent } from './diseases-summary.component';
-import { NzSpaceModule } from 'ng-zorro-antd/space';
-import { CvcEvidenceTableModule } from '@app/components/evidence/evidence-table/evidence-table.module';
+import { NgModule } from '@angular/core';
 import { CvcAssertionsTableModule } from '@app/components/assertions/assertions-table/assertions-table.module';
+import { CvcEvidenceTableModule } from '@app/components/evidence/evidence-table/evidence-table.module';
+import { ReactiveComponentModule } from '@ngrx/component';
+import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
+import { NzGridModule } from 'ng-zorro-antd/grid';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { DiseasesSummaryComponent } from './diseases-summary.component';
 
 @NgModule({
   declarations: [DiseasesSummaryComponent],
   imports: [
     CommonModule,
-    NzSpaceModule,
+    ReactiveComponentModule,
+    NzGridModule,
+    NzDescriptionsModule,
+    NzTypographyModule,
     CvcEvidenceTableModule,
     CvcAssertionsTableModule,
   ]

--- a/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.query.gql
+++ b/client/src/app/views/diseases/diseases-detail/diseases-summary/diseases-summary.query.gql
@@ -1,0 +1,15 @@
+query DiseasesSummary($diseaseId: Int!) {
+  disease(id: $diseaseId) {
+    ...DiseasesSummaryFields
+  }
+}
+
+fragment DiseasesSummaryFields on Disease {
+  id
+  name
+  doid
+  diseaseUrl
+  displayName
+  diseaseAliases
+  link
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -8,12 +8,11 @@ import { environment } from './environments/environment';
 if (environment.production) {
   enableProdMode();
 } else {
-  //we enable RXjs Spy on non production bulds only
+  // enable RXjs Spy on non production bulds only
   const spy = create();
   // deactivate CyclePlugin, which spams console w/
   // an alert about a next cycle in table-scroll.directive.
-  // Re-activate to troubleshoot if a call stack exceeded
-  // error occurs.
+  // Re-activate to troubleshoot if a 'call stack exceeded' error occurs.
   spy.unplug(spy.find(CyclePlugin) as CyclePlugin);
   // we call show for two purposes: first is to log to
   // the console an empty snapshot so we can see that


### PR DESCRIPTION
Refactored the diseases-detail view and diseases-summary page to properly use the auto-height feature of the recently refactored tables. I'd missed this page during the auto-height table feature refactor.

Closes #540 