### PR TITLE
Fixes [N/A N/A] attribute tag display issue

### DIFF
--- a/client/.prettierrc.json
+++ b/client/.prettierrc.json
@@ -1,1 +1,11 @@
-{}
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 80,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "singleAttributePerLine": true,
+  "bracketSameLine": true,
+  "htmlWhitespaceSensitivity": "css"
+}

--- a/client/src/app/components/shared/empty-value/empty-value.component.html
+++ b/client/src/app/components/shared/empty-value/empty-value.component.html
@@ -1,0 +1,38 @@
+<ng-container [ngSwitch]="cvcEmptyCategory">
+  <span
+    *ngSwitchCase="'not-applicable'"
+    class="empty-symbol not-applicable"
+    nz-tooltip
+    nzTooltipTitle="Value is not applicable">
+    <ng-container [ngSwitch]="cvcDisplayMode">
+      <ng-container *ngSwitchCase="'small'"> N/A </ng-container>
+      <ng-container *ngSwitchDefault> Not applicable </ng-container>
+    </ng-container>
+  </span>
+  <span
+    *ngSwitchCase="'unspecified'"
+    nz-tooltip
+    nzTooltipTitle="Unspecified"
+    class="empty-symbol unspecified"
+    nz-tooltip
+    nzTooltipTitle="Value is unspecified">
+    <ng-container [ngSwitch]="cvcDisplayMode">
+      <ng-container *ngSwitchCase="'small'">
+        &ndash;&nbsp;&ndash;
+      </ng-container>
+      <ng-container *ngSwitchDefault>Not specified</ng-container>
+    </ng-container>
+  </span>
+  <span
+    *ngSwitchCase="'invalid'"
+    nz-tooltip
+    nzTooltipTitle="INVALID"
+    class="empty-symbol invalid"
+    nz-tooltip
+    nzTooltipTitle="Error: value requires specification">
+    <ng-container [ngSwitch]="cvcDisplayMode">
+      <ng-container *ngSwitchCase="'small'">!?</ng-container>
+      <ng-container *ngSwitchDefault>Unspecified</ng-container>
+    </ng-container>
+  </span>
+</ng-container>

