### PR TITLE
Fix variant menu behavior

### DIFF
--- a/client/src/app/components/variants/variants-menu/variants-menu.component.html
+++ b/client/src/app/components/variants/variants-menu/variants-menu.component.html
@@ -50,13 +50,17 @@
               nzSize="small"
               id="variant-sort-order"
               name="sortBy"
+              style="width: 115px;"
               [(ngModel)]="sortBy">
               <nz-option nzValue="NAME"
                 nzLabel="Variant Name"
+                style="width: 100%"
                 selected></nz-option>
               <nz-option nzValue="COORDINATE_START"
+                style="width: 100%"
                 nzLabel="Start Position"></nz-option>
               <nz-option nzValue="COORDINATE_END"
+                style="width: 100%"
                 nzLabel="End Position"></nz-option>
             </nz-select>
           </nz-form-control>
@@ -68,15 +72,16 @@
               nzSize="small"
               id="status-filter"
               name="statusFilter"
+              style="width: 320px;"
               [(ngModel)]="statusFilter">
-              <nz-option nzValue="WITH_ACCEPTED"
+              <nz-option nzValue="WITH_ACCEPTED" style="width: 100%"
                 nzLabel="Variants with accepted evidence"></nz-option>
-              <nz-option nzValue="WITH_ACCEPTED_OR_SUBMITTED"
+              <nz-option nzValue="WITH_ACCEPTED_OR_SUBMITTED" style="width: 100%"
                 nzLabel="Variants with accepted and/or submitted evidence"
                 selected></nz-option>
-              <nz-option nzValue="WITH_SUBMITTED"
+              <nz-option nzValue="WITH_SUBMITTED" style="width: 100%"
                 nzLabel="Variants with submitted evidence"></nz-option>
-              <nz-option nzValue="ALL"
+              <nz-option nzValue="ALL" style="width: 100%"
                 nzLabel="All Variants"></nz-option>
             </nz-select>
           </nz-form-control>

--- a/client/src/app/components/variants/variants-menu/variants-menu.component.ts
+++ b/client/src/app/components/variants/variants-menu/variants-menu.component.ts
@@ -87,8 +87,10 @@ export class CvcVariantsMenuComponent implements OnInit {
     this.debouncedQuery.next();
   }
 
-  onVariantStatusFilterChanged(_: VariantDisplayFilter) {
-    this.refresh();
+  onVariantStatusFilterChanged(filter: VariantDisplayFilter) {
+    this.queryRef$.refetch({
+      evidenceStatusFilter: filter
+    })
   }
 
   onVariantSortOrderChanged(col: VariantMenuSortColumns) {


### PR DESCRIPTION
This fixes two issues with the variant menu on Gene pages

 * The `select` widths are now fixed so the menus don't jump around as you pick different options
 * The variant status filter actually fires when you change its value instead of being delayed.

Closes #529 