### PR TITLE
fixes app header and entity home page header wrapping at narrow window widths

### DIFF
--- a/client/src/app/layout/layout.component.html
+++ b/client/src/app/layout/layout.component.html
@@ -253,7 +253,7 @@
   <nz-layout class="right-layout"
     [ngClass]="{ 'is-collapsed': isCollapsed }">
     <nz-header>
-      <div nz-row>
+      <div nz-row id="header-row">
         <!-- sidebar collapse/show trigger -->
         <div nz-col
           nzFlex="40px">
@@ -263,12 +263,12 @@
           </span>
         </div>
         <div nz-col
-          nzFlex="300px"
+          nzFlex="200px"
           id="header-search">
           <cvc-quicksearch></cvc-quicksearch>
         </div>
         <div nz-col
-          nzFlex="300px"
+          nzFlex="1 0 250px"
           id="header-menu">
           <ul nz-menu
             nzMode="horizontal"
@@ -292,7 +292,7 @@
         </div>
         <!-- header user -->
         <div nz-col
-          nzFlex="auto"
+          nzFlex="1 0 auto"
           id="header-viewer">
           <cvc-login-button *ngIf="signedOut$ | async"></cvc-login-button>
           <cvc-viewer-button *ngIf="signedIn$ | async"></cvc-viewer-button>

--- a/client/src/app/layout/layout.component.less
+++ b/client/src/app/layout/layout.component.less
@@ -110,6 +110,10 @@ nz-sider {
   padding: 1em 1em 1em 0;
 }
 
+#header-row {
+  flex-wrap: nowrap;
+}
+
 #header-menu {
   text-align: right;
   height: @app-header-height;

--- a/client/src/app/views/assertions/assertions-home/assertions-home.page.html
+++ b/client/src/app/views/assertions/assertions-home/assertions-home.page.html
@@ -22,7 +22,7 @@
           [nzTwotoneColor]="'Assertion' | entityColor"
           nzType="civic-assertion"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Assertions</h2>
         <p nz-typography

--- a/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.page.html
+++ b/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.page.html
@@ -11,7 +11,7 @@
           [nzTwotoneColor]="'ClinicalTrial' | entityColor"
           nzType="civic-clinicaltrial"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Clinical Trials</h2>
         <p nz-typography

--- a/client/src/app/views/diseases/diseases-home/diseases-home.page.html
+++ b/client/src/app/views/diseases/diseases-home/diseases-home.page.html
@@ -12,7 +12,7 @@
         [nzTwotoneColor]="'Disease' | entityColor"
         nzType="civic-disease"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Diseases</h2>
         <p nz-typography

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.html
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.html
@@ -20,7 +20,7 @@
           nzType="civic-evidence"
         nzTheme="twotone" [nzTwotoneColor]="'EvidenceItem' | entityColor"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Evidence Items</h2>
         <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.</p>

--- a/client/src/app/views/genes/genes-home/genes-home.page.html
+++ b/client/src/app/views/genes/genes-home/genes-home.page.html
@@ -12,7 +12,7 @@
           [nzTwotoneColor]="'Gene' | entityColor"
           nzType="civic-gene"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Genes</h2>
         <p nz-typography

--- a/client/src/app/views/molecular-profiles/molecular-profiles-home/molecular-profiles-home.page.html
+++ b/client/src/app/views/molecular-profiles/molecular-profiles-home/molecular-profiles-home.page.html
@@ -35,15 +35,13 @@
           [nzTwotoneColor]="'MolecularProfile' | entityColor"
           nzType="civic-molecularprofile"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Molecular Profiles</h2>
         <p nz-typography
           nzEllipsis
           nzExpandable
-          [nzEllipsisRows]="2">
-          CIViC molecular profiles are complex combinations of one or more CIViC variants across one or more genes. Variants are placed in combinations connected by AND or OR, and mutual exclusivity is supported by NOT. These relationships may be further defined by parentheses.
-        </p>
+          [nzEllipsisRows]="2">CIViC molecular profiles are... .</p>
       </nz-col>
       <nz-col nzFlex="auto"
         class="header-links">

--- a/client/src/app/views/sources/sources-home/sources-home.page.html
+++ b/client/src/app/views/sources/sources-home/sources-home.page.html
@@ -23,7 +23,7 @@
           [nzTwotoneColor]="'Source' | entityColor"
           nzType="civic-source"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Sources</h2>
         <p nz-typography

--- a/client/src/app/views/users/users-home/users-home.page.html
+++ b/client/src/app/views/users/users-home/users-home.page.html
@@ -11,7 +11,7 @@
           nzTheme="twotone"
           [nzTwotoneColor]="'Curator' | entityColor"
           nzType="civic-curator"></i> </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Contributors</h2>
         <p nz-typography

--- a/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
+++ b/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
@@ -22,7 +22,7 @@
           [nzTwotoneColor]="'VariantGroup' | entityColor"
           nzType="civic-variantgroup"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Variant Groups</h2>
         <p nz-typography

--- a/client/src/app/views/variant-types/variant-types-home/variant-types-home.page.html
+++ b/client/src/app/views/variant-types/variant-types-home/variant-types-home.page.html
@@ -11,7 +11,7 @@
           [nzTwotoneColor]="'VariantType' | entityColor"
           nzType="civic-varianttype"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Variant Types</h2>
         <p nz-typography

--- a/client/src/app/views/variants/variants-home/variants-home.page.html
+++ b/client/src/app/views/variants/variants-home/variants-home.page.html
@@ -34,7 +34,7 @@
           [nzTwotoneColor]="'Variant' | entityColor"
           nzType="civic-variant"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Variants</h2>
         <p nz-typography

--- a/client/src/themes/overrides/entity-page-header.overrides.less
+++ b/client/src/themes/overrides/entity-page-header.overrides.less
@@ -9,6 +9,7 @@
 
   border-radius: @border-radius-md;
   .header-content {
+    flex-wrap: nowrap;
     background-color: #f0f0f0;
     border-top-left-radius: @border-radius-md;
     border-top-right-radius: @border-radius-md;


### PR DESCRIPTION
The viewer area no longer wraps below the other header components, and the home page headers behave better at narrow window widths.

<img width="757" alt="Screen Shot 2022-07-30 at 15 53 07" src="https://user-images.githubusercontent.com/132909/181995835-7a3f6eb5-61f1-45cd-b62f-451368f4bc4b.png">

Closes #544 
