### PR TITLE
removes entity table title icons, entity icons in col headers switched to monochrome

### DIFF
--- a/client/src/app/components/assertions/assertions-table/assertions-table.component.html
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.component.html
@@ -119,8 +119,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
       </tr>
@@ -374,10 +372,6 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Assertion' | entityColor"
-    nzType="civic-assertion"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.component.html
+++ b/client/src/app/components/clinical-trials/clinical-trials-table/clinical-trials-table.component.html
@@ -62,8 +62,6 @@
           nz-tooltip
           nzTooltipTitle="Source Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Source' | entityColor"
             nzType="civic-source"></i> Count
         </th>
         <th nzWidth="75px"
@@ -75,8 +73,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
       </tr>
@@ -124,10 +120,6 @@
 
 <!-- card's title template -->
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'ClinicalTrial' | entityColor"
-    nzType="civic-clinicaltrial"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/diseases/diseases-table/diseases-table.component.html
+++ b/client/src/app/components/diseases/diseases-table/diseases-table.component.html
@@ -65,8 +65,6 @@
           nz-tooltip
           nzTooltipTitle="Gene Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Gene' | entityColor"
             nzType="civic-gene"></i> Count
         </th>
         <th nzWidth="75px"
@@ -78,8 +76,6 @@
           nz-tooltip
           nzTooltipTitle="Variant Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Variant' | entityColor"
             nzType="civic-variant"></i> Count
         </th>
         <th nzWidth="75px"
@@ -91,8 +87,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
         <th nzWidth="75px"
@@ -103,8 +97,6 @@
           nz-tooltip
           nzTooltipTitle="Assertion Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Assertion' | entityColor"
             nzType="civic-assertion"></i> Count
         </th>
       </tr>
@@ -180,11 +172,6 @@
 
 <!-- card's title template -->
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Disease' | entityColor"
-    nzType="civic-disease"></i>
-
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/drugs/drugs-table/drugs-table.component.html
+++ b/client/src/app/components/drugs/drugs-table/drugs-table.component.html
@@ -61,8 +61,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
         <th nzWidth="75px"
@@ -73,8 +71,6 @@
           nz-tooltip
           nzTooltipTitle="Assertion Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Assertion' | entityColor"
             nzType="civic-assertion"></i> Count
         </th>
       </tr>
@@ -124,10 +120,6 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Intervention' | entityColor"
-    nzType="civic-intervention"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.html
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.html
@@ -382,7 +382,6 @@
                 nzTooltipPlacement="top"
                 [nzTooltipTitle]="!isScrolling ? (eid.drugInteractionType | drugInteractionEnumDisplay) : ''">
                 <i nz-icon
-                  style="color: #ac3996"
                   [nzType]="eid.drugInteractionType | drugInteractionEnumDisplay: 'icon-name'"
                   class="attribute-icon"></i>
               </nz-tag>
@@ -469,10 +468,6 @@
 
 <!-- card's title template -->
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'EvidenceItem' | entityColor"
-    nzType="civic-evidence"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/genes/genes-table/genes-table.component.html
+++ b/client/src/app/components/genes/genes-table/genes-table.component.html
@@ -67,8 +67,6 @@
           nz-tooltip
           nzTooltipTitle="Variant Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Variant' | entityColor"
             nzType="civic-variant"></i> Count
         </th>
         <th nzWidth="75px"
@@ -80,8 +78,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i>
           Count
         </th>
@@ -94,8 +90,6 @@
           nz-tooltip
           nzTooltipTitle="Assertion Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Assertion' | entityColor"
             nzType="civic-assertion"></i> Count
         </th>
       </tr>
@@ -159,10 +153,6 @@
 
 <!-- card's title template -->
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Gene' | entityColor"
-    nzType="civic-gene"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/molecular-profiles/molecular-profile-table/molecular-profile-table.component.html
+++ b/client/src/app/components/molecular-profiles/molecular-profile-table/molecular-profile-table.component.html
@@ -71,8 +71,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
         <th nzWidth="75px"
