### PR TITLE
forms-2 <-- evidence-select post merge improvements

### DIFF
--- a/client/src/app/forms2/config/assertion-submit/assertion-submit.form.config.ts
+++ b/client/src/app/forms2/config/assertion-submit/assertion-submit.form.config.ts
@@ -47,33 +47,39 @@ const formFieldConfig: FormlyFieldConfig[] = [
               tooltip: 'TEST TEST TEST TEST',
               helpText: 'This is the description of a molecular profile.',
               watchVariantMolecularProfileId: true,
+              colSpan: 16,
             },
           },
-          <CvcEntityTypeSelectFieldConfig>{
+          {
             key: 'assertionType',
             type: 'type-select',
             props: {
               required: true,
+              colSpan: 8,
             },
           },
-          <CvcDirectionSelectFieldOptions>{
+          {
             key: 'assertionDirection',
             type: 'direction-select',
             props: {
               required: true,
+              colSpan: 8,
             },
           },
-          <CvcSignificanceSelectFieldOptions>{
+          {
             key: 'significance',
             type: 'significance-select',
             props: {
               required: true,
+              colSpan: 8,
             },
           },
-          <CvcDiseaseSelectFieldOptions>{
+          {
             key: 'diseaseId',
             type: 'disease-select',
-            props: {},
+            props: {
+              colSpan: 8,
+            },
           },
           <CvcTherapySelectFieldOptions>{
             key: 'therapyIds',
@@ -100,7 +106,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
           <CvcAmpCategorySelectFieldOptions>{
             key: 'ampLevel',
             type: 'amp-category-select',
-            props: {}
+            props: {},
           },
           <CvcAcmgCodeSelectFieldOptions>{
             key: 'acmgCodeIds',
@@ -123,7 +129,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
             props: {
               required: true,
               isMultiSelect: true,
-              colSpan: 24
+              colSpan: 24,
             },
           },
           {
@@ -131,8 +137,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
             type: 'textarea',
             wrappers: ['form-field'],
             props: {
-              tooltip:
-                'A short, one sentence summary of the Assertion',
+              tooltip: 'A short, one sentence summary of the Assertion',
               placeholder: 'Enter an Assertion Summary',
               label: 'Assertion Summary',
               required: true,
@@ -148,7 +153,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
               placeholder: 'Enter an Assertion Statement',
               label: 'Assertion Statement',
               required: true,
-              rows: 5 
+              rows: 5,
             },
           },
         ],

--- a/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.component.html
+++ b/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.component.html
@@ -7,7 +7,7 @@
     [nzData]="(row$ | ngrxPush) || []"
     cvcTableScroller
     (cvcTableScrollerOnScroll)="onScroll$.next($event)"
-    (cvcTableScrollerOnFetch)="onFetch$.next($event)"
+    (cvcTableScrollerOnFetch)="onFetchMore$.next($event)"
     [cvcTableScrollerQueryRef]="queryRef"
     [cvcTableScrollerPageInfo]="pageInfo$ | ngrxPush"
     [cvcTableScrollerToIndex]="(scrollToIndex$ | ngrxPush)!"

--- a/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.types.ts
+++ b/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.types.ts
@@ -69,7 +69,6 @@ export type EvidenceManagerRowData = Pick<
 export type EvidenceManagerColKey = keyof EvidenceManagerRowData
 export type EvidenceManagerColType =
   | 'select' // select column, displays checkboxes for row selection
-  | 'select-tag' // select + entity tags next to checkboxes
   | 'entity-tag' // display col value with entity-tag
   | 'enum-tag' // display cell data w/ attribute-tag
   | 'default' // short strings, e.g. labels, counts
@@ -91,7 +90,7 @@ interface BaseColumn {
   emptyValueCategory?: CvcEmptyValueCategory // passed to cvc-empty-value component
 }
 
-// implements nz-table filters
+// options list and changes stream for col filters
 interface FilterOptions {
   filter: {
     options: NzTableFilterList // options displayed in filter dropdown
@@ -115,6 +114,7 @@ interface InputFilterOptions {
   }
 }
 
+// default sort order & changes stream for col filters
 export interface SortOptions {
   sort: {
     default?: NzTableSortOrder
@@ -122,6 +122,8 @@ export interface SortOptions {
   }
 }
 
+// checkbox display & changes stream for selection col's
+// header and row cells
 interface SelectionOptions {
   checkbox: {
     th: {
@@ -135,26 +137,11 @@ interface SelectionOptions {
   }
 }
 
+// passed to nz-tables fixedLeft/Right inputs
 interface FixedOptions {
   fixedLeft?: true
   fixedRight?: true
 }
-
-// use context to use another column's entity object to display tag
-interface EntityTagOptions {
-  showStatus?: boolean // display tag status indicator styles
-}
-
-interface TextTagOptions {
-  text?: {}
-}
-
-// displays row[key] value with attribute-tag component.
-// toggle icon off w/ showIcon to render enums that
-// evidenceDisplayEnum won't work with. toggle showLabel off
-// for a little mini-tag w/ just the icon.
-// If showIcon is a string, that string will be provided to icon's nzType
-interface EnumTagOptions {}
 
 interface TagOptions {
   tag?: {
@@ -165,6 +152,26 @@ interface TagOptions {
     maxTags?: number // max tags if value is tag array
   }
 }
+
+// most entity tag cols can be customized using TagOptions.
+// if showStatus set to true, tag will display status styles.
+// NOTE: use BaseColumn's 'context' option if it's necessary
+// to render an entity tag in a column whos row[colKey] data
+// is not a LinkableEntity, e.g. evidence-manager table's 'id' col
+interface EntityTagOptions {
+  showStatus?: boolean // display tag status indicator styles
+}
+
+interface TextTagOptions {
+  text?: {}
+}
+
+// displays row[key] value with attribute-tag component.
+// NOTE: use TagOptions for different cvc-attribute-tag displays in enum-tag cols:
+// - toggle showLabel off for a little mini-tag w/ just the icon.
+// - if attribute-tag cannot automatically pick the correct icon,
+// set showIcon to the name of any nz-icon, and the tag will display that
+interface EnumTagOptions {}
 
 export type ColumnConfigOption =
   | SelectColumnType


### PR DESCRIPTION
Cleaned up code, improved comments & var/fn names in evidence-select & related components. Also removed the type adornments on assertion-submit's form config objects, as those aren't working as intended and are causing more problems than they solve. To work properly & preserve types in form config arrays, field type config & options will need proper discriminated union/intersection types, similar to the [column preference options](https://github.com/griffithlab/civic-v2/blob/3564afaf9f13ad553f1abfdd7fe8a0c0ce3588e0/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.types.ts#L169) in evidence-manager.types used to type its [table options array](https://github.com/griffithlab/civic-v2/blob/3564afaf9f13ad553f1abfdd7fe8a0c0ce3588e0/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.component.ts#L201).
