### PR TITLE
adds aliases col to variant-select's manager table

### DIFF
--- a/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.component.html
+++ b/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.component.html
@@ -267,6 +267,7 @@
                   let-emphasize="emphasize">
                   <ng-container
                     *ngIf="data.length > 0; else emptyEntityTagCell">
+
                     <!-- display full size tags up to maxTags length -->
                     <cvc-entity-tag-list
                       [cvcTagTemplate]="entityTag"

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
@@ -409,7 +409,7 @@
                 *ngIf="col | guardType : colGuards.isDefaultCol as defaultCol"
                 [nzAlign]="defaultCol.align ?? 'left'"
                 [nzLeft]="defaultCol.fixedLeft || false"
-                [nzRight]="defaultCol.fixedRight || false">
+                [nzRight]="defaultCol.fixedRight || false" class="default-col-type">
                 <ng-container
                   *ngIf="row[defaultCol.key] as colData; else emptyDefaultCell">
                   <ng-container

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
@@ -386,7 +386,6 @@
                 [nzAlign]="textTagCol.align ?? 'left'"
                 [nzLeft]="textTagCol.fixedLeft || false"
                 [nzRight]="textTagCol.fixedRight || false">
-                <!-- TODO: show filter text emphasized in tooltip text -->
                 <nz-tag
                   *ngIf="row[textTagCol.key]; else emptyTextTagCell"
                   nz-tooltip
@@ -417,7 +416,8 @@
                     *ngTemplateOutlet="
                       (colData | isArray) ? staticList : staticValue;
                       context: {
-                        $implicit: colData
+                        $implicit: colData,
+                        emphasize: (defaultCol.filter.changes | ngrxPush)?.value
                       }
                     ">
                   </ng-container>
@@ -425,14 +425,16 @@
 
                 <ng-template
                   #staticList
-                  let-array>
+                  let-array
+                  let-emphasize="emphasize">
                   <ng-container *ngIf="array.length > 0; else emptyDefaultCell">
                     <ng-container *ngFor="let value of array; last as last">
                       <ng-container
                         *ngTemplateOutlet="
                           staticValue;
                           context: {
-                            $implicit: value
+                            $implicit: value,
+                            emphasize: emphasize
                           }
                         ">
                       </ng-container
@@ -443,17 +445,15 @@
 
                 <ng-template
                   #staticValue
-                  let-value>
-                  <ng-container
-                    *ngIf="!defaultCol.objectKey; else useObjectKey"
-                    >{{ value }}</ng-container
-                  >
-
-                  <ng-template #useObjectKey>
-                    <ng-container *ngIf="defaultCol.objectKey">{{
-                      value[defaultCol.objectKey]
-                    }}</ng-container>
-                  </ng-template>
+                  let-value
+                  let-emphasize="emphasize">
+                  <span
+                    [innerHtml]="
+                      (defaultCol.objectKey
+                        ? value[defaultCol.objectKey]
+                        : value
+                      ) | highlightTypeahead : emphasize
+                    "></span>
                 </ng-template>
 
                 <ng-template #emptyDefaultCell>

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
@@ -84,6 +84,19 @@
               [nzTooltipTitle]="textTagCol.tooltip">
               {{ textTagCol.label }}
             </th>
+
+            <!-- DEFAULT TAG HEADER -->
+            <th
+              *ngIf="col | guardType : colGuards.isDefaultCol as defaultCol"
+              [nzColumnKey]="defaultCol.key"
+              [nzAlign]="defaultCol.align ?? 'left'"
+              [nzWidth]="defaultCol.width"
+              [nzLeft]="defaultCol.fixedLeft || false"
+              [nzRight]="defaultCol.fixedRight || false"
+              nz-tooltip
+              [nzTooltipTitle]="defaultCol.tooltip">
+              {{ defaultCol.label }}
+            </th>
           </ng-container>
         </ng-container>
       </tr>
@@ -206,6 +219,24 @@
                   </div>
                 </div>
               </nz-dropdown-menu>
+            </th>
+
+            <!-- DEFAULT TAG FILTER -->
+            <th
+              *ngIf="col | guardType : colGuards.isDefaultCol as defaultCol"
+              [nzColumnKey]="defaultCol.key"
+              [nzWidth]="defaultCol.width"
+              [nzAlign]="defaultCol.align ?? 'left'"
+              [nzLeft]="defaultCol.fixedLeft || false"
+              [nzRight]="defaultCol.fixedRight || false">
+              <cvc-table-filter-input
+                *ngIf="defaultCol.filter as filter"
+                [cvcPlaceholder]="defaultCol.filter.options[0].key"
+                [cvcModel]="defaultCol.filter.options[0].value"
+                (cvcModelChange)="
+                  filter.changes!.next({ key: defaultCol.key, value: $event })
+                ">
+              </cvc-table-filter-input>
             </th>
           </ng-container>
         </ng-container>
