### PR TITLE
WIP: updated evidence, assertion tag status styles

### DIFF
--- a/client/src/app/components/assertions/assertions-tag/assertion-tag.component.html
+++ b/client/src/app/components/assertions/assertions-tag/assertion-tag.component.html
@@ -5,13 +5,12 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag
+  <nz-tag [ngClass]="{ rejected: assertion.status === 'REJECTED', submitted: assertion.status === 'SUBMITTED', accepted: assertion.status === 'ACCEPTED' }"
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="assertionPopover"
     nzPopoverPlacement="right"
-    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
-    [nzColor]="assertion.status | colorNameForStatus">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
 
@@ -25,5 +24,10 @@
 </ng-template>
 
 <ng-template #tagContent>
-  <i nz-icon nzType="civic-assertion" nzTheme="twotone" nzTwotoneColor="#7243B5"></i> {{ assertion.name }}
+  <i nz-icon
+    nzType="civic-assertion"
+    nzTheme="twotone"
+    [nzTwotoneColor]="assertion.status === 'REJECTED' ? '#BBB' : '#7243B5'">
+  </i>
+  {{ assertion.name }}
 </ng-template>

--- a/client/src/app/components/assertions/assertions-tag/assertion-tag.component.html
+++ b/client/src/app/components/assertions/assertions-tag/assertion-tag.component.html
@@ -5,12 +5,12 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="assertionPopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover"
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
     [nzColor]="assertion.status | colorNameForStatus">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
@@ -18,12 +18,6 @@
   <ng-template #assertionPopover>
     <cvc-assertion-popover [assertionId]="assertion.id"></cvc-assertion-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag [nzColor]="assertion.status | colorNameForStatus">
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>

--- a/client/src/app/components/assertions/assertions-tag/assertion-tag.component.less
+++ b/client/src/app/components/assertions/assertions-tag/assertion-tag.component.less
@@ -1,3 +1,5 @@
+@import 'themes/overrides/entity-tag-overrides.less';
+
 :host {
   display: inline-block;
 }

--- a/client/src/app/components/clinical-trials/clinical-trial-tag/clinical-trial-tag.component.html
+++ b/client/src/app/components/clinical-trials/clinical-trial-tag/clinical-trial-tag.component.html
@@ -5,24 +5,18 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="clinicalTrialPopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
 
   <ng-template #clinicalTrialPopover>
     <cvc-clinical-trial-popover [clinicalTrialId]="clinicalTrial.id"></cvc-clinical-trial-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag>
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>

--- a/client/src/app/components/comments/comment-tag/comment-tag.component.html
+++ b/client/src/app/components/comments/comment-tag/comment-tag.component.html
@@ -3,12 +3,12 @@
 </a>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="commentPopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
 

--- a/client/src/app/components/diseases/cvc-disease-tag/cvc-disease-tag.component.html
+++ b/client/src/app/components/diseases/cvc-disease-tag/cvc-disease-tag.component.html
@@ -5,14 +5,13 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
-    nz-popover
+  <nz-tag nz-popover
     [nzPopoverMouseEnterDelay]="this.onCloseClicked ? 0 : 0.5"
     [nzPopoverContent]="diseasePopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover"
-    [nzMode]="this.onCloseClicked ? 'closeable' : 'default'" (nzOnClose)="itemClosed($event)"
-    >
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
+    [nzMode]="this.onCloseClicked ? 'closeable' : 'default'"
+    (nzOnClose)="itemClosed($event)">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
 
@@ -21,18 +20,15 @@
   </ng-template>
 </ng-template>
 
-<ng-template #noPopover>
-  <nz-tag [nzMode]="this.onCloseClicked ? 'closeable' : 'default'" (nzOnClose)="itemClosed($event)">
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
-</ng-template>
-
 <ng-template #unlinked>
   <ng-template [ngTemplateOutlet]="tag"></ng-template>
 </ng-template>
 
 <ng-template #tagContent>
-  <i nz-icon nzType="civic-disease" nzTheme="twotone" nzTwotoneColor="#E62F76"></i>
+  <i nz-icon
+    nzType="civic-disease"
+    nzTheme="twotone"
+    nzTwotoneColor="#E62F76"></i>
   <ng-container *ngIf="truncateLongName; else fullName">
     {{ disease.name | truncate: 27 }}
   </ng-container>

