### PR TITLE
Do not validate the subject of a Flag when a Flag is created

### DIFF
--- a/server/app/models/actions/flag_entity.rb
+++ b/server/app/models/actions/flag_entity.rb
@@ -30,7 +30,7 @@ module Actions
 
     def mark_as_flagged
       flaggable.flagged = true
-      flaggable.save!
+      flaggable.save!(validate: false)
     end
 
     def create_comment

--- a/server/app/models/flag.rb
+++ b/server/app/models/flag.rb
@@ -1,7 +1,7 @@
 class Flag < ActiveRecord::Base
   include Commentable
 
-  belongs_to :flaggable, polymorphic: true
+  belongs_to :flaggable, polymorphic: true, validate: false
   belongs_to :flagging_user, class_name: 'User'
   belongs_to :resolving_user, class_name: 'User', required: false
 


### PR DESCRIPTION
As is the case in #803, they may be flagging the very thing that makes the entity invalid.

Closes #803 