@@ -370,6 +401,65 @@
                   <cvc-empty-value
                     [cvcEmptyCategory]="
                       textTagCol.emptyValueCategory || 'unspecified'
+                    "></cvc-empty-value>
+                </ng-template>
+              </td>
+
+              <!-- DEFAULT CELL -->
+              <td
+                *ngIf="col | guardType : colGuards.isDefaultCol as defaultCol"
+                [nzAlign]="defaultCol.align ?? 'left'"
+                [nzLeft]="defaultCol.fixedLeft || false"
+                [nzRight]="defaultCol.fixedRight || false">
+                <ng-container
+                  *ngIf="row[defaultCol.key] as colData; else emptyDefaultCell">
+                  <ng-container
+                    *ngTemplateOutlet="
+                      (colData | isArray) ? staticList : staticValue;
+                      context: {
+                        $implicit: colData
+                      }
+                    ">
+                  </ng-container>
+                </ng-container>
+
+                <ng-template
+                  #staticList
+                  let-array>
+                  <ng-container *ngIf="array.length > 0; else emptyDefaultCell">
+                    <ng-container *ngFor="let value of array; last as last">
+                      <ng-container
+                        *ngTemplateOutlet="
+                          staticValue;
+                          context: {
+                            $implicit: value
+                          }
+                        ">
+                      </ng-container
+                      ><ng-container *ngIf="!last">, </ng-container>
+                    </ng-container>
+                  </ng-container>
+                </ng-template>
+
+                <ng-template
+                  #staticValue
+                  let-value>
+                  <ng-container
+                    *ngIf="!defaultCol.objectKey; else useObjectKey"
+                    >{{ value }}</ng-container
+                  >
+
+                  <ng-template #useObjectKey>
+                    <ng-container *ngIf="defaultCol.objectKey">{{
+                      value[defaultCol.objectKey]
+                    }}</ng-container>
+                  </ng-template>
+                </ng-template>
+
+                <ng-template #emptyDefaultCell>
+                  <cvc-empty-value
+                    [cvcEmptyCategory]="
+                      defaultCol.emptyValueCategory || 'unspecified'
                     "></cvc-empty-value>
                 </ng-template>
               </td>

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.less
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.less
@@ -6,6 +6,13 @@ tr.data-row td:first-of-type {
     margin-left: 6px;
   }
 }