--- a/client/src/app/components/drugs/cvc-drug-tag/cvc-drug-tag.component.html
+++ b/client/src/app/components/drugs/cvc-drug-tag/cvc-drug-tag.component.html
@@ -5,12 +5,12 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="this.onCloseClicked ? 0 : 0.5"
     [nzPopoverContent]="drugPopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover"
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
     [nzMode]="this.onCloseClicked ? 'closeable' : 'default'" (nzOnClose)="itemClosed($event)">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
@@ -18,12 +18,6 @@
   <ng-template #drugPopover>
     <cvc-drug-popover [drugId]="drug.id"></cvc-drug-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag [nzMode]="this.onCloseClicked ? 'closeable' : 'default'" (nzOnClose)="itemClosed($event)">
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>

--- a/client/src/app/components/evidence/evidence-tag/evidence-tag.component.html
+++ b/client/src/app/components/evidence/evidence-tag/evidence-tag.component.html
@@ -5,24 +5,18 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover" nz-popover
+  <nz-tag
+    nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="evidencePopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover"
-    [nzColor]="evidence.status | colorNameForStatus">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
   <ng-template #evidencePopover>
     <cvc-evidence-popover *ngIf="enablePopover"
       [evidenceId]="evidence.id"></cvc-evidence-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag [nzColor]="evidence.status | colorNameForStatus">
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>

--- a/client/src/app/components/evidence/evidence-tag/evidence-tag.component.html
+++ b/client/src/app/components/evidence/evidence-tag/evidence-tag.component.html
@@ -5,7 +5,7 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag
+  <nz-tag [ngClass]="{ rejected: evidence.status === 'REJECTED', submitted: evidence.status === 'SUBMITTED', accepted: evidence.status === 'ACCEPTED' }"
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="evidencePopover"
@@ -27,5 +27,7 @@
   <i nz-icon
     nzType="civic-evidence"
     nzTheme="twotone"
-    nzTwotoneColor="#F68F37"></i> {{ evidence.name }}
+    [nzTwotoneColor]="evidence.status === 'REJECTED' ? '#BBB' : '#F68F37'">
+  </i>
+  {{ evidence.name }}
 </ng-template>

--- a/client/src/app/components/evidence/evidence-tag/evidence-tag.component.less
+++ b/client/src/app/components/evidence/evidence-tag/evidence-tag.component.less
@@ -1,3 +1,5 @@
+@import 'themes/overrides/entity-tag-overrides.less';
+
 :host {
   display: inline-block;
 }

--- a/client/src/app/components/flags/flag-tag/flag-tag.component.html
+++ b/client/src/app/components/flags/flag-tag/flag-tag.component.html
@@ -3,24 +3,18 @@
 </a>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="flagPopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
 
   <ng-template #flagPopover>
     <cvc-flag-popover [flagId]="flag.id"></cvc-flag-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag>
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #tagContent>

--- a/client/src/app/components/genes/gene-tag/gene-tag.component.html
+++ b/client/src/app/components/genes/gene-tag/gene-tag.component.html
@@ -5,11 +5,11 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="this.onCloseClicked ? 0 : 0.5"
     [nzPopoverContent]="genePopover"
-    nzPopoverTrigger="hover"
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
     [nzMode]="this.onCloseClicked ? 'closeable' : 'default'"
     (nzOnClose)="itemClosed($event)">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
@@ -17,13 +17,6 @@
   <ng-template #genePopover>
     <cvc-gene-popover [geneId]="gene.id"></cvc-gene-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag [nzMode]="this.onCloseClicked ? 'closeable' : 'default'"
-    (nzOnClose)="itemClosed($event)">
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>

--- a/client/src/app/components/organizations/organization-tag/organization-tag.component.html
+++ b/client/src/app/components/organizations/organization-tag/organization-tag.component.html
@@ -5,20 +5,14 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
-    nz-popover
+  <nz-tag nz-popover
     [nzPopoverContent]="orgPopover">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
   <ng-template #orgPopover>
-    <cvc-organization-popover *ngIf="enablePopover" [orgId]="org.id"></cvc-organization-popover>
+    <cvc-organization-popover *ngIf="enablePopover"
+      [orgId]="org.id"></cvc-organization-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag>
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>
@@ -27,5 +21,7 @@
 
 <ng-template #tagContent>
   <i nz-icon
-    nzType="civic-organization" nzTheme="twotone" nzTwotoneColor="#58A0C4"></i> {{ org.name }}
+    nzType="civic-organization"
+    nzTheme="twotone"
+    nzTwotoneColor="#58A0C4"></i> {{ org.name }}
 </ng-template>