--- a/client/src/app/components/shared/empty-value/empty-value.component.less
+++ b/client/src/app/components/shared/empty-value/empty-value.component.less
@@ -1,5 +1,4 @@
 .empty-symbol {
-  font-size: 0.9em;
   font-style: oblique;
   display: inline-block;
   cursor: help;

--- a/client/src/app/components/shared/empty-value/empty-value.component.less
+++ b/client/src/app/components/shared/empty-value/empty-value.component.less
@@ -1,0 +1,22 @@
+.empty-symbol {
+  font-size: 0.9em;
+  font-style: oblique;
+  display: inline-block;
+  cursor: help;
+  white-space: no-wrap;
+  &.not-applicable {
+    color: #ccc;
+    font-weight: 500;
+  }
+  &.unspecified {
+    display: inline-block;
+    color: #ccc;
+    font-weight: 500;
+    padding: 0 3px;
+  }
+  &.invalid {
+    display: inline-block;
+    color: #FF4D4F;
+    font-weight: 700;
+  }
+}

--- a/client/src/app/components/shared/empty-value/empty-value.component.ts
+++ b/client/src/app/components/shared/empty-value/empty-value.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core'
+
+export type CvcEmptyValueCategory = 'not-applicable' | 'unspecified' | 'invalid'
+
+@Component({
+  selector: 'cvc-empty-value',
+  templateUrl: './empty-value.component.html',
+  styleUrls: ['./empty-value.component.less'],
+})
+export class EmptyValueComponent {
+  @Input() cvcEmptyCategory: CvcEmptyValueCategory =
+    'not-applicable'
+  @Input() cvcDisplayMode: 'default' | 'small' = 'default'
+}

--- a/client/src/app/components/shared/empty-value/empty-value.module.ts
+++ b/client/src/app/components/shared/empty-value/empty-value.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common'
+import { NgModule } from '@angular/core'
+import { NzIconModule } from 'ng-zorro-antd/icon'
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
+import { EmptyValueComponent } from './empty-value.component'
+
+@NgModule({
+  declarations: [EmptyValueComponent],
+  imports: [CommonModule, NzToolTipModule, NzIconModule],
+  exports: [EmptyValueComponent],
+})
+export class CvcEmptyValueModule {}

--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.module.ts
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.module.ts
@@ -23,6 +23,7 @@ import { CvcAttributeTagModule } from '@app/components/shared/attribute-tag/attr
 import { CvcMolecularProfileTagModule } from '@app/components/molecular-profiles/molecular-profile-tag/molecular-profile-tag.module';
 import { CvcMolecularProfileTagNameModule } from '@app/components/molecular-profiles/molecular-profile-tag-name/molecular-profile-tag-name.module';
 import { CvcTherapyTagModule } from '@app/components/therapies/cvc-therapy-tag/cvc-therapy-tag.module';
+import { CvcEmptyValueModule } from '@app/components/shared/empty-value/empty-value.module';
 
 @NgModule({
   declarations: [AssertionsSummaryPage],
@@ -38,6 +39,7 @@ import { CvcTherapyTagModule } from '@app/components/therapies/cvc-therapy-tag/c
     NzIconModule,
     NzDescriptionsModule,
     NzToolTipModule,
+    CvcEmptyValueModule,
     CvcPipesModule,
     CvcStatusTagModule,
     CvcUserTagModule,

--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
@@ -7,7 +7,8 @@
       <nz-row [nzGutter]="[8,8]">
         <!-- summary, description block -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzLayout="vertical"
+          <nz-descriptions
+            nzLayout="vertical"
             nzSize="small"
             nzBordered="true"
             [nzColumn]="1">
@@ -16,25 +17,28 @@
             </nz-descriptions-item>
 
             <nz-descriptions-item nzTitle="Description">
-              <p nz-typography
+              <p
+                nz-typography
                 class="summary-block"
                 nzEllipsis
                 nzExpandable
-                [nzEllipsisRows]="6">{{ assertion.description }}</p>
+                [nzEllipsisRows]="6">
+                {{ assertion.description }}
+              </p>
             </nz-descriptions-item>
-
           </nz-descriptions>
         </nz-col>
 
         <!-- assertion attributes block -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzSize="small"
+          <nz-descriptions
+            nzSize="small"
             [nzColumn]="{ xxl: 3, xl: 2, lg: 1, md: 1, sm: 1, xs: 1 }"
             nzBordered="true">
-
             <!-- assertion type -->
             <nz-descriptions-item nzTitle="Type">
-              <cvc-attribute-tag cvcAttrName="assertionType"
+              <cvc-attribute-tag
+                cvcAttrName="assertionType"
                 [cvcAttrValue]="assertion.assertionType"
                 nz-tooltip
                 iconPropertyType="type"
@@ -44,7 +48,8 @@
 
             <!-- assertion direction -->
             <nz-descriptions-item nzTitle="Direction">
-              <cvc-attribute-tag [cvcAttrValue]="assertion.assertionDirection"
+              <cvc-attribute-tag
+                [cvcAttrValue]="assertion.assertionDirection"
                 nz-tooltip
                 [nzTooltipTitle]="assertion.assertionDirection | enumTooltip:'assertionDirection':assertion.assertionType:'Assertion'">
               </cvc-attribute-tag>
@@ -52,7 +57,8 @@
 
             <!-- clinical significance -->
             <nz-descriptions-item nzTitle="Significance">
-              <cvc-attribute-tag [cvcAttrValue]="assertion.significance"
+              <cvc-attribute-tag
+                [cvcAttrValue]="assertion.significance"
                 nz-tooltip
                 [nzTooltipTitle]="assertion.significance | enumTooltip:'significance':assertion.assertionType:'Assertion'">
               </cvc-attribute-tag>
@@ -60,7 +66,8 @@
 
             <!-- variant origin -->
             <nz-descriptions-item nzTitle="Variant Origin">
-              <cvc-attribute-tag [cvcAttrValue]="assertion.variantOrigin"
+              <cvc-attribute-tag
+                [cvcAttrValue]="assertion.variantOrigin"
                 nz-tooltip
                 [nzTooltipTitle]="assertion.variantOrigin | enumTooltip:'variantOrigin'">
               </cvc-attribute-tag>
@@ -68,48 +75,57 @@
 
             <!-- AMP/ASO/CAP -->
             <nz-descriptions-item nzTitle="AMP/ASCO/CAP Category">
-              <ng-container *ngIf="assertionRules.requiresAmpLevel(assertion.assertionType); else notApplicable">
+              <ng-container
+                *ngIf="assertionRules.requiresAmpLevel(assertion.assertionType); else valueNotApplicable">
                 <nz-tag>{{ assertion.ampLevel | formatAmp: 'verbose' }}</nz-tag>
               </ng-container>
             </nz-descriptions-item>
 
             <!-- ACMG Codes -->
             <nz-descriptions-item nzTitle="ACMG Codes">
-              <ng-container *ngIf="assertionRules.requiresAcmgCodes(assertion.assertionType); else notApplicable">
+              <ng-container
+                *ngIf="assertionRules.requiresAcmgCodes(assertion.assertionType); else valueNotApplicable">
                 <ng-container *ngIf="assertion.acmgCodes.length > 0">
-                  <nz-tag nz-tooltip
+                  <nz-tag
+                    nz-tooltip
                     [nzTooltipTitle]="code.description"
-                    *ngFor="let code of assertion.acmgCodes">{{ code.code }}</nz-tag>
+                    *ngFor="let code of assertion.acmgCodes"
+                    >{{ code.code }}</nz-tag
+                  >
                 </ng-container>
                 <ng-container *ngIf="assertion.acmgCodes.length == 0">
-                  <span nz-typography
-                    nzType="secondary">None provided</span>
+                  <span
+                    nz-typography
+                    nzType="secondary"
+                    >None provided</span
+                  >
                 </ng-container>
               </ng-container>
             </nz-descriptions-item>
 
             <!-- ClinGen Codes -->
             <nz-descriptions-item nzTitle="ClinGen/CGC/VICC Codes">
-              <ng-container *ngIf="assertionRules.requiresClingenCodes(assertion.assertionType); else notApplicable">
+              <ng-container
+                *ngIf="assertionRules.requiresClingenCodes(assertion.assertionType); else valueNotApplicable">
                 <ng-container *ngIf="assertion.clingenCodes.length > 0">
-                  <nz-tag nz-tooltip
+                  <nz-tag
+                    nz-tooltip
                     [nzTooltipTitle]="code.description"
-                    *ngFor="let code of assertion.clingenCodes">{{code.code }}</nz-tag>
+                    *ngFor="let code of assertion.clingenCodes"
+                    >{{code.code }}</nz-tag
+                  >
                 </ng-container>
                 <ng-container *ngIf="assertion.clingenCodes.length == 0">
-                  <span nz-typography
-                    nzType="secondary">None provided</span>
+                  <span
+                    nz-typography
+                    nzType="secondary"
+                    >None provided</span
+                  >
                 </ng-container>
               </ng-container>
             </nz-descriptions-item>
-
-            <ng-template #notApplicable>
-              <span nz-typography
-                nzType="secondary">Not applicable</span>
-            </ng-template>
           </nz-descriptions>
         </nz-col>
-
       </nz-row>
     </nz-col>
 
@@ -117,14 +133,13 @@
     <nz-col [nzSpan]="12">
       <!-- right col layout row -->
       <nz-row [nzGutter]="[8,8]">
-
         <!-- BLOCK: status, curation events block -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzLayout="vertical"
+          <nz-descriptions
+            nzLayout="vertical"
             nzSize="small"
             [nzColumn]="{ xxl: 3, xl: 3, lg: 3, md: 1, sm: 1, xs: 1 }"
             nzBordered="true">
-
             <!-- status -->
             <nz-descriptions-item nzTitle="Status">
               <cvc-status-tag [status]="assertion.status"></cvc-status-tag>
@@ -133,11 +148,13 @@
             <!-- submit/accept/reject curation events -->
             <nz-descriptions-item [nzTitle]="submittedTitle">
               by
-              <cvc-user-tag [user]="assertion.submissionEvent.originatingUser"></cvc-user-tag>
+              <cvc-user-tag
+                [user]="assertion.submissionEvent.originatingUser"></cvc-user-tag>
             </nz-descriptions-item>
             <ng-template #submittedTitle>
               Submitted
-              <span nz-typography
+              <span
+                nz-typography
                 nzType="secondary">
                 ({{ assertion.submissionEvent.createdAt | timeago }})
               </span>
@@ -145,88 +162,98 @@
 
             <!-- TODO logic below is incorrect see AID1 - must identify the latest accept/reject event, and display that -->
             <!-- display accepted/rejected only if either exists -->
-            <ng-container *ngIf="assertion.rejectionEvent !== null || assertion.acceptanceEvent !== null">
+            <ng-container
+              *ngIf="assertion.rejectionEvent !== null || assertion.acceptanceEvent !== null">
               <!-- show acceptance only if no rejection event exists -->
               <ng-container [ngSwitch]="assertion.rejectionEvent === null">
-                <nz-descriptions-item *ngSwitchCase="true"
+                <nz-descriptions-item
+                  *ngSwitchCase="true"
                   [nzTitle]="acceptedTitle">
                   by
-                  <cvc-user-tag [user]="assertion.acceptanceEvent.originatingUser"></cvc-user-tag>
+                  <cvc-user-tag
+                    [user]="assertion.acceptanceEvent.originatingUser"></cvc-user-tag>
                 </nz-descriptions-item>
                 <ng-template #acceptedTitle>
                   Accepted
-                  <span nz-typography
+                  <span
+                    nz-typography
                     nzType="secondary">
                     ({{ assertion.acceptanceEvent.createdAt| timeago }})
-                </span>
+                  </span>
                 </ng-template>
 
-                <nz-descriptions-item *ngSwitchCase="false"
+                <nz-descriptions-item
+                  *ngSwitchCase="false"
                   [nzTitle]="rejectedTitle">
                   by {{ assertion.rejectionEvent.createdAt | timeago }} by
-                  <cvc-user-tag [user]="assertion.rejectionEvent.originatingUser"></cvc-user-tag>
+                  <cvc-user-tag
+                    [user]="assertion.rejectionEvent.originatingUser"></cvc-user-tag>
                 </nz-descriptions-item>
                 <ng-template #rejectedTitle>
                   Rejected
-                  <span nz-typography
+                  <span
+                    nz-typography
                     nzType="secondary">
-                ({{ assertion.rejectionEvent.createdAt | timeago }})
-              </span>
+                    ({{ assertion.rejectionEvent.createdAt | timeago }})
+                  </span>
                 </ng-template>
               </ng-container>
             </ng-container>
-
           </nz-descriptions>
         </nz-col>
 
         <!-- disease, phenotype block -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzSize="small"
+          <nz-descriptions
+            nzSize="small"
             nzBordered="true"
             [nzColumn]="{ xxl: 2, xl: 1, lg: 1, md: 1, sm: 1, xs: 1 }">
-
             <!-- molecular profile -->
             <nz-descriptions-item nzTitle="Molecular Profile Name">
-              <cvc-molecular-profile-tag [molecularProfile]="assertion.molecularProfile" [enablePopover]="true"></cvc-molecular-profile-tag>
+              <cvc-molecular-profile-tag
+                [molecularProfile]="assertion.molecularProfile"
+                [enablePopover]="true"></cvc-molecular-profile-tag>
             </nz-descriptions-item>
 
             <!-- molecular profile expression -->
             <nz-descriptions-item nzTitle="MP Expression">
-              <cvc-mp-tag-name [nameSegments]="assertion.molecularProfile.parsedName"></cvc-mp-tag-name>
+              <cvc-mp-tag-name
+                [nameSegments]="assertion.molecularProfile.parsedName"></cvc-mp-tag-name>
             </nz-descriptions-item>
 
             <!-- disease -->
             <nz-descriptions-item nzTitle="Disease">
               <ng-container *ngIf="assertion.disease.name">
-                <cvc-disease-tag [disease]="assertion.disease"></cvc-disease-tag>
+                <cvc-disease-tag
+                  [disease]="assertion.disease"></cvc-disease-tag>
               </ng-container>
-              <span *ngIf="!assertion.disease.name"
+              <span
+                *ngIf="!assertion.disease.name"
                 nz-typography
-                nzType="secondary">Not applicable</span>
+                nzType="secondary"
+                >Not applicable</span
+              >
             </nz-descriptions-item>
 
             <!-- phenotypes -->
-            <nz-descriptions-item [nzTitle]="assertion.phenotypes.length > 1 ? 'Phenotypes' : 'Phenotype'">
-              <ng-container *ngIf="assertion.phenotypes.length === 0">
-                <span nz-typography
-                  nzType="secondary">None Specified</span>
-              </ng-container>
-              <ng-container *ngIf="assertion.phenotypes.length > 0">
-                <cvc-tag-list>
-                  <ng-container *ngFor="let ph of assertion.phenotypes">
-                    <cvc-phenotype-tag [phenotype]="ph"></cvc-phenotype-tag>
-                  </ng-container>
-                </cvc-tag-list>
-              </ng-container>
+            <nz-descriptions-item
+              [nzTitle]="assertion.phenotypes.length > 1 ? 'Phenotypes' : 'Phenotype'">
+              <cvc-tag-list
+                *ngIf="assertion.phenotypes.length > 0; else valueUnspecified">
+                <ng-container *ngFor="let ph of assertion.phenotypes">
+                  <cvc-phenotype-tag [phenotype]="ph"></cvc-phenotype-tag>
+                </ng-container>
+              </cvc-tag-list>
             </nz-descriptions-item>
 
             <!-- therapies -->
-            <nz-descriptions-item [nzTitle]="assertion.therapies.length > 1 ? 'Therapies' : 'Therapy'">
+            <nz-descriptions-item
+              [nzTitle]="assertion.therapies.length > 1 ? 'Therapies' : 'Therapy'">
               <ng-container [ngPlural]="assertion.therapies.length">
                 <!-- no therapy -->
                 <ng-template ngPluralCase="=0">
-                  <span nz-typography
-                    nzType="secondary">N/A</span>
+                  <ng-container
+                    [ngTemplateOutlet]="valueNotApplicable"></ng-container>
                 </ng-template>
 
                 <!-- one or more therapies -->
@@ -238,79 +265,104 @@
                   </cvc-tag-list>
                 </ng-template>
               </ng-container>
-
             </nz-descriptions-item>
 
-            <nz-descriptions-item *ngIf="assertion.therapyInteractionType"
+            <nz-descriptions-item
+              *ngIf="assertion.therapyInteractionType"
               nzTitle="Therapy Interaction Type">
               <nz-tag>
-                <i nz-icon
+                <i
+                  nz-icon
                   [nzType]="assertion.therapyInteractionType | therapyInteractionEnumDisplay: 'icon-name'"
-                  class="attribute-icon"></i> {{ assertion.therapyInteractionType | titlecase }}
+                  class="attribute-icon"></i>
+                {{ assertion.therapyInteractionType | titlecase }}
               </nz-tag>
             </nz-descriptions-item>
 
             <!-- regulatory approval -->
-            <nz-descriptions-item nzTitle="Regulatory Approval"
+            <nz-descriptions-item
+              nzTitle="Regulatory Approval"
               nzSpan="1">
-              <i nz-icon
+              <i
+                nz-icon
                 *ngIf="assertion.regulatoryApproval === true"
                 [nzType]="'check-circle'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#52c41a'"></i>
-              <i nz-icon
+              <i
+                nz-icon
                 *ngIf="assertion.regulatoryApproval === false"
                 [nzType]="'close-square'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#d93026'"></i>
               <ng-container *ngIf="assertion.regulatoryApprovalLastUpdated">
-                (last updated {{ assertion.regulatoryApprovalLastUpdated | timeago }})
+                (last updated {{ assertion.regulatoryApprovalLastUpdated |
+                timeago }})
               </ng-container>
-              <ng-container *ngIf="assertion.regulatoryApproval === undefined">
-                <span nz-typography nzType="secondary">N/A</span>
-              </ng-container>
+              <ng-container
+                *ngIf="assertion.regulatoryApproval === undefined"
+                [ngTemplateOutlet]="valueNotApplicable"></ng-container>
             </nz-descriptions-item>
 
             <!-- FDA companion test -->
-            <nz-descriptions-item nzTitle="FDA Companion Test"
+            <nz-descriptions-item
+              nzTitle="FDA Companion Test"
               nzSpan="1">
-              <i nz-icon
+              <i
+                nz-icon
                 *ngIf="assertion.fdaCompanionTest === true"
                 [nzType]="'check-circle'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#52c41a'"></i>
-              <i nz-icon
+              <i
+                nz-icon
                 *ngIf="assertion.fdaCompanionTest === false"
                 [nzType]="'close-square'"
                 [nzTheme]="'twotone'"
                 [nzTwotoneColor]="'#d93026'"></i>
               <ng-container *ngIf="assertion.fdaCompanionTestLastUpdated">
-                (last updated {{ assertion.fdaCompanionTestLastUpdated | timeago }})
+                (last updated {{ assertion.fdaCompanionTestLastUpdated | timeago
+                }})
               </ng-container>
               <ng-container *ngIf="assertion.fdaCompanionTest=== undefined">
-                <span nz-typography nzType="secondary">N/A</span>
+                <span
+                  nz-typography
+                  nzType="secondary"
+                  >N/A</span
+                >
               </ng-container>
             </nz-descriptions-item>
 
             <!-- NCCN guideline -->
             <nz-descriptions-item nzTitle="NCCN Guideline">
-              <ng-container *ngIf="assertion.nccnGuideline">{{ assertion.nccnGuideline.name }} ({{
-                        assertion.nccnGuidelineVersion}})</ng-container>
+              <ng-container *ngIf="assertion.nccnGuideline"
+                >{{ assertion.nccnGuideline.name }} ({{
+                assertion.nccnGuidelineVersion}})</ng-container
+              >
               <ng-container *ngIf="!assertion.nccnGuideline">
-                <span nz-typography
-                  nzType="secondary">None Provided</span>
+                <span
+                  nz-typography
+                  nzType="secondary"
+                  >None Provided</span
+                >
               </ng-container>
             </nz-descriptions-item>
           </nz-descriptions>
         </nz-col>
-
       </nz-row>
     </nz-col>
 
     <!-- evidence table -->
     <nz-col [nzSpan]="24">
-      <cvc-evidence-table [assertionId]="assertion.id"
+      <cvc-evidence-table
+        [assertionId]="assertion.id"
         cvcTitle="{{assertion.name}} Evidence"></cvc-evidence-table>
     </nz-col>
   </nz-row>
 </ng-container>
+<ng-template #valueNotApplicable>
+  <cvc-empty-value cvcEmptyCategory="not-applicable"></cvc-empty-value>
+</ng-template>
+<ng-template #valueUnspecified>
+  <cvc-empty-value cvcEmptyCategory="unspecified"></cvc-empty-value>
+</ng-template>

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.module.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.module.ts
@@ -27,6 +27,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 import { CvcMolecularProfileTagModule } from '@app/components/molecular-profiles/molecular-profile-tag/molecular-profile-tag.module';
 import { CvcMolecularProfileTagNameModule } from '@app/components/molecular-profiles/molecular-profile-tag-name/molecular-profile-tag-name.module';
 import { CvcTherapyTagModule } from '@app/components/therapies/cvc-therapy-tag/cvc-therapy-tag.module';
+import { CvcEmptyValueModule } from '@app/components/shared/empty-value/empty-value.module';
 
 @NgModule({
   declarations: [EvidenceSummaryPage],
@@ -42,6 +43,7 @@ import { CvcTherapyTagModule } from '@app/components/therapies/cvc-therapy-tag/c
     NzIconModule,
     NzDescriptionsModule,
     NzToolTipModule,
+    CvcEmptyValueModule,
     CvcPipesModule,
     CvcEvidenceRatingModule,
     CvcDiseaseTagModule,

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
@@ -3,32 +3,35 @@
     <!-- LEFT COLUMN: evidence description, evidence attributes-->
     <nz-col [nzSpan]="12">
       <nz-row [nzGutter]="[8,8]">
-
         <!-- BLOCK: evidence description -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzLayout="vertical"
+          <nz-descriptions
+            nzLayout="vertical"
             nzSize="small"
             nzBordered="true">
             <nz-descriptions-item nzTitle="Statement">
-              <p nz-typography
+              <p
+                nz-typography
                 class="summary-block"
                 nzEllipsis
                 nzExpandable
-                [nzEllipsisRows]="6">{{ evidence.description }}</p>
+                [nzEllipsisRows]="6">
+                {{ evidence.description }}
+              </p>
             </nz-descriptions-item>
-
           </nz-descriptions>
         </nz-col>
 
         <!-- BLOCK: evidence attributes -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzSize="small"
+          <nz-descriptions
+            nzSize="small"
             [nzColumn]="{ xxl: 3, xl: 2, lg: 1, md: 1, sm: 1, xs: 1 }"
             nzBordered="true">
-
             <!-- evidence type -->
             <nz-descriptions-item nzTitle="Type">
-              <cvc-attribute-tag cvcAttrName="evidenceType"
+              <cvc-attribute-tag
+                cvcAttrName="evidenceType"
                 [cvcAttrValue]="evidence.evidenceType"
                 iconPropertyType="type"
                 nz-tooltip
@@ -38,7 +41,9 @@
 
             <!-- evidence direction -->
             <nz-descriptions-item nzTitle="Direction">
-              <cvc-attribute-tag [cvcAttrValue]="evidence.evidenceDirection"
+              <cvc-attribute-tag
+                *ngIf="evidence.evidenceDirection !== 'NA'; else valueNotApplicable"
+                [cvcAttrValue]="evidence.evidenceDirection"
                 nz-tooltip
                 [nzTooltipTitle]="evidence.evidenceDirection | enumTooltip:'evidenceDirection':evidence.evidenceType:'EvidenceItem'">
               </cvc-attribute-tag>
@@ -46,7 +51,9 @@
 
             <!-- significance -->
             <nz-descriptions-item nzTitle="Significance">
-              <cvc-attribute-tag [cvcAttrValue]="evidence.significance"
+              <cvc-attribute-tag
+                *ngIf="evidence.evidenceDirection !== 'NA'; else valueNotApplicable"
+                [cvcAttrValue]="evidence.significance"
                 nz-tooltip
                 [nzTooltipTitle]="evidence.significance | enumTooltip:'significance':evidence.evidenceType:'EvidenceItem'">
               </cvc-attribute-tag>
@@ -54,7 +61,8 @@
 
             <!-- variant origin -->
             <nz-descriptions-item nzTitle="Variant Origin">
-              <cvc-attribute-tag [cvcAttrValue]="evidence.variantOrigin"
+              <cvc-attribute-tag
+                [cvcAttrValue]="evidence.variantOrigin"
                 nz-tooltip
                 [nzTooltipTitle]="evidence.variantOrigin | enumTooltip:'variantOrigin'">
               </cvc-attribute-tag>
@@ -62,24 +70,28 @@
 
             <!-- evidence level -->
             <nz-descriptions-item nzTitle="Level">
-              <nz-tag nz-tooltip
+              <nz-tag
+                nz-tooltip
                 [nzTooltipTitle]="evidence.evidenceLevel | enumTooltip:'evidenceLevel'">
-                <strong>{{ evidence.evidenceLevel  }}</strong> - {{ evidence.evidenceLevel | enumTooltip:'evidenceLevelBrief' }}
+                <strong>{{ evidence.evidenceLevel }}</strong> - {{
+                evidence.evidenceLevel | enumTooltip:'evidenceLevelBrief' }}
               </nz-tag>
             </nz-descriptions-item>
 
             <!-- evidence rating -->
             <nz-descriptions-item nzTitle="Rating">
-              <nz-tag nz-tooltip
+              <nz-tag
+                nz-tooltip
                 [nzTooltipTitle]="evidence.evidenceRating | enumTooltip:'evidenceRating'">
-                <cvc-evidence-rating [starRating]="evidence.evidenceRating"></cvc-evidence-rating>
+                <cvc-evidence-rating
+                  [starRating]="evidence.evidenceRating"></cvc-evidence-rating>
               </nz-tag>
             </nz-descriptions-item>
-
           </nz-descriptions>
         </nz-col>
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzSize="small"
+          <nz-descriptions
+            nzSize="small"
             nzBordered="true"
             [nzColumn]="{ xxl: 2, xl: 1, lg: 1, md: 1, sm: 1, xs: 1 }">
             <!-- source -->
@@ -88,19 +100,17 @@
             </nz-descriptions-item>
 
             <!-- clinical trials -->
-            <nz-descriptions-item [nzTitle]="evidence.source.clinicalTrials.length > 1 ? 'Clinical Trials' : 'Clinical Trial'">
-              <ng-container *ngIf="evidence.source.clinicalTrials.length > 0">
+            <nz-descriptions-item
+              [nzTitle]="evidence.source.clinicalTrials.length > 1 ? 'Clinical Trials' : 'Clinical Trial'">
+              <ng-container
+                *ngIf="evidence.source.clinicalTrials.length > 0; else valueUnspecified">
                 <ng-container *ngFor="let t of evidence.source.clinicalTrials">
-                  <cvc-clinical-trial-tag [clinicalTrial]="t"></cvc-clinical-trial-tag>
+                  <cvc-clinical-trial-tag
+                    [clinicalTrial]="t"></cvc-clinical-trial-tag>
                 </ng-container>
-              </ng-container>
-              <ng-container *ngIf="evidence.source.clinicalTrials.length === 0">
-                <span nz-typography
-                  nzType="secondary">None Specified</span>
               </ng-container>
             </nz-descriptions-item>
           </nz-descriptions>
-
         </nz-col>
       </nz-row>
     </nz-col>
@@ -110,11 +120,11 @@
       <nz-row [nzGutter]="[8,8]">
         <!-- BLOCK: status, curation events -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzLayout="vertical"
+          <nz-descriptions
+            nzLayout="vertical"
             nzSize="small"
             [nzColumn]="{ xxl: 3, xl: 3, lg: 3, md: 1, sm: 1, xs: 1 }"
             nzBordered="true">
-
             <!-- status -->
             <nz-descriptions-item nzTitle="Status">
               <cvc-status-tag [status]="evidence.status"></cvc-status-tag>
@@ -123,99 +133,106 @@
             <!-- submit/accept/reject curation events -->
             <nz-descriptions-item [nzTitle]="submittedTitle">
               by
-              <cvc-user-tag [user]="evidence.submissionEvent.originatingUser"></cvc-user-tag>
+              <cvc-user-tag
+                [user]="evidence.submissionEvent.originatingUser"></cvc-user-tag>
             </nz-descriptions-item>
             <ng-template #submittedTitle>
               Submitted
-              <span nz-typography
+              <span
+                nz-typography
                 nzType="secondary">
                 ({{ evidence.submissionEvent.createdAt | timeago }})
               </span>
             </ng-template>
             <!-- TODO logic below is incorrect, see AID1 - must identify the latest accept/reject event, and display that -->
             <!-- display accepted/rejected only if either exists -->
-            <ng-container *ngIf="evidence.rejectionEvent !== null || evidence.acceptanceEvent !== null">
+            <ng-container
+              *ngIf="evidence.rejectionEvent !== null || evidence.acceptanceEvent !== null">
               <!-- show acceptance only if no rejection event exists -->
               <ng-container [ngSwitch]="evidence.rejectionEvent === null">
-                <nz-descriptions-item *ngSwitchCase="true"
+                <nz-descriptions-item
+                  *ngSwitchCase="true"
                   [nzTitle]="acceptedTitle">
                   by
-                  <cvc-user-tag [user]="evidence.acceptanceEvent.originatingUser"></cvc-user-tag>
+                  <cvc-user-tag
+                    [user]="evidence.acceptanceEvent.originatingUser"></cvc-user-tag>
                 </nz-descriptions-item>
                 <ng-template #acceptedTitle>
                   Accepted
-                  <span nz-typography
+                  <span
+                    nz-typography
                     nzType="secondary">
-                ({{ evidence.acceptanceEvent.createdAt| timeago }})
-              </span>
+                    ({{ evidence.acceptanceEvent.createdAt| timeago }})
+                  </span>
                 </ng-template>
-                <nz-descriptions-item *ngSwitchCase="false"
+                <nz-descriptions-item
+                  *ngSwitchCase="false"
                   nzTitle="Rejected">
                   by
-                  <cvc-user-tag [user]="evidence.rejectionEvent.originatingUser"></cvc-user-tag>
+                  <cvc-user-tag
+                    [user]="evidence.rejectionEvent.originatingUser"></cvc-user-tag>
                 </nz-descriptions-item>
                 <ng-template #rejectedTitle>
                   Rejected
-                  <span nz-typography
+                  <span
+                    nz-typography
                     nzType="secondary">
-                ({{ evidence.rejectionEvent.createdAt | timeago }})
-              </span>
+                    ({{ evidence.rejectionEvent.createdAt | timeago }})
+                  </span>
                 </ng-template>
               </ng-container>
             </ng-container>
-
           </nz-descriptions>
         </nz-col>
 
         <!-- BLOCK: evidence linked attributes -->
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzSize="small"
+          <nz-descriptions
+            nzSize="small"
             nzBordered="true"
             [nzColumn]="{ xxl: 2, xl: 1, lg: 1, md: 1, sm: 1, xs: 1 }">
             <!-- molecular profile -->
             <nz-descriptions-item nzTitle="Molecular Profile">
-              <cvc-molecular-profile-tag [molecularProfile]="evidence.molecularProfile" [enablePopover]="true"></cvc-molecular-profile-tag>
+              <cvc-molecular-profile-tag
+                [molecularProfile]="evidence.molecularProfile"
+                [enablePopover]="true"></cvc-molecular-profile-tag>
             </nz-descriptions-item>
 
             <!-- molecular profile expression -->
             <nz-descriptions-item nzTitle="MP Expression">
-              <cvc-mp-tag-name [nameSegments]="evidence.molecularProfile.parsedName"></cvc-mp-tag-name>
+              <cvc-mp-tag-name
+                [nameSegments]="evidence.molecularProfile.parsedName"></cvc-mp-tag-name>
             </nz-descriptions-item>
 
             <!-- disease -->
             <nz-descriptions-item nzTitle="Disease">
-              <ng-container *ngIf="evidence.disease">
+              <ng-container *ngIf="evidence.disease; else valueNotApplicable">
                 <a routerLink="/diseases/{{evidence.disease.id}}">
-                  <cvc-disease-tag [disease]="evidence.disease"></cvc-disease-tag>
+                  <cvc-disease-tag
+                    [disease]="evidence.disease"></cvc-disease-tag>
                 </a>
               </ng-container>
-              <span *ngIf="!evidence.disease"
-                nz-typography
-                nzType="secondary">N/A</span>
             </nz-descriptions-item>
 
             <!-- phenotypes -->
-            <nz-descriptions-item [nzTitle]="evidence.phenotypes.length > 1 ? 'Phenotypes' : 'Phenotype'">
-              <ng-container *ngIf="evidence.phenotypes.length > 0; else noPhenotypes">
-                <cvc-tag-list>
-                  <ng-container *ngFor="let ph of evidence.phenotypes">
-                    <cvc-phenotype-tag [phenotype]="ph"></cvc-phenotype-tag>
-                  </ng-container>
-                </cvc-tag-list>
-              </ng-container>
-              <ng-template #noPhenotypes>
-                <span nz-typography
-                  nzType="secondary">None Specified</span>
-              </ng-template>
+            <nz-descriptions-item
+              [nzTitle]="evidence.phenotypes.length > 1 ? 'Phenotypes' : 'Phenotype'">
+              <cvc-tag-list
+                *ngIf="evidence.phenotypes.length > 0; else valueUnspecified">
+                <ng-container *ngFor="let ph of evidence.phenotypes">
+                  <cvc-phenotype-tag [phenotype]="ph"></cvc-phenotype-tag>
+                </ng-container>
+              </cvc-tag-list>
             </nz-descriptions-item>
 
             <!-- therapies -->
-            <nz-descriptions-item [nzTitle]="evidence.therapies.length > 1 ? 'Therapies' : 'Therapy'">
+            <nz-descriptions-item
+              [nzTitle]="evidence.therapies.length > 1 ? 'Therapies' : 'Therapy'">
               <ng-container [ngPlural]="evidence.therapies.length">
                 <!-- no drug -->
                 <ng-template ngPluralCase="=0">
-                  <span nz-typography
-                    nzType="secondary">N/A</span>
+                  <ng-container
+                    [ngTemplateOutlet]="valueNotApplicable"></ng-container>
                 </ng-template>
 
                 <!-- one or more drugs -->
@@ -227,25 +244,29 @@
                   </cvc-tag-list>
                 </ng-template>
               </ng-container>
-
             </nz-descriptions-item>
-            <nz-descriptions-item *ngIf="evidence.therapyInteractionType"
+            <nz-descriptions-item
+              *ngIf="evidence.therapyInteractionType"
               nzTitle="Therapy Interaction Type">
               {{ evidence.therapyInteractionType | titlecase }}
             </nz-descriptions-item>
-
-
           </nz-descriptions>
         </nz-col>
       </nz-row>
-
     </nz-col>
 
     <!-- ASSERTIONS TABLE -->
     <nz-col [nzSpan]="24">
-      <cvc-assertions-table [evidenceId]="evidence.id"
+      <cvc-assertions-table
+        [evidenceId]="evidence.id"
         cvcTitle="{{evidence.name}} Assertions">
       </cvc-assertions-table>
     </nz-col>
   </nz-row>
 </ng-container>
+<ng-template #valueNotApplicable>
+  <cvc-empty-value cvcEmptyCategory="not-applicable"></cvc-empty-value>
+</ng-template>
+<ng-template #valueUnspecified>
+  <cvc-empty-value cvcEmptyCategory="unspecified"></cvc-empty-value>
+</ng-template>

--- a/client/src/app/views/molecular-profiles/molecular-profiles-detail/molecular-profiles-summary/molecular-profiles-summary.module.ts
+++ b/client/src/app/views/molecular-profiles/molecular-profiles-detail/molecular-profiles-summary/molecular-profiles-summary.module.ts
@@ -21,6 +21,7 @@ import { CvcGeneTagModule } from '@app/components/genes/gene-tag/gene-tag.module
 import { MolecularProfilesSummaryPage } from './molecular-profiles-summary.page';
 import { CvcMolecularProfileTagNameModule } from '@app/components/molecular-profiles/molecular-profile-tag-name/molecular-profile-tag-name.module';
 import { CvcMolecularProfileVariantCardModule } from '@app/components/molecular-profiles/molecular-profile-variant-card/molecular-profile-variant-card.module';
+import { CvcEmptyValueModule } from '@app/components/shared/empty-value/empty-value.module';
 
 @NgModule({
   declarations: [MolecularProfilesSummaryPage],
@@ -34,6 +35,7 @@ import { CvcMolecularProfileVariantCardModule } from '@app/components/molecular-
     NzTypographyModule,
     NzIconModule,
     NzTagModule,
+    CvcEmptyValueModule,
     CvcPipesModule,
     CvcEvidenceTableModule,
     CvcAssertionsTableModule,

--- a/client/src/app/views/molecular-profiles/molecular-profiles-detail/molecular-profiles-summary/molecular-profiles-summary.page.html
+++ b/client/src/app/views/molecular-profiles/molecular-profiles-detail/molecular-profiles-summary/molecular-profiles-summary.page.html
@@ -3,50 +3,50 @@
   <nz-row [nzGutter]="[8,16]">
     <!-- molecular profile attributes block -->
     <nz-col [nzSpan]="24">
-
       <nz-row [nzGutter]="[8,8]">
         <nz-col [nzSpan]="24">
-
-          <nz-descriptions nzSize="small"
+          <nz-descriptions
+            nzSize="small"
             nzBordered="true"
             [nzColumn]="1"
             nzLayout="vertical">
-            <nz-descriptions-item nzTitle="MP Expression"
+            <nz-descriptions-item
+              nzTitle="MP Expression"
               [nzSpan]="1">
               <cvc-mp-tag-name [nameSegments]="mp.parsedName"></cvc-mp-tag-name>
             </nz-descriptions-item>
           </nz-descriptions>
         </nz-col>
         <nz-col [nzSpan]="24">
-          <nz-descriptions nzSize="small"
+          <nz-descriptions
+            nzSize="small"
             nzBordered="true"
             [nzColumn]="2"
             nzLayout="vertical">
-
             <nz-descriptions-item nzTitle="Description">
-              <p *ngIf="mp.description; else noDescription"
+              <p
+                *ngIf="mp.description; else noDescription"
                 nz-typography
                 nzEllipsis
                 nzExpandable
-                [nzEllipsisRows]="14">{{ mp.description }}</p>
+                [nzEllipsisRows]="14">
+                {{ mp.description }}
+              </p>
 
               <ng-template #noDescription>
-                <cvc-empty-revisable notification="No description provided"> </cvc-empty-revisable>
+                <cvc-empty-revisable notification="No description provided">
+                </cvc-empty-revisable>
               </ng-template>
             </nz-descriptions-item>
 
             <nz-descriptions-item nzTitle="Sources">
-              <ng-container *ngIf="mp.sources.length > 0; else noSources">
-                <cvc-tag-list>
-                  <cvc-source-tag *ngFor="let source of mp.sources"
-                    [source]="source">
-                  </cvc-source-tag>
-                </cvc-tag-list>
-              </ng-container>
-              <ng-template #noSources>
-                <span nz-typography
-                  nzType="secondary">None specified</span>
-              </ng-template>
+              <cvc-tag-list
+                *ngIf="mp.sources.length > 0; else valueUnspecified">
+                <cvc-source-tag
+                  *ngFor="let source of mp.sources"
+                  [source]="source">
+                </cvc-source-tag>
+              </cvc-tag-list>
             </nz-descriptions-item>
 
             <!-- CIViC Score-->
@@ -56,19 +56,14 @@
 
             <!-- aliases -->
             <nz-descriptions-item nzTitle="Aliases">
-              <ng-container *ngIf="mp.molecularProfileAliases.length > 0; else noAliases">
-                <cvc-tag-list>
-                  <nz-tag *ngFor="let alias of mp.molecularProfileAliases">{{ alias }}</nz-tag>
-                </cvc-tag-list>
-              </ng-container>
-              <ng-template #noAliases>
-                <span nz-typography
-                  nzType="secondary">None specified</span>
-              </ng-template>
+              <cvc-tag-list
+                *ngIf="mp.molecularProfileAliases.length > 0; else valueUnspecified">
+                <nz-tag *ngFor="let alias of mp.molecularProfileAliases"
+                  >{{ alias }}</nz-tag
+                >
+              </cvc-tag-list>
             </nz-descriptions-item>
-
           </nz-descriptions>
-
         </nz-col>
       </nz-row>
     </nz-col>
@@ -77,15 +72,20 @@
     <nz-col nzSpan="24">
       <nz-card nzTitle="MP Variants">
         <nz-row [nzGutter]="[8,8]">
-          <nz-col nzSpan="24" *ngFor="let v of mp.variants">
-            <cvc-mp-variant-card [variant]="v" [currentMolecularProfileId]="mp.id"></cvc-mp-variant-card>
+          <nz-col
+            nzSpan="24"
+            *ngFor="let v of mp.variants">
+            <cvc-mp-variant-card
+              [variant]="v"
+              [currentMolecularProfileId]="mp.id"></cvc-mp-variant-card>
           </nz-col>
         </nz-row>
       </nz-card>
     </nz-col>
     <!-- evidence table -->
     <nz-col nzSpan="24">
-      <cvc-evidence-table [molecularProfileId]="mp.id"
+      <cvc-evidence-table
+        [molecularProfileId]="mp.id"
         [displayMolecularProfile]="false"
         cvcHeight="300px"
         cvcTitle="Evidence">
@@ -95,10 +95,17 @@
     <!-- assertions table -->
 
     <nz-col nzSpan="24">
-      <cvc-assertions-table [molecularProfileId]="mp.id"
+      <cvc-assertions-table
+        [molecularProfileId]="mp.id"
         cvcHeight="200px"
         cvcTitle="{{mp.name}} Assertions">
       </cvc-assertions-table>
     </nz-col>
   </nz-row>
 </ng-container>
+<ng-template #valueNotApplicable>
+  <cvc-empty-value cvcEmptyCategory="not-applicable"></cvc-empty-value>
+</ng-template>
+<ng-template #valueUnspecified>
+  <cvc-empty-value cvcEmptyCategory="unspecified"></cvc-empty-value>
+</ng-template>


### PR DESCRIPTION
Direction and Significance N/A attribute displays on Evidence summaries now show a text 'Not applicable'. These attribute displays now use an empty-value component that can help standardize the display N/A, Unspecified, Missing messages throughout the app. I also similarly updated the rest of the Evidence attributes w/ potentially empty or N/A values and applied the same updates to Assertions and Molecular Profile summary templates.