### PR TITLE
fix org-selector-btn synchronization of class, disabled, hidden

### DIFF
--- a/client/src/app/components/shared/moderate-entity-buttons/moderate-entity-buttons.component.html
+++ b/client/src/app/components/shared/moderate-entity-buttons/moderate-entity-buttons.component.html
@@ -1,16 +1,27 @@
 <div class="center">
   <nz-spin [nzSpinning]="this.isSubmitting">
-    <nz-space nzDirection="horizontal" nzSize="large">
-      <ng-container *ngIf="!this.rejectOnly">
-        <cvc-org-selector-btn-group [(selectedOrg)]="this.mostRecentOrg" *nzSpaceItem>
-          <button cvcOrgSelectorBtn nzType="primary" nzSize="large" nz-button
-            (click)="this.moderate(this.evidenceStatuses.Accepted)">Accept {{ this.entityType }}</button>
-        </cvc-org-selector-btn-group>
-      </ng-container>
-      <cvc-org-selector-btn-group nzDanger nzType="primary" [(selectedOrg)]="this.mostRecentOrg" *nzSpaceItem>
-        <button cvcOrgSelectorBtn nzDanger nzType="primary" nzSize="large" nz-button
-          (click)="this.moderate(this.evidenceStatuses.Rejected)">Reject {{ this.entityType }}</button>
-      </cvc-org-selector-btn-group>
-    </nz-space>
+    <cvc-org-selector-btn-group *ngIf="!this.rejectOnly"
+      [(selectedOrg)]="this.mostRecentOrg">
+      <button cvcOrgSelectorBtn
+        nzType="primary"
+        nzSize="large"
+        nz-button
+        (click)="this.moderate(this.evidenceStatuses.Accepted)">
+        Accept {{ this.entityType }}
+      </button>
+    </cvc-org-selector-btn-group>
+    &nbsp;
+    <cvc-org-selector-btn-group nzDanger
+      nzType="primary"
+      [(selectedOrg)]="this.mostRecentOrg">
+      <button cvcOrgSelectorBtn
+        nzDanger
+        nzType="primary"
+        nzSize="large"
+        nz-button
+        (click)="this.moderate(this.evidenceStatuses.Rejected)">
+        Reject {{ this.entityType }}
+      </button>
+    </cvc-org-selector-btn-group>
   </nz-spin>
 </div>

--- a/client/src/app/forms/complex-molecular-profile-input/complex-molecular-profile-input.form.ts
+++ b/client/src/app/forms/complex-molecular-profile-input/complex-molecular-profile-input.form.ts
@@ -39,7 +39,6 @@ import { SelectedVariant } from '../variant-submit/variant-submit.form';
 import { MutatorWithState } from '@app/core/utilities/mutation-state-wrapper';
 import { NetworkErrorsService } from '@app/core/services/network-errors.service';
 import { LinkableMolecularProfile } from '@app/components/molecular-profiles/molecular-profile-tag/molecular-profile-tag.component';
-import { tag } from 'rxjs-spy/cjs/operators';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { FormMolecularProfile } from '../forms.interfaces';
 
@@ -106,7 +105,6 @@ export class CvcComplexMolecularProfileInputForm implements OnDestroy, OnInit {
       pluck('data', 'previewMolecularProfileName'),
       filter(isNonNulled),
       map((data) => data.segments),
-      tag("preview segment"),
       takeUntil(this.destroy$)
     );
 
@@ -114,7 +112,6 @@ export class CvcComplexMolecularProfileInputForm implements OnDestroy, OnInit {
       pluck('data', 'previewMolecularProfileName'),
       filter(isNonNulled),
       map((data) => data.existingMolecularProfile),
-      tag("exists"),
       takeUntil(this.destroy$)
     );
 

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
@@ -9,7 +9,7 @@
 
   <!-- if multiple organizations, wrap in btn-group w/ selector btn -->
   <ng-container *ngIf="organizations.length > 1">