@@ -84,8 +82,6 @@
           nz-tooltip
           nzTooltipTitle="Assertion Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Assertion' | entityColor"
             nzType="civic-assertion"></i> Count
         </th>
       </tr>
@@ -168,10 +164,6 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'MolecularProfile' | entityColor"
-    nzType="civic-molecularprofile"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/organizations/organizations-table/organizations-table.component.html
+++ b/client/src/app/components/organizations/organizations-table/organizations-table.component.html
@@ -111,10 +111,6 @@
 
 <!-- card's title template -->
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Organization' | entityColor"
-    nzType="civic-organization"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.component.html
+++ b/client/src/app/components/phenotypes/phenotypes-table/phenotypes-table.component.html
@@ -62,8 +62,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
         <th nzWidth="75px"
@@ -75,8 +73,6 @@
           nz-tooltip
           nzTooltipTitle="Assertion Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Assertion' | entityColor"
             nzType="civic-assertion"></i> Count
         </th>
       </tr>
@@ -126,10 +122,6 @@
 
 <!-- card's title template -->
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Phenotype' | entityColor"
-    nzType="civic-phenotype"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/sources/sources-table/sources-table.component.html
+++ b/client/src/app/components/sources/sources-table/sources-table.component.html
@@ -85,8 +85,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
         <th nzWidth="75px"
@@ -98,8 +96,6 @@
           nz-tooltip
           nzTooltipTitle="Suggestion Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Queue' | entityColor"
             nzType="civic-queue"></i> Count
         </th>
       </tr>
@@ -185,10 +181,6 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Source' | entityColor"
-    nzType="civic-source"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/users/users-table/users-table.component.html
+++ b/client/src/app/components/users/users-table/users-table.component.html
@@ -70,8 +70,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
         <th nzWidth="75px"
@@ -80,8 +78,6 @@
           nz-tooltip
           nzTooltipTitle="Revision Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Revision' | entityColor"
             nzType="civic-revision"></i> Count
         </th>
       </tr>
@@ -172,10 +168,6 @@
 
 <!-- card's title template -->
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Curator' | entityColor"
-    nzType="civic-curator"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/variant-groups/variant-groups-table/variant-groups-table.component.html
+++ b/client/src/app/components/variant-groups/variant-groups-table/variant-groups-table.component.html
@@ -63,8 +63,6 @@
           nz-tooltip
           nzTooltipTitle="Variant Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Variant' | entityColor"
             nzType="civic-variant"></i> Count
         </th>
         <th nzWidth="75px"
@@ -76,8 +74,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
       </tr>
@@ -138,11 +134,6 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'VariantGroup' | entityColor"
-    nzType="civic-variantgroup"></i>
-
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/variant-types/variant-types-table/variant-types-table.component.html
+++ b/client/src/app/components/variant-types/variant-types-table/variant-types-table.component.html
@@ -61,8 +61,6 @@
           nz-tooltip
           nzTooltipTitle="Variant Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Variant' | entityColor"
             nzType="civic-variant"></i> Count
         </th>
       </tr>
@@ -108,10 +106,6 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'VariantType' | entityColor"
-    nzType="civic-varianttype"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/components/variants/variants-table/variants-table.component.html
+++ b/client/src/app/components/variants/variants-table/variants-table.component.html
@@ -71,8 +71,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Score">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Score
         </th>
         <th nzWidth="75px"
@@ -84,8 +82,6 @@
           nz-tooltip
           nzTooltipTitle="Evidence Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'EvidenceItem' | entityColor"
             nzType="civic-evidence"></i> Count
         </th>
         <th nzWidth="75px"
@@ -97,8 +93,6 @@
           nz-tooltip
           nzTooltipTitle="Assertion Count">
           <i nz-icon
-            nzTheme="twotone"
-            [nzTwotoneColor]="'Assertion' | entityColor"
             nzType="civic-assertion"></i> Count
         </th>
       </tr>