--- a/client/src/app/components/phenotypes/phenotype-tag/phenotype-tag.component.html
+++ b/client/src/app/components/phenotypes/phenotype-tag/phenotype-tag.component.html
@@ -5,12 +5,12 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="this.onCloseClicked ? 0 : 0.5"
     [nzPopoverContent]="phenotypePopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover"
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
     [nzMode]="this.onCloseClicked ? 'closeable' : 'default'" (nzOnClose)="itemClosed($event)"
     >
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>

--- a/client/src/app/components/revisions/revision-tag/revision-tag.component.html
+++ b/client/src/app/components/revisions/revision-tag/revision-tag.component.html
@@ -3,24 +3,18 @@
 </a>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="revisionPopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
 
   <ng-template #revisionPopover>
     <cvc-revision-popover [revisionId]="revision.id"></cvc-revision-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag>
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #tagContent>

--- a/client/src/app/components/shared/contributor-stack/contributor-stack.component.html
+++ b/client/src/app/components/shared/contributor-stack/contributor-stack.component.html
@@ -1,15 +1,27 @@
 <ng-container *ngIf="sortedContributors && sortedContributors.length > 0; else noContributors">
-  <a *ngFor="let u of sortedContributors" routerLink="/users/{{u.user.id}}" class="avatar">
-    <nz-avatar [nzSize]="14" nz-popover [nzPopoverMouseEnterDelay]="0.5" [nzPopoverContent]="curatorPopover"
-      nzPopoverTrigger="hover" nzPopoverPlacement="bottomRight" nzIcon="user" [nzSrc]="u.user.profileImagePath"
+  <a *ngFor="let u of sortedContributors"
+    routerLink="/users/{{u.user.id}}"
+    class="avatar">
+    <nz-avatar [nzSize]="14"
+      nz-popover
+      [nzPopoverMouseEnterDelay]="0.5"
+      [nzPopoverContent]="curatorPopover"
+      nzPopoverTrigger="hover"
+      nzPopoverPlacement="bottomRight"
+      nzIcon="user"
+      [nzSrc]="u.user.profileImagePath"
       nzSize="small"></nz-avatar>
     <ng-template #curatorPopover>
       <cvc-user-popover [userId]="u.user.id">
         <ng-template #additionalMetadata>
-          <nz-descriptions nzBordered nzTitle="Activity" nzSize="small" [nzColumn]="1">
+          <nz-descriptions nzBordered
+            nzTitle="Activity"
+            nzSize="small"
+            [nzColumn]="1">
             <nz-descriptions-item nzTitle="Contributions">
               <ng-container *ngFor="let a of u.uniqueActions; last as isLast">
-                {{a.action | eventVerbiage: 'contributor-card' : a.count }}<ng-container *ngIf="! isLast">, </ng-container>
+                {{a.action | eventVerbiage: 'contributor-card' : a.count }}
+                <ng-container *ngIf="! isLast">, </ng-container>
               </ng-container>
             </nz-descriptions-item>
             <nz-descriptions-item nzTitle="Last Contribution">

--- a/client/src/app/components/sources/source-tag/source-tag.component.html
+++ b/client/src/app/components/sources/source-tag/source-tag.component.html
@@ -5,12 +5,11 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
-    nz-popover
+  <nz-tag nz-popover
     [nzPopoverMouseEnterDelay]="this.onCloseClicked ? 0 : 0.5"
     [nzPopoverContent]="sourcePopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover"
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
     [(nzPopoverVisible)]="popoverVisible"
     [nzMode]="this.onCloseClicked ? 'closeable' : 'default'"
     (nzOnClose)="itemClosed($event)">
@@ -20,13 +19,6 @@
   <ng-template #sourcePopover>
     <cvc-source-popover [sourceId]="source.id"></cvc-source-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag [nzMode]="this.onCloseClicked ? 'closeable' : 'default'"
-    (nzOnClose)="itemClosed($event)">
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>
@@ -40,10 +32,10 @@
     nzTwotoneColor="#F9BA45"></i>
   <ng-container *ngIf="this.mode === 'normal'; else concise">
     <ng-container *ngIf="truncateLongName">
-    {{ this.displayName | truncate: 50}}
+      {{ this.displayName | truncate: 50}}
     </ng-container>
     <ng-container *ngIf="!truncateLongName">
-    {{ this.displayName }}
+      {{ this.displayName }}
     </ng-container>
   </ng-container>
   <ng-template #concise>