-    <nz-button-group [nzSize]="nzSize">
+    <nz-button-group>
 
       <ng-container *ngTemplateOutlet="submitButton"></ng-container>
 

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
@@ -13,7 +13,8 @@
 
       <ng-container *ngTemplateOutlet="submitButton"></ng-container>
 
-      <button type="button" nz-button [nzType]="buttonType" [nzDanger]="this.nzDanger" class="org-dropdown-btn"
+      <button type="button" nz-button
+        [ngClass]="buttonClass$ | ngrxPush"
         [disabled]="isDisabled$ | ngrxPush"
         nz-dropdown [nzDropdownMenu]="orgMenu">
         <nz-space nzDirection="horizontal" [nzSize]="4">

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
@@ -15,6 +15,7 @@
 
       <button type="button" nz-button
         [ngClass]="buttonClass$ | ngrxPush"
+        [hidden]="isHidden$ | ngrxPush"
         [disabled]="isDisabled$ | ngrxPush"
         nz-dropdown [nzDropdownMenu]="orgMenu">
         <nz-space nzDirection="horizontal" [nzSize]="4">

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.html
@@ -18,12 +18,10 @@
         [hidden]="isHidden$ | ngrxPush"
         [disabled]="isDisabled$ | ngrxPush"
         nz-dropdown [nzDropdownMenu]="orgMenu">