@@ -171,10 +165,6 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <i nz-icon
-    nzTheme="twotone"
-    [nzTwotoneColor]="'Variant' | entityColor"
-    nzType="civic-variant"></i>
   <ng-container *ngIf="this.cvcTitleTemplate">
     <ng-template [ngTemplateOutlet]="cvcTitleTemplate"></ng-template>
   </ng-container>

--- a/client/src/app/core/utilities/get-entity-color.ts
+++ b/client/src/app/core/utilities/get-entity-color.ts
@@ -30,7 +30,9 @@ export const EntityColors = new Map<string, string>([
   ['Organization', '#3d7b99'],
 
   // entity state colors
-  ['Rejected', '#BBBBBB']
+  ['Rejected', '#BBBBBB'],
+
+  ['Greyscale', '#999999']
 ])
 
 export function getEntityColor(entity: string): string {

--- a/client/src/app/layout/layout.component.html
+++ b/client/src/app/layout/layout.component.html
@@ -253,7 +253,7 @@
   <nz-layout class="right-layout"
     [ngClass]="{ 'is-collapsed': isCollapsed }">
     <nz-header>
-      <div nz-row>
+      <div nz-row id="header-row">
         <!-- sidebar collapse/show trigger -->
         <div nz-col
           nzFlex="40px">
@@ -263,12 +263,12 @@
           </span>
         </div>
         <div nz-col
-          nzFlex="300px"
+          nzFlex="200px"
           id="header-search">
           <cvc-quicksearch></cvc-quicksearch>
         </div>
         <div nz-col
-          nzFlex="300px"
+          nzFlex="1 0 250px"
           id="header-menu">
           <ul nz-menu
             nzMode="horizontal"
@@ -292,7 +292,7 @@
         </div>
         <!-- header user -->
         <div nz-col
-          nzFlex="auto"
+          nzFlex="1 0 auto"
           id="header-viewer">
           <cvc-login-button *ngIf="signedOut$ | async"></cvc-login-button>
           <cvc-viewer-button *ngIf="signedIn$ | async"></cvc-viewer-button>

--- a/client/src/app/layout/layout.component.less
+++ b/client/src/app/layout/layout.component.less
@@ -110,6 +110,10 @@ nz-sider {
   padding: 1em 1em 1em 0;
 }
 
+#header-row {
+  flex-wrap: nowrap;
+}
+
 #header-menu {
   text-align: right;
   height: @app-header-height;

--- a/client/src/app/views/assertions/assertions-home/assertions-home.page.html
+++ b/client/src/app/views/assertions/assertions-home/assertions-home.page.html
@@ -22,7 +22,7 @@
           [nzTwotoneColor]="'Assertion' | entityColor"
           nzType="civic-assertion"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Assertions</h2>
         <p nz-typography

--- a/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.page.html
+++ b/client/src/app/views/clinical-trials/clinical-trials-home/clinical-trials-home.page.html
@@ -11,7 +11,7 @@
           [nzTwotoneColor]="'ClinicalTrial' | entityColor"
           nzType="civic-clinicaltrial"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Clinical Trials</h2>
         <p nz-typography

--- a/client/src/app/views/diseases/diseases-home/diseases-home.page.html
+++ b/client/src/app/views/diseases/diseases-home/diseases-home.page.html
@@ -12,7 +12,7 @@
         [nzTwotoneColor]="'Disease' | entityColor"
         nzType="civic-disease"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Diseases</h2>
         <p nz-typography

--- a/client/src/app/views/evidence/evidence-home/evidence-home.page.html
+++ b/client/src/app/views/evidence/evidence-home/evidence-home.page.html
@@ -20,7 +20,7 @@
           nzType="civic-evidence"
         nzTheme="twotone" [nzTwotoneColor]="'EvidenceItem' | entityColor"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Evidence Items</h2>
         <p nz-typography nzEllipsis nzExpandable [nzEllipsisRows]="2">The clinical evidence statement is a piece of information that has been manually curated from trustable medical literature about a variant or genomic ‘event’ that has implications in cancer predisposition, diagnosis (aka molecular classification), prognosis, or predictive response to therapy.</p>

