### PR TITLE
molecular-profile select field UX improvements

### DIFF
--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
@@ -1,6 +1,5 @@
 <nz-row [nzGutter]="[8, 12]">
-  <nz-col
-    nzFlex="auto">
+  <nz-col nzFlex="auto">
     <ng-container *ngrxLet="selectDisplay$ as display">
       <cvc-mp-finder
         *ngIf="display.showFinder && !editorOpen"
@@ -18,26 +17,30 @@
         </span>
       </div>
 
-      <cvc-entity-select
-        *ngIf="display.showSelect"
-        [cvcSelectMode]="props.isMultiSelect ? 'multiple' : 'default'"
-        [cvcCustomTemplate]="selectedTemplate"
-        [cvcFormControl]="formControl"
-        [cvcFormlyAttributes]="field"
-        [cvcEntityName]="props.entityName"
-        [cvcPlaceholder]="props.placeholder"
-        [cvcResults]="result$ | ngrxPush"
-        [cvcDisabled]="props.disabled"
-        [cvcAllowClear]="false"
-        [cvcOptions]="selectOption$ | ngrxPush"
-        [cvcShowError]="showError"
-        [cvcLoading]="isLoading$ | ngrxPush"
-        [cvcBorderless]="true"
-        [cvcSuffixIcon]="null"
-        [cvcShowArrow]="false"
-        (cvcOnSearch)="onSearch$.next($event)"
-        (cvcOnModelChange)="props.change && props.change(field, $event)">
-      </cvc-entity-select>
+      <!-- using inline-block here to shrink select to size of its tag contents,
+      reducing the changes a user will click within it and cause the search dropdown to appear -->
+      <div style="display: inline-block">
+        <cvc-entity-select
+          *ngIf="display.showSelect"
+          [cvcSelectMode]="props.isMultiSelect ? 'multiple' : 'default'"
+          [cvcCustomTemplate]="selectedTemplate"
+          [cvcFormControl]="formControl"
+          [cvcFormlyAttributes]="field"
+          [cvcEntityName]="props.entityName"
+          [cvcPlaceholder]="props.placeholder"
+          [cvcResults]="result$ | ngrxPush"
+          [cvcDisabled]="props.disabled"
+          [cvcAllowClear]="false"
+          [cvcOptions]="selectOption$ | ngrxPush"
+          [cvcShowError]="showError"
+          [cvcLoading]="isLoading$ | ngrxPush"
+          [cvcBorderless]="true"
+          [cvcSuffixIcon]="null"
+          [cvcShowArrow]="false"
+          (cvcOnSearch)="onSearch$.next($event)"
+          (cvcOnModelChange)="props.change && props.change(field, $event)">
+        </cvc-entity-select>
+      </div>
     </ng-container>
   </nz-col>
   <nz-col nzFlex="50px">


### PR DESCRIPTION
Updates the molecular-profile-select field with several UX improvements.

This initial commit includes a workaround for the dropdown menu appearing if a selected tag's background is clicked. It's not quite a fix b/c it does not prevent a click on the select area's background from displaying a dropdown. However, it swiches the select's display mode to inline, causing it to wrap more tightly around the tag, thus reducing the changes a user will click the background instead of the tag's close btn. An actual fix would require switching out the select for a simple tag display, which I wanted to avoid in order to faciliate a single and muli mp mode using the same component as we do with other fields.