### PR TITLE
Remove nzLabel on the quicksearch dropdown options to remove tooltip

### DIFF
--- a/client/src/app/components/layout/quicksearch/quicksearch-component.html
+++ b/client/src/app/components/layout/quicksearch/quicksearch-component.html
@@ -10,7 +10,6 @@
   [nzDropdownMatchSelectWidth]="false">
   <nz-option *ngFor="let o of (option$ | ngrxPush)"
     nzCustomContent
-    [nzLabel]="o.text"
     [nzValue]="o.result">
     <i nz-icon
       [nzType]="iconNameForResult(o.result)"


### PR DESCRIPTION
Closes #644 