--- a/client/src/app/views/genes/genes-home/genes-home.page.html
+++ b/client/src/app/views/genes/genes-home/genes-home.page.html
@@ -12,7 +12,7 @@
           [nzTwotoneColor]="'Gene' | entityColor"
           nzType="civic-gene"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Genes</h2>
         <p nz-typography

--- a/client/src/app/views/molecular-profiles/molecular-profiles-home/molecular-profiles-home.page.html
+++ b/client/src/app/views/molecular-profiles/molecular-profiles-home/molecular-profiles-home.page.html
@@ -35,15 +35,13 @@
           [nzTwotoneColor]="'MolecularProfile' | entityColor"
           nzType="civic-molecularprofile"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Molecular Profiles</h2>
         <p nz-typography
           nzEllipsis
           nzExpandable
-          [nzEllipsisRows]="2">
-          CIViC molecular profiles are complex combinations of one or more CIViC variants across one or more genes. Variants are placed in combinations connected by AND or OR, and mutual exclusivity is supported by NOT. These relationships may be further defined by parentheses.
-        </p>
+          [nzEllipsisRows]="2">CIViC molecular profiles are... .</p>
       </nz-col>
       <nz-col nzFlex="auto"
         class="header-links">

--- a/client/src/app/views/sources/sources-home/sources-home.page.html
+++ b/client/src/app/views/sources/sources-home/sources-home.page.html
@@ -23,7 +23,7 @@
           [nzTwotoneColor]="'Source' | entityColor"
           nzType="civic-source"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Sources</h2>
         <p nz-typography

--- a/client/src/app/views/users/users-home/users-home.page.html
+++ b/client/src/app/views/users/users-home/users-home.page.html
@@ -11,7 +11,7 @@
           nzTheme="twotone"
           [nzTwotoneColor]="'Curator' | entityColor"
           nzType="civic-curator"></i> </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Contributors</h2>
         <p nz-typography

--- a/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
+++ b/client/src/app/views/variant-groups/variant-groups-home/variant-groups-home.page.html
@@ -22,7 +22,7 @@
           [nzTwotoneColor]="'VariantGroup' | entityColor"
           nzType="civic-variantgroup"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Variant Groups</h2>
         <p nz-typography

--- a/client/src/app/views/variant-types/variant-types-home/variant-types-home.page.html
+++ b/client/src/app/views/variant-types/variant-types-home/variant-types-home.page.html
@@ -11,7 +11,7 @@
           [nzTwotoneColor]="'VariantType' | entityColor"
           nzType="civic-varianttype"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Variant Types</h2>
         <p nz-typography

--- a/client/src/app/views/variants/variants-home/variants-home.page.html
+++ b/client/src/app/views/variants/variants-home/variants-home.page.html
@@ -34,7 +34,7 @@
           [nzTwotoneColor]="'Variant' | entityColor"
           nzType="civic-variant"></i>
       </nz-col>
-      <nz-col nzFlex="600px"
+      <nz-col nzFlex="0 1 600px"
         class="header-description">
         <h2>Variants</h2>
         <p nz-typography

--- a/client/src/themes/overrides/entity-page-header.overrides.less
+++ b/client/src/themes/overrides/entity-page-header.overrides.less
@@ -9,6 +9,7 @@
 
   border-radius: @border-radius-md;
   .header-content {
+    flex-wrap: nowrap;
     background-color: #f0f0f0;
     border-top-left-radius: @border-radius-md;
     border-top-right-radius: @border-radius-md;


### PR DESCRIPTION
The entity icons in table titles are redundant, because the first column of the table displays tags with the entity icons. 

Switched column header entity icons to monochrome, as color icons should be reserved for placement on elements that represent an actual entity (e.g. tags, cards, summary pages), and not an aggregate of entities.