### PR TITLE
Long evidence and assertion descriptons will overflow into scroll

### DIFF
--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
@@ -17,9 +17,10 @@
 
             <nz-descriptions-item nzTitle="Description">
               <p nz-typography
+                class="summary-block"
                 nzEllipsis
                 nzExpandable
-                [nzEllipsisRows]="14">{{ assertion.description }}</p>
+                [nzEllipsisRows]="6">{{ assertion.description }}</p>
             </nz-descriptions-item>
 
           </nz-descriptions>

--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.less
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.less
@@ -8,3 +8,8 @@
 nz-space, nz-space-item {
   width: 100%;
 }
+
+.summary-block {
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
@@ -11,9 +11,10 @@
             nzBordered="true">
             <nz-descriptions-item nzTitle="Statement">
               <p nz-typography
+                class="summary-block"
                 nzEllipsis
                 nzExpandable
-                [nzEllipsisRows]="14">{{ evidence.description }}</p>
+                [nzEllipsisRows]="6">{{ evidence.description }}</p>
             </nz-descriptions-item>
 
           </nz-descriptions>

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.less
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.less
@@ -5,3 +5,7 @@
   display: block;
 }
 
+.summary-block {
+  max-height: 200px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
This prevents the text box from pushing the tables off the bottom of the page.

closes #749 