### PR TITLE
entity-select dropdowns now limited to select width

### DIFF
--- a/client/src/app/forms2/components/entity-select/entity-select.component.html
+++ b/client/src/app/forms2/components/entity-select/entity-select.component.html
@@ -3,7 +3,7 @@
   nzServerSearch
   nzAllowClear
   [class.ng-dirty]="cvcShowError"
-  [nzDropdownMatchSelectWidth]="false"
+  [nzDropdownMatchSelectWidth]="true"
   [formControl]="cvcFormControl"
   [formlyAttributes]="cvcFormlyAttributes"
   [nzMode]="cvcSelectMode"

--- a/client/src/app/forms2/types/disease-select/disease-select.type.html
+++ b/client/src/app/forms2/types/disease-select/disease-select.type.html
@@ -46,6 +46,8 @@
             <span
               nz-typography
               nzType="secondary"
+              nz-tooltip
+              [nzTooltipTitle]="result.diseaseAliases.join(', ')"
               [innerHtml]="
                 result.diseaseAliases.join(', ')
                   | highlightTypeahead : searchString

--- a/client/src/app/forms2/types/disease-select/disease-select.type.less
+++ b/client/src/app/forms2/types/disease-select/disease-select.type.less
@@ -1,6 +1,0 @@
-.option-container {
-    // max-width: 800px;
-    // border: 1px solid red;
-    // overflow:hidden;
-    // text-overflow: ellipsis;
-}

--- a/client/src/app/forms2/types/disease-select/disease-select.type.less
+++ b/client/src/app/forms2/types/disease-select/disease-select.type.less
@@ -1,0 +1,6 @@
+.option-container {
+    // max-width: 800px;
+    // border: 1px solid red;
+    // overflow:hidden;
+    // text-overflow: ellipsis;
+}

--- a/client/src/app/forms2/types/gene-select/gene-select.type.html
+++ b/client/src/app/forms2/types/gene-select/gene-select.type.html
@@ -33,6 +33,8 @@
             <span
               nz-typography
               nzType="secondary"
+              nz-tooltip
+              [nzTooltipTitle]="result.geneAliases.join(', ')"
               [innerHtml]="
                 result.geneAliases.join(', ')
                   | highlightTypeahead : searchString

--- a/client/src/app/forms2/types/therapy-select/therapy-select.type.html
+++ b/client/src/app/forms2/types/therapy-select/therapy-select.type.html
@@ -38,11 +38,13 @@
             "></span>
         </ng-container>
         <ng-container *ngIf="result.therapyAliases.length > 0">
-          Aliases:
+          <strong>Aliases: </strong>
           <em>
             <span
               nz-typography
               nzType="secondary"
+              nz-tooltip
+              [nzTooltipTitle]="result.therapyAliases.join(', ')"
               [innerHtml]="
                 result.therapyAliases.join(', ')
                   | highlightTypeahead : searchString

--- a/client/src/app/forms2/types/variant-select/variant-select.type.html
+++ b/client/src/app/forms2/types/variant-select/variant-select.type.html
@@ -61,12 +61,14 @@
       <span
         nz-typography
         nzType="secondary">
-        Aliases:
+        <strong>Aliases:</strong>
         <ng-container *ngIf="result.variantAliases.length > 0; else noAliases">
           <em>
             <span
               nz-typography
               nzType="secondary"
+              nz-tooltip
+              [nzTooltipTitle]="result.variantAliases.join(', ')"
               [innerHtml]="
                 result.variantAliases.join(', ')
                   | highlightTypeahead : searchString


### PR DESCRIPTION
This prevents them from unsightly resizing/repositioining to display options w/ many aliases. Overflow text like aliases now provide a tooltip to view all the option contents.

Closes #789 