### PR TITLE
Lookup Variant by alias before creating a new one

### DIFF
--- a/server/app/graphql/mutations/add_variant.rb
+++ b/server/app/graphql/mutations/add_variant.rb
@@ -28,12 +28,13 @@ class Mutations::AddVariant < Mutations::BaseMutation
   end
 
   def resolve(name:, gene_id:)
-    existing_variant = Variant.where(gene_id: gene_id)
-      .where('name ILIKE ?', name)
+    existing_variant = Variant.joins(:variant_aliases).where(gene_id: gene_id)
+      .where('variants.name ILIKE ?', name)
+      .or(Variant.joins(:variant_aliases).where(gene_id: gene_id).where('variant_aliases.name ILIKE ?', name))
       .first
 
     if existing_variant.present?
-      return { 
+      return {
         variant: existing_variant,
         new: false,
         molecular_profile: existing_variant.single_variant_molecular_profile


### PR DESCRIPTION
Closes #566 

In the refactored forms we should add an indicator when a new variant isn't created because one with the same name/alias already exists. Currently it just inserts the existing Variant into the form.