-        <nz-space nzDirection="horizontal" [nzSize]="4">
-          <span>for</span>
-          <nz-avatar [nzSrc]="selectedOrg?.profileImagePath" [nzSize]="10"
-            [nzShape]="'square'"></nz-avatar>
-          <i nz-icon nzType="down"></i>
-        </nz-space>
+        <span>for</span>
+        <nz-avatar [nzSrc]="selectedOrg?.profileImagePath" [nzSize]="10"
+          [nzShape]="'square'"></nz-avatar>
+        <i nz-icon nzType="down"></i>
       </button>
     </nz-button-group>
   </ng-container>

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.less
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.less
@@ -1,9 +1,20 @@
 :host {
   display: inline-block;
+  ::ng-deep .ant-btn-dangerous.ant-btn-primary:first-child:not(:last-child) {
+    border-right-color: #ff4d4f;
+  }
+  ::ng-deep .ant-btn-dangerous.ant-btn-primary:hover,
+  ::ng-deep .ant-btn-dangerous.ant-btn-primary:focus {
+    border-right-color: #fd7978;
+  }
 }
 
 .org-dropdown-btn {
   nz-avatar {
     margin: 0 6px;
+  }
+  &.ant-btn-dangerous:last-child:not(:first-child),
+  .ant-btn-dangerous + .ant-btn-dangerous {
+    border-left-color: #fd7978;
   }
 }

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.less
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.less
@@ -1,5 +1,6 @@
 :host {
   display: inline-block;
+  // fixes the right border on the first button
   ::ng-deep .ant-btn-dangerous.ant-btn-primary:first-child:not(:last-child) {
     border-right-color: #ff4d4f;
   }
@@ -13,6 +14,7 @@
   nz-avatar {
     margin: 0 6px;
   }
+  // fixes the left border on the last button
   &.ant-btn-dangerous:last-child:not(:first-child),
   .ant-btn-dangerous + .ant-btn-dangerous {
     border-left-color: #fd7978;

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -18,10 +18,6 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
   @Input() selectedOrg!: Maybe<Organization>;
   @Output() selectedOrgChange = new EventEmitter<Organization>();
 
-  @Input() buttonType: NzButtonType = 'primary';
-  @Input() nzDanger: BooleanInput = false;
-  @Input() nzSize: 'large' | 'default' | 'small' = 'small';
-
   @ContentChild(CvcOrgSelectorBtnDirective, { static: false }) button?: CvcOrgSelectorBtnDirective
 
   organizations$!: Observable<Organization[]>;
@@ -30,6 +26,7 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
   isDisabled$: Subject<boolean>
   isHidden$: Subject<boolean>
   buttonClass$: BehaviorSubject<string>
+  baseButtonClass = 'org-dropdown-btn'
   constructor(private viewerService: ViewerService) {
     this.isDisabled$ = new Subject<boolean>()
     this.isHidden$ = new Subject<boolean>()
@@ -72,8 +69,8 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
         this.button.domChange
           .pipe(untilDestroyed(this))
           .subscribe((m: ButtonMutation) => {
-            if(m.type === 'class' && typeof m.change === 'string') {
-              this.buttonClass$.next(m.change)
+            if (m.type === 'class' && typeof m.change === 'string') {
+              this.buttonClass$.next(`${this.baseButtonClass} ${m.change}`)
             } else if (m.type === 'disabled' && typeof m.change === 'boolean') {
               this.isDisabled$.next(m.change)
             } else if (m.type === 'hidden' && typeof m.change === 'boolean') {

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -2,8 +2,6 @@ import { AfterViewInit, Component, ContentChild, EventEmitter, Input, OnInit, Ou
 import { Viewer, ViewerService } from '@app/core/services/viewer/viewer.service';
 import { Maybe, Organization } from '@app/generated/civic.apollo';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { NzButtonType } from 'ng-zorro-antd/button';
-import { BooleanInput } from 'ng-zorro-antd/core/types';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { map, pluck, tap } from 'rxjs/operators';
 import { ButtonMutation, CvcOrgSelectorBtnDirective } from './org-selector-btn.directive';

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -4,7 +4,7 @@ import { Maybe, Organization } from '@app/generated/civic.apollo';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { NzButtonType } from 'ng-zorro-antd/button';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
-import { Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { map, pluck, tap } from 'rxjs/operators';
 import { ButtonMutation, CvcOrgSelectorBtnDirective } from './org-selector-btn.directive';
 
@@ -28,9 +28,10 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
   mostRecentOrg$!: Observable<Maybe<Organization>>;
 
   isDisabled$: Subject<boolean>
-
+  buttonClass$: BehaviorSubject<string>
   constructor(private viewerService: ViewerService) {
     this.isDisabled$ = new Subject<boolean>()
+    this.buttonClass$ = new BehaviorSubject<string>('org-selector-btn')
     // this.isDisabled$.asObservable()
     // .pipe(tag('org-selector-btn-group isDisabled$')).subscribe();
   }
@@ -64,14 +65,19 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
     // subscribe to org-selector-btn.directive's domChange @Output,
     // emit mutation events from the appropriate Subjects
     // TODO: handle classList mutations
-    if (this.button && this.button.domChange) {
-      this.button.domChange
-        .pipe(untilDestroyed(this))
-        .subscribe((m: ButtonMutation) => {
-          if (m.type === 'disabled' && typeof m.change === 'boolean') {
-            this.isDisabled$.next(m.change)
-          }
-        });
+    if (this.button) {
+      if (this.button.domChange) {
+        this.button.domChange
+          .pipe(untilDestroyed(this))
+          .subscribe((m: ButtonMutation) => {
+            if (m.type === 'disabled' && typeof m.change === 'boolean') {
+              this.isDisabled$.next(m.change)
+            }
+            if(m.type === 'class') {
+              this.buttonClass$.next(m.change)
+            }
+          });
+      }
     }
   }
 

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -1,23 +1,20 @@
-import {
-  AfterViewInit, Component, ContentChild, EventEmitter, Input, OnDestroy,
-  OnInit, Output
-} from '@angular/core';
+import { AfterViewInit, Component, ContentChild, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Viewer, ViewerService } from '@app/core/services/viewer/viewer.service';
 import { Maybe, Organization } from '@app/generated/civic.apollo';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { NzButtonType } from 'ng-zorro-antd/button';
 import { BooleanInput } from 'ng-zorro-antd/core/types';
-import {
-  Observable, Subject
-} from 'rxjs';
-import { map, pluck, takeUntil, tap } from 'rxjs/operators';
+import { Observable, Subject } from 'rxjs';
+import { map, pluck, tap } from 'rxjs/operators';
 import { ButtonMutation, CvcOrgSelectorBtnDirective } from './org-selector-btn.directive';
 
+@UntilDestroy()
 @Component({
   selector: 'cvc-org-selector-btn-group',
   templateUrl: './org-selector-btn-group.component.html',
   styleUrls: ['./org-selector-btn-group.component.less']
 })
-export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit, OnDestroy {
+export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
   @Input() selectedOrg!: Maybe<Organization>;
   @Output() selectedOrgChange = new EventEmitter<Organization>();
 
@@ -31,8 +28,6 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit, O
   mostRecentOrg$!: Observable<Maybe<Organization>>;
 
   isDisabled$: Subject<boolean>
-
-  private destroy$ = new Subject()
 
   constructor(private viewerService: ViewerService) {
     this.isDisabled$ = new Subject<boolean>()
@@ -62,7 +57,7 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit, O
           }
         }));
 
-    this.mostRecentOrg$.pipe(takeUntil(this.destroy$)).subscribe();
+    this.mostRecentOrg$.pipe(untilDestroyed(this)).subscribe();
   }
 
   ngAfterViewInit() {
@@ -71,7 +66,7 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit, O
     // TODO: handle classList mutations
     if (this.button && this.button.domChange) {
       this.button.domChange
-        .pipe(takeUntil(this.destroy$))
+        .pipe(untilDestroyed(this))
         .subscribe((m: ButtonMutation) => {
           if (m.type === 'disabled' && typeof m.change === 'boolean') {
             this.isDisabled$.next(m.change)
@@ -80,8 +75,4 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit, O
     }
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.unsubscribe();
-  }
 }

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -28,10 +28,12 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
   mostRecentOrg$!: Observable<Maybe<Organization>>;
 
   isDisabled$: Subject<boolean>
+  isHidden$: Subject<boolean>
   buttonClass$: BehaviorSubject<string>
   constructor(private viewerService: ViewerService) {
     this.isDisabled$ = new Subject<boolean>()
-    this.buttonClass$ = new BehaviorSubject<string>('org-selector-btn')
+    this.isHidden$ = new Subject<boolean>()
+    this.buttonClass$ = new BehaviorSubject<string>('')
     // this.isDisabled$.asObservable()
     // .pipe(tag('org-selector-btn-group isDisabled$')).subscribe();
   }
@@ -70,11 +72,12 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
         this.button.domChange
           .pipe(untilDestroyed(this))
           .subscribe((m: ButtonMutation) => {
-            if (m.type === 'disabled' && typeof m.change === 'boolean') {
-              this.isDisabled$.next(m.change)
-            }
-            if(m.type === 'class') {
+            if(m.type === 'class' && typeof m.change === 'string') {
               this.buttonClass$.next(m.change)
+            } else if (m.type === 'disabled' && typeof m.change === 'boolean') {
+              this.isDisabled$.next(m.change)
+            } else if (m.type === 'hidden' && typeof m.change === 'boolean') {
+              this.isHidden$.next(m.change)
             }
           });
       }

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -31,8 +31,6 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
     this.isDisabled$ = new Subject<boolean>()
     this.isHidden$ = new Subject<boolean>()
     this.buttonClass$ = new BehaviorSubject<string>('')
-    // this.isDisabled$.asObservable()
-    // .pipe(tag('org-selector-btn-group isDisabled$')).subscribe();
   }
 
   selectOrg(org: any): void {
@@ -63,7 +61,6 @@ export class CvcOrgSelectorBtnGroupComponent implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     // subscribe to org-selector-btn.directive's domChange @Output,
     // emit mutation events from the appropriate Subjects
-    // TODO: handle classList mutations
     if (this.button) {
       if (this.button.domChange) {
         this.button.domChange

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.module.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn-group.module.ts
@@ -5,7 +5,6 @@ import { CvcOrgSelectorBtnDirective } from './org-selector-btn.directive';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
 import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
-import { NzSpaceModule } from 'ng-zorro-antd/space';
 import { ReactiveComponentModule } from '@ngrx/component';
 
 @NgModule({
@@ -16,7 +15,6 @@ import { ReactiveComponentModule } from '@ngrx/component';
     NzButtonModule,
     NzAvatarModule,
     NzDropDownModule,
-    NzSpaceModule,
   ],
   exports: [CvcOrgSelectorBtnDirective, CvcOrgSelectorBtnGroupComponent]
 })

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
@@ -1,18 +1,13 @@
-import {
-  Directive,
-  ElementRef,
-  EventEmitter,
-  OnDestroy,
-  Output
-} from '@angular/core';
-import { from, Observable, Subject } from 'rxjs';
-import { filter, map, takeUntil } from 'rxjs/operators';
+import { Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { from, Observable } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 
 export interface ButtonMutation {
   type: 'disabled' | 'classList'
   change: boolean | DOMTokenList
 }
-
+@UntilDestroy()
 @Directive({
   selector: 'button[cvcOrgSelectorBtn]',
 })
@@ -23,8 +18,6 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
   private changes: MutationObserver;
   private mutation$!: Observable<MutationRecord>
   private disabledChange$!: Observable<ButtonMutation>
-
-  private destroy$ = new Subject()
 
   constructor(private el: ElementRef) {
     // observe DOM mutations on attributes defined in attributeFilter
@@ -40,7 +33,7 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
           }));
 
       this.disabledChange$
-        .pipe(takeUntil(this.destroy$))
+        .pipe(untilDestroyed(this))
         .subscribe((m: ButtonMutation) => {
           this.domChange.emit(m)
         })
@@ -48,7 +41,7 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
 
     this.changes.observe(this.el.nativeElement, {
       attributeFilter: ['disabled'],
-      // attributes: true,
+      attributes: true,
       childList: false,
       subtree: false
     });
@@ -57,7 +50,5 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
 
   ngOnDestroy(): void {
     this.changes.disconnect();
-    this.destroy$.next()
-    this.destroy$.unsubscribe()
   }
 }

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { from, Observable } from 'rxjs';
-import { tag } from 'rxjs-spy/cjs/operators/tag';
 import { distinctUntilKeyChanged, filter, map } from 'rxjs/operators';
 
 export interface ButtonMutation {
@@ -24,7 +23,6 @@ export class CvcOrgSelectorBtnDirective implements AfterViewInit, OnDestroy {
   public initialClass!: string
   constructor(private el: ElementRef) {
     // observe DOM mutations on attributes defined in attributeFilter
-    // TODO: handle classList updates to coordinate nz-button types, styles.
     this.changes = new MutationObserver((mutations: MutationRecord[]) => {
       from(mutations)
         .pipe(
@@ -57,7 +55,6 @@ export class CvcOrgSelectorBtnDirective implements AfterViewInit, OnDestroy {
             }
           }),
           distinctUntilKeyChanged('key'),
-          tag('org-selector-btn.directive from(mutation)'),
           untilDestroyed(this)
         )
         .subscribe(mutation => {

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
@@ -5,8 +5,9 @@ import { tag } from 'rxjs-spy/cjs/operators/tag';
 import { distinctUntilKeyChanged, filter, map } from 'rxjs/operators';
 
 export interface ButtonMutation {
-  type: any
-  change: any
+  type: 'disabled' | 'class' | 'hidden'
+  change: boolean | string
+  key: string
 }
 @UntilDestroy()
 @Directive({
@@ -30,17 +31,23 @@ export class CvcOrgSelectorBtnDirective implements AfterViewInit, OnDestroy {
           // filter(mr => mr.attributeName === 'disabled'),
           map((mr: MutationRecord) => {
             const t = mr.target as HTMLInputElement
-            if (mr.attributeName === 'disabled') {
+            if (mr.attributeName === 'class') {
+              return {
+                type: 'class',
+                change: t.classList.value,
+                key: `${mr.attributeName}:${t.classList.value}`}
+            } else if (mr.attributeName === 'disabled') {
               return {
                 type: 'disabled',
                 change: t.disabled,
                 key: `${mr.attributeName}:${t.disabled}`
               }
-            } else if (mr.attributeName === 'class') {
+            } else if (mr.attributeName === 'hidden') {
               return {
-                type: 'class',
-                change: t.classList.value,
-                key: `${mr.attributeName}:${t.classList.value}`}
+                type: 'hidden',
+                change: t.hidden,
+                key: `${mr.attributeName}:${t.hidden}`
+              }
             } else {
               return {
                 type: mr.attributeName,
@@ -62,6 +69,7 @@ export class CvcOrgSelectorBtnDirective implements AfterViewInit, OnDestroy {
       attributeFilter: [
         'class',
         'disabled',
+        'hidden'
       ],
       attributes: true,
       childList: false,

--- a/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
+++ b/client/src/app/forms/config/components/org-selector-btn-group/org-selector-btn.directive.ts
@@ -1,17 +1,18 @@
-import { Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, EventEmitter, OnDestroy, Output } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { from, Observable } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { tag } from 'rxjs-spy/cjs/operators/tag';
+import { distinctUntilKeyChanged, filter, map } from 'rxjs/operators';
 
 export interface ButtonMutation {
-  type: 'disabled' | 'classList'
-  change: boolean | DOMTokenList
+  type: any
+  change: any
 }
 @UntilDestroy()
 @Directive({
   selector: 'button[cvcOrgSelectorBtn]',
 })
-export class CvcOrgSelectorBtnDirective implements OnDestroy {
+export class CvcOrgSelectorBtnDirective implements AfterViewInit, OnDestroy {
   @Output()
   public domChange = new EventEmitter();
 
@@ -19,28 +20,49 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
   private mutation$!: Observable<MutationRecord>
   private disabledChange$!: Observable<ButtonMutation>
 
+  public initialClass!: string
   constructor(private el: ElementRef) {
     // observe DOM mutations on attributes defined in attributeFilter
     // TODO: handle classList updates to coordinate nz-button types, styles.
     this.changes = new MutationObserver((mutations: MutationRecord[]) => {
-      this.mutation$ = from(mutations)
-
-      this.disabledChange$ = this.mutation$
-        .pipe(filter(mr => mr.attributeName === 'disabled'),
-          map(mr => {
+      from(mutations)
+        .pipe(
+          // filter(mr => mr.attributeName === 'disabled'),
+          map((mr: MutationRecord) => {
             const t = mr.target as HTMLInputElement
-            return { type: 'disabled', change: t.disabled }
-          }));
-
-      this.disabledChange$
-        .pipe(untilDestroyed(this))
-        .subscribe((m: ButtonMutation) => {
-          this.domChange.emit(m)
-        })
+            if (mr.attributeName === 'disabled') {
+              return {
+                type: 'disabled',
+                change: t.disabled,
+                key: `${mr.attributeName}:${t.disabled}`
+              }
+            } else if (mr.attributeName === 'class') {
+              return {
+                type: 'class',
+                change: t.classList.value,
+                key: `${mr.attributeName}:${t.classList.value}`}
+            } else {
+              return {
+                type: mr.attributeName,
+                change: 'unknown change type',
+                key: `${mr.attributeName}:unknown-change-type`
+              }
+            }
+          }),
+          distinctUntilKeyChanged('key'),
+          tag('org-selector-btn.directive from(mutation)'),
+          untilDestroyed(this)
+        )
+        .subscribe(mutation => {
+          this.domChange.emit(mutation)
+        });
     });
 
     this.changes.observe(this.el.nativeElement, {
-      attributeFilter: ['disabled'],
+      attributeFilter: [
+        'class',
+        'disabled',
+      ],
       attributes: true,
       childList: false,
       subtree: false
@@ -48,6 +70,10 @@ export class CvcOrgSelectorBtnDirective implements OnDestroy {
 
   }
 
+  ngAfterViewInit(): void {
+    console.log(`directive ngAfterViewInit classList.value: ${this.el.nativeElement.classList.value}`)
+    this.initialClass = this.el.nativeElement.classList.value;
+  }
   ngOnDestroy(): void {
     this.changes.disconnect();
   }

--- a/client/src/app/forms/config/types/org-submit-button/org-submit-button.type.html
+++ b/client/src/app/forms/config/types/org-submit-button/org-submit-button.type.html
@@ -1,10 +1,11 @@
 <cvc-form-buttons>
-  <cvc-org-selector-btn-group #orgButton [(selectedOrg)]="selectedOrg"
-    [nzSize]="to.submitSize">
+  <cvc-org-selector-btn-group #orgButton
+    [(selectedOrg)]="selectedOrg">
     <button type="submit"
       (click)="orgButton.refreshViewer();"
       nz-button
       cvcOrgSelectorBtn
+      [nzSize]="to.submitSize"
       nzType="primary"
       [disabled]="!form.valid">
       {{ to.submitLabel }}

--- a/client/src/app/forms/evidence-submit/evidence-submit.form.html
+++ b/client/src/app/forms/evidence-submit/evidence-submit.form.html
@@ -10,13 +10,14 @@
   <nz-spin nzTip="Submitting"
     *nzSpaceItem
     [nzSpinning]="this.loading">
-    <form  nz-form
+    <form nz-form
       [formGroup]="formGroup"
       (ngSubmit)="submitEvidence(formModel)"
       nzLayout="vertical">
       <ng-container *ngTemplateOutlet="formMessages"></ng-container>
 
-      <formly-form *ngIf="!this.success" [form]="formGroup"
+      <formly-form *ngIf="!this.success"
+        [form]="formGroup"
         [fields]="formFields"
         [model]="formModel"
         [options]="formOptions"
@@ -40,12 +41,12 @@
       </ng-container>
     </ng-template>
   </nz-spin>
-  </nz-space>
-
+</nz-space>
+<!--
   <div nz-row>
     <div nz-col
       nzSpan="24">
       <ngx-json-viewer *ngIf="formModel"
         [json]="formModel"></ngx-json-viewer>
     </div>
-  </div>
+  </div> -->

--- a/client/src/app/views/evidence/evidence-add/evidence-submit/evidence-submit.module.ts
+++ b/client/src/app/views/evidence/evidence-add/evidence-submit/evidence-submit.module.ts
@@ -6,16 +6,32 @@ import { NzSkeletonModule } from 'ng-zorro-antd/skeleton';
 import { NzCardModule } from 'ng-zorro-antd/card';
 import { EvidenceSubmitPage } from './evidence-submit.page';
 import { EvidenceSubmitFormModule } from '@app/forms/evidence-submit/evidence-submit.module';
+import { CvcOrgSelectorBtnGroupModule } from '@app/forms/config/components/org-selector-btn-group/org-selector-btn-group.module';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzSwitchModule } from 'ng-zorro-antd/switch';
+import { FormsModule } from '@angular/forms';
+import { NzRadioModule } from 'ng-zorro-antd/radio';
 
 @NgModule({
   declarations: [EvidenceSubmitPage],
   imports: [
     CommonModule,
+    FormsModule,
     NzGridModule,
     NzSpaceModule,
     NzCardModule,
     NzSkeletonModule,
     EvidenceSubmitFormModule,
+
+    // debug
+    NzSwitchModule,
+    NzRadioModule,
+    NzGridModule,
+    NzIconModule,
+    NzButtonModule,
+    CvcOrgSelectorBtnGroupModule,
+
   ]
 })
 export class EvidenceSubmitModule { }


### PR DESCRIPTION
The org-selector-btn has had several problems w/ keeping the selector button's classes and disabled/hidden state synchronized with the transcluded button it's attached to. This update fixes all those problems by copying all class updates from the transcluded button (with the cvcOrgSelectorBtn directive), as well as disabled and hidden state changes. Also fixes some small style issues when a button w/ 'primary' nzType also has nzDanger applied, inside an nz-button-group.