+// FIXME: overflow also needs to include a overflow count and popover with omitted items,
+// this is just a temporary visual fix to prevent content overlapping the adjacent cell
+td.default-col-type {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .ant-table-filter-dropdown {
   padding: 8px;
 }

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.config.ts
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.config.ts
@@ -1,27 +1,19 @@
 import { formatEvidenceEnum } from '@app/core/utilities/enum-formatters/format-evidence-enum'
 import { CvcInputEnum } from '@app/forms2/forms2.types'
 import {
-  EvidenceDirection,
-  EvidenceLevel,
-  EvidenceSignificance,
-  EvidenceSortColumns,
-  EvidenceType,
-  TherapyInteraction,
-  VariantsSortColumns,
+    VariantsSortColumns
 } from '@app/generated/civic.apollo'
 import { NzTableFilterList } from 'ng-zorro-antd/table'
 import { BehaviorSubject, Observable } from 'rxjs'
 import { tag } from 'rxjs-spy/operators'
-import { $enum, EnumWrapper } from 'ts-enum-util'
+import { EnumWrapper } from 'ts-enum-util'
 import {
-  CvcFilterChange,
-  CvcSortChange,
-  VariantManagerColKey,
-  VariantManagerColQueryMap,
-  VariantManagerColSortMap,
-  VariantManagerTableConfig,
-  hasFilterOptions,
-  hasSortOptions,
+    CvcFilterChange,
+    CvcSortChange, hasFilterOptions,
+    hasSortOptions, VariantManagerColKey,
+    VariantManagerColQueryMap,
+    VariantManagerColSortMap,
+    VariantManagerTableConfig
 } from './variant-manager.types'
 
 // export enum VariantsSortColumns {
@@ -82,11 +74,11 @@ export class VariantManagerConfig {
         },
       },
       {
-        hidden: true,
         key: 'id',
         label: 'ID',
-        type: 'default',
-        width: '30px',
+        hidden: true,
+        type: 'hidden',
+        width: '0px',
       },
       {
         key: 'variant',
@@ -106,6 +98,18 @@ export class VariantManagerConfig {
         filter: {
           inputType: 'default',
           options: [{ key: 'Filter Variant Name', value: null }],
+        },
+      },
+      {
+        key: 'aliases',
+        label: 'Aliases',
+        type: 'default',
+        width: '150px',
+        objectKey: 'name',
+        sort: {},
+        filter: {
+          inputType: 'default',
+          options: [{ key: 'Filter Aliases', value: null }],
         },
       },
       {

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.config.ts
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.config.ts
@@ -37,7 +37,8 @@ export const columnKeyToQueryVariableMap: VariantManagerColQueryMap = {
   diseases: 'diseaseName',
   therapies: 'therapyName',
   variant: 'variantName',
-  gene: 'entrezSymbol'
+  gene: 'entrezSymbol',
+  aliases: 'variantAlias'
 }
 
 // colum keys included here will be hidden in preference panel, preventing

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.types.ts
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.types.ts
@@ -75,6 +75,7 @@ export type ConvertedQueryVar = keyof Pick<
   | 'diseaseName'
   | 'therapyName'
   | 'entrezSymbol'
+  | 'variantAlias'
 >
 
 // convenience type for various map keys

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.types.ts
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.types.ts
@@ -44,7 +44,7 @@ export type VariantManagerConnection = VariantManagerQuery['browseVariants']
 
 // additional columns added to row data for table templates, logic
 type VariantManagerRowDataExtra = {
-  variant: Pick<BrowseVariant, 'id' | 'name' | 'link'>,
+  variant: Pick<BrowseVariant, 'id' | 'name' | 'link'>
   // need evidence object for entity tag in selectEntity column
   gene: Pick<Gene, 'id' | 'name' | 'link'>
   // additional boolean column to handle row selected state
@@ -83,10 +83,11 @@ export type VariantManagerColKey = keyof VariantManagerRowData
 // each col type has different settings for nz-table features, e.g. filter/sort
 // and cvc-variant-manager features, e.g. entity-tag display options
 export type VariantManagerColType =
+  | 'default' // short strings, e.g. labels, counts
+  | 'hidden' // hidden column, e.g. id
   | 'select' // select column, displays checkboxes for row selection
   | 'entity-tag' // display col value with entity-tag
   | 'enum-tag' // display cell data w/ attribute-tag
-  | 'default' // short strings, e.g. labels, counts
   | 'text-tag' // long strings or simple sanitized HTML, e.g. descriptions, summaries
 
 export type VariantManagerColSortMap = {
@@ -166,6 +167,12 @@ interface FixedConfig {
   fixedRight?: true
 }
 
+// provides a key to pluck a value from a column object,
+// currently only used by default col to display static values on objects
+interface ObjectKeyConfig {
+  objectKey?: string
+}
+
 interface TagConfig {
   tag?: {
     showLabel?: EnumOutputStyle | boolean
@@ -197,14 +204,25 @@ interface TextTagConfig {
 interface EnumTagConfig {}
 
 export type ColumnConfig =
+  | DefaultColumnType
+  | HiddenColumnType
   | SelectColumnType
   | EntityTagType
   | EnumTagType
-  | DefaultColumnType
   | TextTagType
 
-export interface DefaultColumnType extends BaseColumnConfig, FixedConfig {
+export interface DefaultColumnType
+  extends BaseColumnConfig,
+    FixedConfig,
+    InputFilterConfig,
+    SortConfig,
+    ObjectKeyConfig {
   type: 'default'
+}
+
+export interface HiddenColumnType extends BaseColumnConfig {
+  type: 'hidden'
+  hidden: true
 }
 
 // displays a checkbox for the table's select feature
@@ -282,6 +300,10 @@ export const isDefaultColumn: TypeGuard<ColumnConfig, DefaultColumnType> = (
   option: ColumnConfig
 ): option is DefaultColumnType => option.type === 'default'
 
+export const isHiddenColumn: TypeGuard<ColumnConfig, HiddenColumnType> = (
+  option: ColumnConfig
+): option is HiddenColumnType => option.type === 'hidden'
+
 export const isSelectColumn: TypeGuard<ColumnConfig, SelectColumnType> = (
   option: ColumnConfig
 ): option is SelectColumnType => option.type === 'select'
@@ -299,6 +321,7 @@ export const isTextTagOptions: TypeGuard<ColumnConfig, TextTagType> = (
 ): option is TextTagType => option.type === 'text-tag'
 
 export const colTypeGuards = {
+  isDefaultCol: isDefaultColumn,
   isSelectCol: isSelectColumn,
   isEntityTagCol: isEntityTagOptions,
   isEnumTagCol: isEnumTagOptions,

--- a/client/src/app/forms2/types/variant-select/variant-select.type.ts
+++ b/client/src/app/forms2/types/variant-select/variant-select.type.ts
@@ -136,7 +136,7 @@ export class CvcVariantSelectField
     this.onVid$ = new ReplaySubject<Maybe<number[]>>()
     this.onShowMgrClick$ = new Subject<void>()
     this.showMgr$ = this.onShowMgrClick$.pipe(
-      // startWith(true),
+      startWith(true),
       scan((acc, _) => !acc, false)
     )
   }


### PR DESCRIPTION
The col still needs an overflow counter and popover to display the omitted aliases - currently overflow is handled with CSS ellipsis. At least users can now filter by alias, bringing the table mostly up to par w/ the current variant table in select mode.