--- a/client/src/app/components/users/user-tag/user-tag.component.html
+++ b/client/src/app/components/users/user-tag/user-tag.component.html
@@ -5,11 +5,11 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="userPopover"
-    nzPopoverTrigger="hover"
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
     nzPopoverPlacement="topCenter">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>

--- a/client/src/app/components/variant-groups/variant-group-tag/variant-group-tag.component.html
+++ b/client/src/app/components/variant-groups/variant-group-tag/variant-group-tag.component.html
@@ -5,22 +5,16 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="popoverContent"
-    nzPopoverTrigger="hover">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
   <ng-template #popoverContent>
     <cvc-variant-group-popover *ngIf="enablePopover" [variantGroupId]="variantgroup.id"></cvc-variant-group-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag>
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>

--- a/client/src/app/components/variant-types/variant-type-tag/variant-type-tag.component.html
+++ b/client/src/app/components/variant-types/variant-type-tag/variant-type-tag.component.html
@@ -5,12 +5,12 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
+  <nz-tag
     nz-popover
     [nzPopoverMouseEnterDelay]="0.5"
     [nzPopoverContent]="variantTypePopover"
     nzPopoverPlacement="right"
-    nzPopoverTrigger="hover">
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
   </nz-tag>
   <ng-template #variantTypePopover>

--- a/client/src/app/components/variants/variant-tag/variant-tag.component.html
+++ b/client/src/app/components/variants/variant-tag/variant-tag.component.html
@@ -5,11 +5,10 @@
 </ng-container>
 
 <ng-template #tag>
-  <nz-tag *ngIf="enablePopover; else noPopover"
-    nz-popover
+  <nz-tag nz-popover
     [nzPopoverMouseEnterDelay]="this.onCloseClicked ? 0 : 0.5"
     [nzPopoverContent]="popoverContent"
-    nzPopoverTrigger="hover"
+    [nzPopoverTrigger]="enablePopover ? 'hover' : null"
     [nzMode]="this.onCloseClicked ? 'closeable' : 'default'"
     (nzOnClose)="itemClosed($event)">
     <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
@@ -18,13 +17,6 @@
     <cvc-variant-popover *ngIf="enablePopover"
       [variantId]="variant.id"></cvc-variant-popover>
   </ng-template>
-</ng-template>
-
-<ng-template #noPopover>
-  <nz-tag [nzMode]="this.onCloseClicked ? 'closeable' : 'default'"
-    (nzOnClose)="itemClosed($event)">
-    <ng-template [ngTemplateOutlet]="tagContent"></ng-template>
-  </nz-tag>
 </ng-template>
 
 <ng-template #unlinked>

--- a/client/src/themes/global-variables.less
+++ b/client/src/themes/global-variables.less
@@ -16,6 +16,9 @@
 @white: #fff;
 @black: #000;
 
+// Status Colors
+@suggested-color: #fadb14;
+
 // Layout
 @layout-body-background: #f0f2f5;
 @layout-header-background: #001529;
@@ -41,6 +44,7 @@
 @text-color-inverse: @white;
 @icon-color: inherit;
 @icon-color-hover: fade(@black, 75%);
+@tag-default-color: @text-color;
 @heading-color: fade(@black, 85%);
 @text-color-dark: fade(@white, 85%);
 @text-color-secondary-dark: fade(@white, 65%);

--- a/client/src/themes/overrides/entity-tag-overrides.less
+++ b/client/src/themes/overrides/entity-tag-overrides.less
@@ -1,0 +1,15 @@
+@import 'themes/global-variables.less';
+
+:host ::ng-deep nz-tag {
+  &.rejected {
+    border-color: lighten(@border-color-base, 5%);
+    border-right-width: 5px;
+    background-color: #FFF;
+    color: lighten(@tag-default-color, 60%)
+  }
+  &.submitted{
+    border-right-width: 5px;
+    border-color: #ffe58f;
+  }
+  // no style modifications for accepted status
+}


### PR DESCRIPTION
With the updated status styles, accepted entities are display with no style modifications. Non-accepted entities display a widened right-side border, and the following additional style modifications:

Suggested entity border is colored yellow:
<img width="275" alt="Screen Shot 2022-07-12 at 15 36 04" src="https://user-images.githubusercontent.com/132909/178590498-6cfbea88-a309-4830-89ea-c9d381f92934.png">

Rejected entity border is lightened 5% from normal, and both icon and text are lightened and desaturated:
<img width="210" alt="Screen Shot 2022-07-12 at 15 38 22" src="https://user-images.githubusercontent.com/132909/178590814-5a1beccd-b72e-44d5-9693-69e2b81e0437.png">

