### PR TITLE
distinguish between false and undefined

### DIFF
--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
@@ -252,17 +252,20 @@
             <nz-descriptions-item nzTitle="Regulatory Approval"
               nzSpan="1">
               <i nz-icon
-                *ngIf="assertion.regulatoryApproval"
+                *ngIf="assertion.regulatoryApproval === true"
                 [nzType]="'check-circle'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#52c41a'"></i>
               <i nz-icon
-                *ngIf="!assertion.regulatoryApproval"
+                *ngIf="assertion.regulatoryApproval === false"
                 [nzType]="'close-square'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#d93026'"></i>
               <ng-container *ngIf="assertion.regulatoryApprovalLastUpdated">
                 (last updated {{ assertion.regulatoryApprovalLastUpdated | timeago }})
+              </ng-container>
+              <ng-container *ngIf="assertion.regulatoryApproval === undefined">
+                <span nz-typography nzType="secondary">N/A</span>
               </ng-container>
             </nz-descriptions-item>
 
@@ -270,17 +273,20 @@
             <nz-descriptions-item nzTitle="FDA Companion Test"
               nzSpan="1">
               <i nz-icon
-                *ngIf="assertion.fdaCompanionTest"
+                *ngIf="assertion.fdaCompanionTest === true"
                 [nzType]="'check-circle'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#52c41a'"></i>
               <i nz-icon
-                *ngIf="!assertion.fdaCompanionTest"
+                *ngIf="assertion.fdaCompanionTest === false"
                 [nzType]="'close-square'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#d93026'"></i>
               <ng-container *ngIf="assertion.fdaCompanionTestLastUpdated">
                 (last updated {{ assertion.fdaCompanionTestLastUpdated | timeago }})
+              </ng-container>
+              <ng-container *ngIf="assertion.fdaCompanionTest=== undefined">
+                <span nz-typography nzType="secondary">N/A</span>
               </ng-container>
             </nz-descriptions-item>
 


### PR DESCRIPTION
closes #680 

We will want to verify that older (pre v2) assertions are correctly set to null rather than false for types other than predictive