### PR TITLE
mp-select field UX improvements

### DIFF
--- a/client/src/app/core/utilities/molecular-profile-parser.ts
+++ b/client/src/app/core/utilities/molecular-profile-parser.ts
@@ -87,7 +87,8 @@ function parseSection(section: string): MpParseResult {
         return {
           errorMessage:
             'Expression may not include both AND/OR within a single segment.',
-          errorHelp: 'Segments may only contain identical boolean operators. Use parentheses to group form segments with consistent AND/OR operators.'
+          errorHelp:
+            'Segments may only contain identical boolean operators. Use parentheses to group form segments with consistent AND/OR operators.',
         }
       }
     }
@@ -100,10 +101,18 @@ function parseSection(section: string): MpParseResult {
   for (let token of segments.map((s) => s.trim())) {
     let matchData = variantToken.exec(token)
     if (matchData === null) {
+      // NOTE: empty token at this point appears to only occur when a paren is the last character in the expression
+      if (token.length === 0) {
+        return {
+          errorMessage: `Expression appears to be incomplete.`,
+          errorHelp: 'Ensure that all parentheses are balanced.',
+        }
+      }
       if (token !== exprPlaceholder) {
         return {
           errorMessage: `Variant '${token}' does not match the expected format.`,
-          errorHelp: 'The token should be a #VID prepended with an optional NOT.'
+          errorHelp:
+            'The token should be a #VID prepended with an optional NOT.',
         }
       }
     } else {

--- a/client/src/app/core/utilities/molecular-profile-parser.ts
+++ b/client/src/app/core/utilities/molecular-profile-parser.ts
@@ -12,14 +12,14 @@ const whitespace = /\s+/
 const exprPlaceholder = 'EXPR'
 
 export type MpParseErrorType =
-  | 'invalidVariant'
-  | 'trailingBoolean'
-  | 'initialBoolean'
-  | 'multipleBoolean'
-  | 'incompleteNOT'
-  | 'trailingNOT'
   | 'incompleteExpression'
+  | 'incompleteNOT'
+  | 'initialBoolean'
+  | 'invalidToken'
+  | 'multipleBoolean'
   | 'queryError'
+  | 'trailingBoolean'
+  | 'trailingNOT'
 
 export interface MpParseError {
   errorType: MpParseErrorType
@@ -86,7 +86,7 @@ function parseSection(section: string): MpParseResult {
     errorType: 'multipleBoolean',
     errorMessage: 'Multiple boolean operators found.',
     errorHelp:
-      'AND / OR boolean operators may not be used multiple times in a single expression.',
+      'AND / OR boolean operators may not be used multiple times within a single expression.',
   }
   // FIXME: this error is returned whenever an unbalanced paren is present, even if it is not the last token
   // so this error is displayed when sub-expressions are being entered, which could be confusing.
@@ -130,7 +130,7 @@ function parseSection(section: string): MpParseResult {
       if (token.length === 0) {
         return incompleteExpressionError
       }
-      // incomplete VID
+      // incomplete VIDs
       if (token === 'NOT' || token.split(' ').pop() === 'NOT') {
         return {
           errorType: 'incompleteNOT',
@@ -139,12 +139,13 @@ function parseSection(section: string): MpParseResult {
             'Ensure that NOT operators are followed by a valid Variant token.',
         }
       }
+
       if (token !== exprPlaceholder) {
         return {
-          errorType: 'invalidVariant',
-          errorMessage: `Variant '${token}' does not match the expected format.`,
+          errorType: 'invalidToken',
+          errorMessage: `Token '${token}' does not match the expected format.`,
           errorHelp:
-            'The token should be a #VID prepended with an optional NOT.',
+            'The token should be a #VID followed by a Variant ID, or an AND/OR boolean.',
         }
       }
     } else {

--- a/client/src/app/core/utilities/molecular-profile-parser.ts
+++ b/client/src/app/core/utilities/molecular-profile-parser.ts
@@ -13,6 +13,7 @@ const exprPlaceholder = 'EXPR'
 
 export interface MpParseError {
   errorMessage: string
+  errorHelp?: string
 }
 
 export type MpParseResult = MpParseError | MolecularProfileComponentInput
@@ -64,13 +65,18 @@ function parseSection(section: string): MpParseResult {
     let isBool = booleanToken.test(token)
     if (isBool && i == tokens.length - 1) {
       return {
-        errorMessage:
-          'Trailing boolean operator found. You cannot end your profile with an operator.',
+        errorMessage: 'Trailing AND/OR operator found.',
+        errorHelp:
+          'Boolean operators may not be used at the end of an expression.',
       }
     }
 
     if (isBool && i == 0) {
-      return { errorMessage: 'The expression cannot start with AND/OR' }
+      return {
+        errorMessage: 'The expression may not start with AND/OR.',
+        errorHelp:
+          'Boolean operators may not be used at the beginning of an expression.',
+      }
     }
 
     if (isBool && !firstBoolean) {
@@ -80,7 +86,8 @@ function parseSection(section: string): MpParseResult {
       if (nextBool !== firstBoolean) {
         return {
           errorMessage:
-            'You cannot mix and match AND/OR in a single segment. Use parenthesis to logically group your variants.',
+            'Expression may not include both AND/OR within a single segment.',
+          errorHelp: 'Segments may only contain identical boolean operators. Use parentheses to group form segments with consistent AND/OR operators.'
         }
       }
     }
@@ -95,7 +102,8 @@ function parseSection(section: string): MpParseResult {
     if (matchData === null) {
       if (token !== exprPlaceholder) {
         return {
-          errorMessage: `Variant ${token} does not match the expected format. The token should be a #VID prepended with an optional NOT.`,
+          errorMessage: `Variant '${token}' does not match the expected format.`,
+          errorHelp: 'The token should be a #VID prepended with an optional NOT.'
         }
       }
     } else {

--- a/client/src/app/core/utilities/molecular-profile-parser.ts
+++ b/client/src/app/core/utilities/molecular-profile-parser.ts
@@ -17,9 +17,9 @@ export type MpParseErrorType =
   | 'initialBoolean'
   | 'invalidToken'
   | 'multipleBoolean'
-  | 'queryError'
   | 'trailingBoolean'
   | 'trailingNOT'
+  | 'queryError'
 
 export interface MpParseError {
   errorType: MpParseErrorType

--- a/client/src/app/forms2/components/entity-tag/entity-tag.component.less
+++ b/client/src/app/forms2/components/entity-tag/entity-tag.component.less
@@ -102,6 +102,7 @@ nz-tag {
     }
     .tag-label {
       display: inline-block;
+      font-weight: normal;
       margin: 0;
       padding: 0;
       margin: -3px 0 -4px 0;

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
@@ -75,6 +75,7 @@ const typeConfig: ConfigOption = {
     NzTypographyModule,
     NzToolTipModule,
     NzPopoverModule,
+    NzSpaceModule,
     CvcFormSubmissionStatusDisplayModule,
     CvcMolecularProfileTagNameModule,
     CvcFormFieldWrapperModule,

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
@@ -17,6 +17,7 @@ import { NzFormModule } from 'ng-zorro-antd/form'
 import { NzGridModule } from 'ng-zorro-antd/grid'
 import { NzIconModule } from 'ng-zorro-antd/icon'
 import { NzInputModule } from 'ng-zorro-antd/input'
+import { NzListModule } from 'ng-zorro-antd/list'
 import { NzModalModule } from 'ng-zorro-antd/modal'
 import { NzPopoverModule } from 'ng-zorro-antd/popover'
 import { NzSelectModule } from 'ng-zorro-antd/select'
@@ -24,8 +25,8 @@ import { NzSpaceModule } from 'ng-zorro-antd/space'
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
 import { NzTypographyModule } from 'ng-zorro-antd/typography'
 import {
-    CvcMolecularProfileSelectField,
-    CvcMolecularProfileSelectFieldProps
+  CvcMolecularProfileSelectField,
+  CvcMolecularProfileSelectFieldProps,
 } from './molecular-profile-select.type'
 import { MpExpressionEditorComponent } from './mp-expression-editor/mp-expression-editor.component'
 import { MpFinderComponent } from './mp-finder/mp-finder.component'
@@ -54,7 +55,11 @@ const typeConfig: ConfigOption = {
 }
 
 @NgModule({
-  declarations: [CvcMolecularProfileSelectField, MpExpressionEditorComponent, MpFinderComponent],
+  declarations: [
+    CvcMolecularProfileSelectField,
+    MpExpressionEditorComponent,
+    MpFinderComponent,
+  ],
   imports: [
     CommonModule,
     FormsModule,
@@ -78,6 +83,8 @@ const typeConfig: ConfigOption = {
     NzPopoverModule,
     NzSpaceModule,
     NzCheckboxModule,
+    NzListModule,
+
     CvcFormSubmissionStatusDisplayModule,
     CvcMolecularProfileTagNameModule,
     CvcFormFieldWrapperModule,

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
@@ -17,6 +17,7 @@ import { NzGridModule } from 'ng-zorro-antd/grid'
 import { NzIconModule } from 'ng-zorro-antd/icon'
 import { NzInputModule } from 'ng-zorro-antd/input'
 import { NzModalModule } from 'ng-zorro-antd/modal'
+import { NzPopoverModule } from 'ng-zorro-antd/popover'
 import { NzSelectModule } from 'ng-zorro-antd/select'
 import { NzSpaceModule } from 'ng-zorro-antd/space'
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
@@ -73,6 +74,7 @@ const typeConfig: ConfigOption = {
     NzAutocompleteModule,
     NzTypographyModule,
     NzToolTipModule,
+    NzPopoverModule,
     CvcFormSubmissionStatusDisplayModule,
     CvcMolecularProfileTagNameModule,
     CvcFormFieldWrapperModule,

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
@@ -29,7 +29,8 @@ import {
   CvcMolecularProfileSelectFieldProps,
 } from './molecular-profile-select.type'
 import { MpExpressionEditorComponent } from './mp-expression-editor/mp-expression-editor.component'
-import { MpFinderComponent } from './mp-finder/mp-finder.component'
+import { MpFinderComponent } from './mp-finder/mp-finder.component';
+import { MpEditorPopoverHelpComponent } from './mp-expression-editor/mp-editor-popover-help.component'
 
 const typeConfig: ConfigOption = {
   types: [
@@ -59,6 +60,7 @@ const typeConfig: ConfigOption = {
     CvcMolecularProfileSelectField,
     MpExpressionEditorComponent,
     MpFinderComponent,
+    MpEditorPopoverHelpComponent,
   ],
   imports: [
     CommonModule,

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
@@ -19,6 +19,7 @@ import { NzInputModule } from 'ng-zorro-antd/input'
 import { NzModalModule } from 'ng-zorro-antd/modal'
 import { NzSelectModule } from 'ng-zorro-antd/select'
 import { NzSpaceModule } from 'ng-zorro-antd/space'
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
 import { NzTypographyModule } from 'ng-zorro-antd/typography'
 import {
     CvcMolecularProfileSelectField,
@@ -71,6 +72,7 @@ const typeConfig: ConfigOption = {
     NzFormModule,
     NzAutocompleteModule,
     NzTypographyModule,
+    NzToolTipModule,
     CvcFormSubmissionStatusDisplayModule,
     CvcMolecularProfileTagNameModule,
     CvcFormFieldWrapperModule,

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.module.ts
@@ -12,6 +12,7 @@ import { ConfigOption, FieldTypeConfig, FormlyModule } from '@ngx-formly/core'
 import { NzAlertModule } from 'ng-zorro-antd/alert'
 import { NzAutocompleteModule } from 'ng-zorro-antd/auto-complete'
 import { NzButtonModule } from 'ng-zorro-antd/button'
+import { NzCheckboxModule } from 'ng-zorro-antd/checkbox'
 import { NzFormModule } from 'ng-zorro-antd/form'
 import { NzGridModule } from 'ng-zorro-antd/grid'
 import { NzIconModule } from 'ng-zorro-antd/icon'
@@ -76,6 +77,7 @@ const typeConfig: ConfigOption = {
     NzToolTipModule,
     NzPopoverModule,
     NzSpaceModule,
+    NzCheckboxModule,
     CvcFormSubmissionStatusDisplayModule,
     CvcMolecularProfileTagNameModule,
     CvcFormFieldWrapperModule,

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
@@ -50,6 +50,8 @@
       nz-button
       nzBlock
       class="expression-button"
+      nz-tooltip
+      nzTooltipTitle="Add/Edit Complex MP Expression"
       (click)="this.onShowExpClick$.next()">
       <span
         nz-icon

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
@@ -13,7 +13,7 @@
           nz-typography
           nzEllipsis
           nzType="secondary">
-          <i>Select a Molecular Profile with the expression editor </i>
+          <i>Select or create a Molecular Profile with the expression editor </i>
         </span>
       </div>
 

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
@@ -69,7 +69,6 @@
     *ngIf="showExp$ | ngrxPush as showExp">
     <cvc-mp-expression-editor
       [cvcPrepopulateWithId]="onMpId$ | ngrxPush"
-      (cvcOnEditPrepopulated)="onEditPrepopulated$.next($event)"
       (cvcOnSelect)="onMpSelect$.next($event)"></cvc-mp-expression-editor>
   </nz-col>
 </nz-row>

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.html
@@ -7,21 +7,22 @@
 
       <div
         class="editor-message"
-        *ngIf="!display.showSelect && editorOpen">
+        *ngIf="editorOpen">
         &nbsp;
         <span
           nz-typography
           nzEllipsis
           nzType="secondary">
-          <i> Select a Molecular Profile with the expression editor </i>
+          <i>Select a Molecular Profile with the expression editor </i>
         </span>
       </div>
 
       <!-- using inline-block here to shrink select to size of its tag contents,
       reducing the changes a user will click within it and cause the search dropdown to appear -->
-      <div style="display: inline-block">
+      <div
+        style="display: inline-block"
+        *ngIf="display.showSelect && !editorOpen">
         <cvc-entity-select
-          *ngIf="display.showSelect"
           [cvcSelectMode]="props.isMultiSelect ? 'multiple' : 'default'"
           [cvcCustomTemplate]="selectedTemplate"
           [cvcFormControl]="formControl"

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.less
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.less
@@ -11,6 +11,7 @@ form,
 }
 .editor-message {
   padding: 3px;
-  border: 1px solid #cccccc;
+  background-color: #f5f5f5;
+  cursor: default;
   border-radius: 2px;
 }

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
@@ -198,7 +198,7 @@ export class CvcMolecularProfileSelectField
         if (!mp) {
           // this.field.formControl.setValue(undefined)
           this.selectDisplay$.next({
-            showFinder: false,
+            showFinder: true,
             showSelect: false,
           })
           return

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
@@ -145,7 +145,7 @@ export class CvcMolecularProfileSelectField
     this.onShowExpClick$ = new Subject<void>()
     this.showExp$ = this.onShowExpClick$.pipe(
       scan((acc, _) => !acc, false),
-      startWith(true),
+      // startWith(true),
       tap((open) => (this.editorOpen = open))
     )
     this.selectDisplay$ = new BehaviorSubject<SelectDisplayModel>({

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
@@ -118,7 +118,7 @@ export class CvcMolecularProfileSelectField
       placeholder: 'Search Molecular Profiles',
       isMultiSelect: false,
       description:
-        'Select a Gene and Variant to specify a simple Molecular Profile, or use the Editor to specify a complex Molecular Profile',
+        'Select a Gene and Variant to specify a simple Molecular Profile.',
       extraType: 'prompt',
       entityName: {
         singular: 'Molecular Profile',

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
@@ -103,7 +103,6 @@ export class CvcMolecularProfileSelectField
   onMpSelect$: BehaviorSubject<Maybe<MolecularProfile>>
   onMpId$: ReplaySubject<Maybe<number>>
   onShowExpClick$: Subject<void>
-  onEditPrepopulated$: BehaviorSubject<boolean>
 
   // PRESENTATION STREAMS
   showExp$: Observable<boolean>
@@ -152,7 +151,6 @@ export class CvcMolecularProfileSelectField
       showFinder: true,
       showSelect: false,
     })
-    this.onEditPrepopulated$ = new BehaviorSubject<boolean>(false)
   }
 
   ngAfterViewInit(): void {

--- a/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/molecular-profile-select.type.ts
@@ -145,7 +145,7 @@ export class CvcMolecularProfileSelectField
     this.onShowExpClick$ = new Subject<void>()
     this.showExp$ = this.onShowExpClick$.pipe(
       scan((acc, _) => !acc, false),
-      // startWith(true),
+      startWith(true),
       tap((open) => (this.editorOpen = open))
     )
     this.selectDisplay$ = new BehaviorSubject<SelectDisplayModel>({
@@ -193,8 +193,16 @@ export class CvcMolecularProfileSelectField
 
     // populate MP select if variantId received from child form model
     this.onMpSelect$
-      .pipe(filter(isNonNulled), untilDestroyed(this))
-      .subscribe((mp: MolecularProfile) => {
+      .pipe(untilDestroyed(this))
+      .subscribe((mp: Maybe<MolecularProfile>) => {
+        if (!mp) {
+          // this.field.formControl.setValue(undefined)
+          this.selectDisplay$.next({
+            showFinder: false,
+            showSelect: false,
+          })
+          return
+        }
         this.selectOption$.next([{ label: mp.name, value: mp.id }])
         if (this.editorOpen) this.onShowExpClick$.next()
         this.cdr.detectChanges()

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
@@ -2,17 +2,27 @@
     <ng-container [ngSwitch]="cvcErrorType">
       <!-- INCOMPLETE EXPRESSION -->
       <ng-container *ngSwitchCase="'incompleteExpression'">
-        <span>INCOMPLETE EXPRESSION</span>
+        <p>
+          The expression contains open parentheses, please ensure that all
+          parenthetical expressions are closed with balanced parentheses.
+        </p>
       </ng-container>
 
       <!-- INCOMPLETE 'NOT' -->
       <ng-container *ngSwitchCase="'incompleteNOT'">
-        <span>INCOMPLETE NOT</span>
+        <p>
+          Complete the expression by appending a <strong>#VID</strong> token to
+          the incomplete boolean expression. Or append an embedded expression
+          using parentheses.
+        </p>
       </ng-container>
 
       <!-- INITIAL BOOLEAN -->
       <ng-container *ngSwitchCase="'initialBoolean'">
-        <span>INITIAL BOOLEAN</span>
+        <p>
+          MP Expressions may not begin with an AND or OR boolean. Ensure the
+          expression begins with a #VID or NOT #VID token.
+        </p>
       </ng-container>
 
       <!-- INVALID TOKEN -->

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
@@ -1,0 +1,82 @@
+  <div class="help-content">
+    ERROR TYPE: {{ cvcErrorType }}
+    <ng-container [ngSwitch]="cvcErrorType">
+      <!-- INVALID VARIANT -->
+      <ng-container *ngSwitchCase="'invalidVariant'">
+        <span>INVALID VARIANT</span>
+      </ng-container>
+
+      <!-- TRAILING BOOLEAN -->
+      <ng-container *ngSwitchCase="'trailingBoolean'">
+        <span>TRAILING BOOLEAN</span>
+      </ng-container>
+
+      <!-- INITIAL BOOLEAN -->
+      <ng-container *ngSwitchCase="'initialBoolean'">
+        <span>INITIAL BOOLEAN</span>
+      </ng-container>
+
+      <!-- MULTIPLE BOOLEAN -->
+      <ng-container *ngSwitchCase="'multipleBoolean'">
+        <span>MULTIPLE BOOLEAN</span>
+      </ng-container>
+
+      <!-- INCOMPLETE EXPRESSION -->
+      <ng-container *ngSwitchCase="'incompleteExpression'">
+        <span>INCOMPLETE EXPRESSION</span>
+      </ng-container>
+
+      <!-- QUERY ERROR -->
+      <ng-container *ngSwitchCase="'queryError'">
+        <span>QUERY ERROR</span>
+      </ng-container>
+
+      <!-- QUERY ERROR -->
+      <ng-container *ngSwitchCase="'queryError'">
+        <span>QUERY ERROR</span>
+      </ng-container>
+
+      <!-- GETTING STARTED -->
+      <ng-container *ngSwitchDefault>
+        <p>
+          The Molecular Profile editor allows the selection or creation of complex
+          Molecular Profiles by writing Molecular Profile Expressions. MP
+          Expressions are composed with a simple language comprised of Variant
+          tokens, boolean operators, and parentheses. For example:
+        </p>
+        <p>
+          <strong>#VID12 AND #VID2220</strong><br />
+          <strong>#VID12 AND #VID2220 OR (#VID456 AND #VID123)</strong><br />
+        </p>
+
+        <p>
+          <strong>Variant Tokens</strong><br />
+          Variant tokens are composed of a CIViC Variant ID prepended with
+          <strong>#VID</strong>, and refer to specific CIViC Variants. For
+          example, <strong>#VID12</strong> refers to <strong>BRAF V600E</strong>;
+          <strong>#VID2220</strong> refers to <strong>ALK FUSION</strong>.
+        </p>
+        <p>
+          <strong>Boolean Operators</strong><br />
+          MP Expressions with more than a single variant must include boolean
+          operators - <strong>AND</strong>, <strong>OR</strong>, and
+          <strong>NOT</strong> - indicating their relationship. For example, the
+          expression <strong>#VID12 AND #VID2220</strong> describes a MP that
+          includes both <strong>BRAF V600E</strong> and
+          <strong>ALK FUSION</strong>.
+        </p>
+        <p>
+          <strong>Parentheses</strong><br />
+          Expressions cannot have both <strong>AND</strong> and
+          <strong>OR</strong> operators within the same expression. To construct
+          complex MPs that require multiple operators, one must use parentheses to
+          create embedded expressions.
+        </p>
+        <p>
+          <strong>NOTE:</strong> Be sure to read the help text provided along with
+          every alert message by clicking on the 'Syntax Assistance' button at the
+          right side of its alert box.
+        </p>
+      </ng-container>
+    </ng-container>
+  </div>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
@@ -1,14 +1,13 @@
   <div class="help-content">
-    ERROR TYPE: {{ cvcErrorType }}
     <ng-container [ngSwitch]="cvcErrorType">
-      <!-- INVALID VARIANT -->
-      <ng-container *ngSwitchCase="'invalidVariant'">
-        <span>INVALID VARIANT</span>
+      <!-- INCOMPLETE EXPRESSION -->
+      <ng-container *ngSwitchCase="'incompleteExpression'">
+        <span>INCOMPLETE EXPRESSION</span>
       </ng-container>
 
-      <!-- TRAILING BOOLEAN -->
-      <ng-container *ngSwitchCase="'trailingBoolean'">
-        <span>TRAILING BOOLEAN</span>
+      <!-- INCOMPLETE 'NOT' -->
+      <ng-container *ngSwitchCase="'incompleteNOT'">
+        <span>INCOMPLETE NOT</span>
       </ng-container>
 
       <!-- INITIAL BOOLEAN -->
@@ -16,24 +15,79 @@
         <span>INITIAL BOOLEAN</span>
       </ng-container>
 
+      <!-- INVALID TOKEN -->
+      <ng-container *ngSwitchCase="'invalidToken'">
+        <p>
+          Molecular Profile expressions use a simple domain-specific language to
+          specify complex MPs. The expression string is parsed by splitting it
+          into 'tokens' delineated with spaces - between each space in the
+          expression is a token. Permitted tokens are:
+        </p>
+        <ul>
+          <li>
+            Variant Tokens - <strong>#VID</strong> or
+            <strong>NOT #VID</strong>followed by a valid Variant ID
+          </li>
+          <li>Boolean Tokens - <strong>AND</strong>, <strong>OR</strong></li>
+          <li>
+            Parentheses - <strong>(</strong> or <strong>)</strong>, for grouping
+            tokens into expressions
+          </li>
+        </ul>
+        <p>
+          <strong>Invalid Token</strong> errors occur if the parser encounters any
+          text or token that does not match those listed above.
+        </p>
+      </ng-container>
+
       <!-- MULTIPLE BOOLEAN -->
       <ng-container *ngSwitchCase="'multipleBoolean'">
-        <span>MULTIPLE BOOLEAN</span>
+        <p>
+          A single expression may not include more than one
+          <strong>AND</strong> or <strong>OR</strong> boolean operator. To
+          construct complex expressions, create embedded expressions using
+          parentheses.
+        </p>
+        <p>
+          For example, the expression
+          <strong>#VID12 AND #VID2220 OR #VID456</strong> is invalid, but the
+          expression <strong>#VID12 AND (#VID2220 OR #VID456)</strong> is valid.
+          The parentheses create a sub-expression indpendent of the outer
+          expression, moving its <strong>OR</strong> boolean out of the context of
+          the outer.
+        </p>
       </ng-container>
 
-      <!-- INCOMPLETE EXPRESSION -->
-      <ng-container *ngSwitchCase="'incompleteExpression'">
-        <span>INCOMPLETE EXPRESSION</span>
+      <!-- TRAILING BOOLEAN -->
+      <ng-container *ngSwitchCase="'trailingBoolean'">
+        <p>
+          Complete the expression by appending a <strong>#VID</strong> token to
+          the incomplete boolean expression. Or append an embedded expression
+          using parentheses.
+        </p>
       </ng-container>
 
-      <!-- QUERY ERROR -->
-      <ng-container *ngSwitchCase="'queryError'">
-        <span>QUERY ERROR</span>
+      <!-- UNKNOWN VARIANT ERROR -->
+      <ng-container *ngSwitchCase="'unknownVariant'">
+        <p>
+          A Variant ID provided in the expression cannot be matched to any Variant
+          in the CIViC database. Please re-check the Variant ID.
+        </p>
+        <p>
+          You may also create a new Variant by clicking on the 'Variant' button,
+          selecting a Gene and then clicking on the 'Create Variant' button that
+          will be provided if the Variant typeahead cannot match the name you have
+          entered.
+        </p>
       </ng-container>
 
-      <!-- QUERY ERROR -->
-      <ng-container *ngSwitchCase="'queryError'">
-        <span>QUERY ERROR</span>
+      <!-- UNKNOWN VARIANT ERROR -->
+      <ng-container *ngSwitchCase="'identicalVariants'">
+        <p>
+          An expression may not contain multiple instances of the same Variant.
+          Either remove or change the duplicate variant, or use parentheses to
+          create an embedded expression with the duplicate variant.
+        </p>
       </ng-container>
 
       <!-- GETTING STARTED -->
@@ -44,10 +98,14 @@
           Expressions are composed with a simple language comprised of Variant
           tokens, boolean operators, and parentheses. For example:
         </p>
-        <p>
+
+        <blockquote>
           <strong>#VID12 AND #VID2220</strong><br />
+          <strong>#VID12 OR #VID2220</strong><br />
+          <strong>#VID12 AND NOT #VID2220</strong><br />
           <strong>#VID12 AND #VID2220 OR (#VID456 AND #VID123)</strong><br />
-        </p>
+          <strong>#VID12 AND #VID2220 OR (NOT #VID456 AND #VID123)</strong><br />
+        </blockquote>
 
         <p>
           <strong>Variant Tokens</strong><br />

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.html
@@ -85,8 +85,7 @@
       <ng-container *ngSwitchCase="'identicalVariants'">
         <p>
           An expression may not contain multiple instances of the same Variant.
-          Either remove or change the duplicate variant, or use parentheses to
-          create an embedded expression with the duplicate variant.
+          Either remove or change the duplicate variant.
         </p>
       </ng-container>
 
@@ -103,8 +102,8 @@
           <strong>#VID12 AND #VID2220</strong><br />
           <strong>#VID12 OR #VID2220</strong><br />
           <strong>#VID12 AND NOT #VID2220</strong><br />
-          <strong>#VID12 AND #VID2220 OR (#VID456 AND #VID123)</strong><br />
-          <strong>#VID12 AND #VID2220 OR (NOT #VID456 AND #VID123)</strong><br />
+          <strong>#VID12 AND #VID2220 AND (#VID456 OR #VID123)</strong><br />
+          <strong>#VID12 AND #VID2220 AND (NOT #VID456 AND #VID123)</strong><br />
         </blockquote>
 
         <p>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core'
+import { MpParseErrorType } from '@app/core/utilities/molecular-profile-parser'
+
+@Component({
+  selector: 'cvc-mp-editor-popover-help',
+  templateUrl: './mp-editor-popover-help.component.html',
+  styles: ['.help-content { max-width: 500px; }'],
+})
+export class MpEditorPopoverHelpComponent {
+  @Input() cvcErrorType?: MpParseErrorType // if undefined, will display 'getting started' help
+}

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-editor-popover-help.component.ts
@@ -4,8 +4,11 @@ import { MpParseErrorType } from '@app/core/utilities/molecular-profile-parser'
 @Component({
   selector: 'cvc-mp-editor-popover-help',
   templateUrl: './mp-editor-popover-help.component.html',
-  styles: ['.help-content { max-width: 500px; }'],
+  styles: [
+    '.help-content { max-width: 500px; } blockquote { margin-left: 1em; }',
+  ],
 })
 export class MpEditorPopoverHelpComponent {
-  @Input() cvcErrorType?: MpParseErrorType // if undefined, will display 'getting started' help
+  @Input() cvcErrorType?: // if undefined, will display 'getting started' help
+  MpParseErrorType | 'identicalVariants' | 'unknownVariant'
 }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -146,8 +146,22 @@
         [ngModel]="inputValue$ | ngrxPush"
         (ngModelChange)="onInputChange$.next($event)"></textarea>
     </nz-col>
+    <nz-col nzFlex="120px">
+      <button
+        nz-button
+        nzType="default"
+        nzShape="round"
+        nzSize="small"
+        nz-popover
+        nzPopoverTitle="Example Molecular Profile Expressions"
+        nzPopoverTrigger="click"
+        [nzPopoverContent]=""
+        nzBlock>
+        Example Expressions
+      </button>
+    </nz-col>
     <nz-col
-      nzFlex="24"
+      nzFlex="auto"
       style="text-align: right">
       <nz-space>
         <span
@@ -170,6 +184,25 @@
           nzPopoverPlacement="bottom">
           <strong>Variant</strong>
         </button>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nz-popover
+          nzPopoverTitle="Append Variant NOT #VID"
+          nzPopoverTrigger="click"
+          nzSize="small"
+          nzShape="round"
+          nzType="primary"
+          [nzPopoverContent]="appendNotVariant"
+          nzPopoverPlacement="bottom">
+          <strong>NOT Variant</strong>
+        </button>
+        <span
+          *nzSpaceItem
+          class="btn-divider">
+          |
+        </span>
         <button
           *nzSpaceItem
           type="button"
@@ -197,6 +230,21 @@
           nzType="primary"
           nzSize="small"
           nzShape="round"
+          (click)="onAppendInput$.next('NOT')">
+          <strong>NOT</strong>
+        </button>
+        <span
+          *nzSpaceItem
+          class="btn-divider">
+          |
+        </span>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nzType="primary"
+          nzSize="small"
+          nzShape="round"
           (click)="onAppendInput$.next('(')">
           <strong>(</strong>
         </button>
@@ -211,33 +259,53 @@
           <strong>)</strong>
         </button>
       </nz-space>
-      <ng-template #appendVariant>
-        <div class="append-variant-content">
-          <nz-row [nzGutter]="[6, 8]">
-            <nz-col nzSpan="24">
-              <p
-                nz-typography
-                nzType="secondary"
-                style="margin: 0; padding-bottom: 6px">
-                Select a Gene then a Variant to append its VID.
-              </p>
-            </nz-col>
-            <nz-col nzFlex="50px">
-              <label
-                nz-checkbox
-                [(ngModel)]="varSelectNOTChecked"
-              class="var-select-not">
-                Prepend <strong>NOT</strong>
-              </label>
-            </nz-col>
-            <nz-col nzFlex="auto">
-              <cvc-mp-finder
-                (cvcOnVariantSelect)="onVariantSelect$.next($event)">
-              </cvc-mp-finder>
-            </nz-col>
-          </nz-row>
-        </div>
-      </ng-template>
     </nz-col>
   </nz-row>
 </cvc-form-submission-status-display>
+
+<!-- APPEND VARIANT #VID POPOVER -->
+<ng-template #appendVariant>
+  <div class="append-variant-content">
+    <nz-row [nzGutter]="[6, 8]">
+      <nz-col nzSpan="24">
+        <p
+          nz-typography
+          nzType="secondary"
+          style="margin: 0; padding-bottom: 6px">
+          Select a Gene then a Variant to append its #VID.
+        </p>
+      </nz-col>
+      <nz-col nzSpan="24">
+        <cvc-mp-finder
+          (cvcOnVariantSelect)="
+            onVariantSelect$.next({ variant: $event, prependNot: false })
+          ">
+        </cvc-mp-finder>
+      </nz-col>
+    </nz-row>
+  </div>
+</ng-template>
+
+<!-- APPEND NOT + #VID POPOVER -->
+<ng-template #appendNotVariant>
+  <div class="append-variant-content">
+    <nz-row [nzGutter]="[6, 8]">
+      <nz-col nzSpan="24">
+        <p
+          nz-typography
+          nzType="secondary"
+          style="margin: 0; padding-bottom: 6px">
+          Select a Gene then a Variant to append its #VID, prepended with NOT
+          boolean.
+        </p>
+      </nz-col>
+      <nz-col nzSpan="24">
+        <cvc-mp-finder
+          (cvcOnVariantSelect)="
+            onVariantSelect$.next({ variant: $event, prependNot: true })
+          ">
+        </cvc-mp-finder>
+      </nz-col>
+    </nz-row>
+  </div>
+</ng-template>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -5,6 +5,21 @@
   <ng-template #success>Added new Molecular Profile</ng-template>
   <nz-row
     [nzGutter]="[6, 6]"
+    style="padding-bottom: 6px">
+    <nz-col [nzSpan]="24">
+      <ng-container *ngIf="expressionError$ | ngrxPush as error">
+        {{ error }}
+      </ng-container>
+      <nz-alert
+        *ngIf="expressionMessage$ | ngrxPush as message"
+        nzType="info"
+        [nzMessage]="message"
+        nzShowIcon></nz-alert>
+    </nz-col>
+  </nz-row>
+
+  <nz-row
+    [nzGutter]="[6, 6]"
     class="preview-row">
     <!-- preview, messages, errors -->
     <nz-col nzFlex="100px">
@@ -14,24 +29,17 @@
       <div
         class="expression-preview"
         [ngClass]="{ active: (expressionSegment$ | ngrxPush) !== undefined }">
-        <span
-          *ngIf="expressionMessage$ | ngrxPush as message"
-          nz-typography
-          nzType="secondary">
-          {{ message }}
-        </span>
-        <span
-          *ngIf="expressionError$ | ngrxPush as error"
-          nz-typography
-          nzType="secondary">
-          {{ error }}
-        </span>
-        <span
-          *ngIf="expressionSegment$ | ngrxPush as segments"
-          nz-typography
-          nzType="secondary">
-          <cvc-mp-tag-name [nameSegments]="segments"></cvc-mp-tag-name>
-        </span>
+        <ng-container *ngrxLet="expressionSegment$ | ngrxPush as segments">
+          <cvc-mp-tag-name
+            *ngIf="segments"
+            [nameSegments]="segments"></cvc-mp-tag-name>
+          <span
+            *ngIf="!segments"
+            nz-typography
+            nzType="secondary">
+            Preview
+          </span>
+        </ng-container>
       </div>
     </nz-col>
     <nz-col nzFlex="100px">

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -52,51 +52,7 @@
             GETTING STARTED
           </button>
           <ng-template #gettingStartedHelp>
-            <div class="help-content">
-              <p>
-                The Molecular Profile editor allows the selection or creation of
-                complex Molecular Profiles by writing Molecular Profile
-                Expressions. MP Expressions are composed with a simple language
-                comprised of Variant tokens, boolean operators, and parentheses.
-                For example:
-              </p>
-              <p>
-                <strong>#VID12 AND #VID2220</strong><br />
-                <strong>#VID12 AND #VID2220 OR (#VID456 AND #VID123)</strong
-                ><br />
-              </p>
-
-              <p>
-                <strong>Variant Tokens</strong><br />
-                Variant tokens are composed of a CIViC Variant ID prepended with
-                <strong>#VID</strong>, and refer to specific CIViC Variants. For
-                example, <strong>#VID12</strong> refers to
-                <strong>BRAF V600E</strong>; <strong>#VID2220</strong> refers to
-                <strong>ALK FUSION</strong>.
-              </p>
-              <p>
-                <strong>Boolean Operators</strong><br />
-                MP Expressions with more than a single variant must include
-                boolean operators - <strong>AND</strong>, <strong>OR</strong>,
-                and <strong>NOT</strong> - indicating their relationship. For
-                example, the expression
-                <strong>#VID12 AND #VID2220</strong> describes a MP that
-                includes both <strong>BRAF V600E</strong> and
-                <strong>ALK FUSION</strong>.
-              </p>
-              <p>
-                <strong>Parentheses</strong><br />
-                Expressions cannot have both <strong>AND</strong> and
-                <strong>OR</strong> operators within the same expression. To
-                construct complex MPs that require multiple operators, one must
-                use parentheses to create embedded expressions.
-              </p>
-              <p>
-                <strong>NOTE:</strong> Be sure to read the help text provided
-                along with every alert message by clicking on the 'Syntax
-                Assistance' button at the right side of its alert box.
-              </p>
-            </div>
+            <cvc-mp-editor-popover-help></cvc-mp-editor-popover-help>
           </ng-template>
         </ng-template>
       </ng-container>
@@ -199,7 +155,9 @@
             </ng-container>
             <!-- trailing boolean help -->
             <ng-template #invalidVariantHelp>
-              <span>INVALID VARIANT</span>
+              ERROR TYPE: {{ error.errorType }}
+              <cvc-mp-editor-popover-help
+                cvcErrorType="invalidVariant"></cvc-mp-editor-popover-help>
             </ng-template>
           </ng-container>
 
@@ -212,7 +170,8 @@
               ">
             </ng-container>
             <ng-template #trailingBooleanHelp>
-              <span>TRAILING BOOLEAN ERROR</span>
+              <cvc-mp-editor-popover-help
+                cvcErrorType="trailingBoolean"></cvc-mp-editor-popover-help>
             </ng-template>
           </ng-container>
 
@@ -225,7 +184,8 @@
               ">
             </ng-container>
             <ng-template #initialBooleanHelp>
-              <span>INITIAL BOOLEAN ERROR</span>
+              <cvc-mp-editor-popover-help
+                cvcErrorType="initialBoolean"></cvc-mp-editor-popover-help>
             </ng-template>
           </ng-container>
 
@@ -238,7 +198,8 @@
               ">
             </ng-container>
             <ng-template #multipleBooleanHelp>
-              <span>MULTIPLE BOOLEAN ERROR</span>
+              <cvc-mp-editor-popover-help
+                cvcErrorType="multipleBoolean"></cvc-mp-editor-popover-help>
             </ng-template>
           </ng-container>
 
@@ -254,7 +215,8 @@
               ">
             </ng-container>
             <ng-template #incompleteExpressionHelp>
-              <span>INCOMPLETE EXPRESSION ERROR</span>
+              <cvc-mp-editor-popover-help
+                cvcErrorType="incompleteExpression"></cvc-mp-editor-popover-help>
             </ng-template>
           </ng-container>
 
@@ -270,7 +232,8 @@
               ">
             </ng-container>
             <ng-template #queryErrorHelp>
-              <span>QUERY ERROR</span>
+              <cvc-mp-editor-popover-help
+                cvcErrorType="queryError"></cvc-mp-editor-popover-help>
             </ng-template>
           </ng-container>
           <ng-container *ngSwitchDefault>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -3,25 +3,110 @@
   entityType="Molecular Profile"
   [successMessage]="success">
   <ng-template #success>Added new Molecular Profile</ng-template>
+  <!-- info & error messages row -->
   <nz-row
     [nzGutter]="[6, 6]"
-    style="padding-bottom: 6px">
-    <nz-col [nzSpan]="24">
+    class="info-row">
+    <!-- ERROR -->
+    <nz-col nzSpan="24">
       <ng-container *ngIf="expressionError$ | ngrxPush as error">
-        {{ error }}
+        <nz-alert
+          nzType="error"
+          [nzMessage]="error.errorMessage"
+          [nzAction]="errorAction"
+          nzShowIcon></nz-alert>
+        <ng-template #errorAction>
+          <button
+            nz-button
+            nzDanger
+            nzType="dashed"
+            nzSize="small"
+            nzShape="round">
+            <span
+              *ngIf="error.errorHelp as helptext"
+              nz-tooltip
+              [nzTooltipTitle]="helptext">
+              <span
+                nz-icon
+                nzType="question-circle"
+                nzTheme="fill"></span>
+              SYNTAX ASSISTANCE
+            </span>
+          </button>
+        </ng-template>
       </ng-container>
-      <nz-alert
-        *ngIf="expressionMessage$ | ngrxPush as message"
-        nzType="info"
-        [nzMessage]="message"
-        nzShowIcon></nz-alert>
+      <!-- MESSAGE -->
+      <ng-container *ngIf="expressionMessage$ | ngrxPush as message">
+        <nz-alert
+          nzType="info"
+          [nzMessage]="message"
+          [nzAction]="messageAction"
+          nzShowIcon></nz-alert>
+
+        <ng-template #messageAction>
+          <button
+            nz-button
+            nzType="dashed"
+            nzSize="small"
+            nzShape="round">
+            <span
+              nz-tooltip
+              [nzTooltipTitle]="'Enter #VID[id] and boolean tokens to construct a Molecular Profile expression.'">
+              <span
+                nz-icon
+                nzType="question-circle"
+                nzTheme="fill"></span>
+              GETTING STARTED
+            </span>
+          </button>
+        </ng-template>
+      </ng-container>
+      <!-- SUCCESS -->
+      <ng-container
+        *ngIf="
+          !(expressionError$ | ngrxPush) && !(expressionMessage$ | ngrxPush)
+        ">
+        <nz-alert
+          nzType="success"
+          [nzMessage]="
+            'Select Molecular Profile by clicking the adjacent button ->'
+          "
+          nzShowIcon></nz-alert>
+      </ng-container>
     </nz-col>
+    <!-- <nz-col
+          nzFlex="100px"
+          class="action-buttons">
+          <button
+            *ngIf="existingMp$ | ngrxPush as mp"
+            (click)="cvcOnSelect.next(mp)"
+            [disabled]="(expressionError$ | ngrxPush) === undefined"
+            type="button"
+            nz-button
+            nzType="primary"
+            nzBlock>
+            Select MP
+          </button>
+          <button
+            *ngIf="!(existingMp$ | ngrxPush)"
+            [disabled]="
+              (expressionError$ | ngrxPush) === undefined ||
+              !(expressionSegment$ | ngrxPush)
+            "
+            (click)="onCreateNewMp$.next()"
+            type="button"
+            nz-button
+            nzType="primary"
+            nzBlock>
+            Add MP
+          </button>
+        </nz-col> -->
   </nz-row>
 
   <nz-row
     [nzGutter]="[6, 6]"
     class="preview-row">
-    <!-- preview, messages, errors -->
+    <!-- preview row -->
     <nz-col nzFlex="100px">
       <div class="finder-label">Preview:</div>
     </nz-col>
@@ -42,31 +127,8 @@
         </ng-container>
       </div>
     </nz-col>
-    <nz-col nzFlex="100px">
-      <button
-        *ngIf="existingMp$ | ngrxPush as mp"
-        (click)="cvcOnSelect.next(mp)"
-        [disabled]="expressionError$ | ngrxPush"
-        type="button"
-        nz-button
-        nzType="primary"
-        nzBlock>
-        Select MP
-      </button>
-      <button
-        *ngIf="!(existingMp$ | ngrxPush)"
-        [disabled]="
-          (expressionError$ | ngrxPush) || !(expressionSegment$ | ngrxPush)
-        "
-        (click)="onCreateNewMp$.next()"
-        type="button"
-        nz-button
-        nzType="primary"
-        nzBlock>
-        Add MP
-      </button>
-    </nz-col>
   </nz-row>
+
   <nz-row [nzGutter]="[6, 6]">
     <!-- input textarea -->
     <nz-col nzFlex="100px">

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -3,10 +3,28 @@
   entityType="Molecular Profile"
   [successMessage]="success">
   <ng-template #success>Added new Molecular Profile</ng-template>
-  <!-- info & error messages row -->
+
+  <!-- PREVIEW ROW -->
   <nz-row
-    [nzGutter]="[6, 6]"
-    class="info-row">
+    [nzGutter]="[6, 8]">
+    <!-- preview row -->
+    <nz-col nzSpan="24">
+      <div
+        class="expression-preview"
+        [ngClass]="{ active: (expressionSegment$ | ngrxPush) !== undefined }">
+        <ng-container *ngrxLet="expressionSegment$ | ngrxPush as segments">
+          <cvc-mp-tag-name
+            *ngIf="segments"
+            [nameSegments]="segments"></cvc-mp-tag-name>
+          <span
+            *ngIf="!segments"
+            nz-typography
+            nzType="secondary">
+            Valid Molecular Profile expressions will be previewed here.
+          </span>
+        </ng-container>
+      </div>
+    </nz-col>
     <nz-col nzSpan="24">
       <!-- ERROR -->
       <ng-container *ngIf="expressionError$ | ngrxPush as error">
@@ -83,6 +101,7 @@
                 type="button"
                 nz-button
                 nzType="primary"
+                nzSize="small"
                 nzBlock>
                 Select this MP
               </button>
@@ -116,32 +135,6 @@
         </ng-container>
       </ng-container>
     </nz-col>
-  </nz-row>
-
-  <nz-row
-    [nzGutter]="[6, 6]"
-    class="preview-row">
-    <!-- preview row -->
-    <nz-col nzSpan="24">
-      <div
-        class="expression-preview"
-        [ngClass]="{ active: (expressionSegment$ | ngrxPush) !== undefined }">
-        <ng-container *ngrxLet="expressionSegment$ | ngrxPush as segments">
-          <cvc-mp-tag-name
-            *ngIf="segments"
-            [nameSegments]="segments"></cvc-mp-tag-name>
-          <span
-            *ngIf="!segments"
-            nz-typography
-            nzType="secondary">
-            Valid Molecular Profile expressions will be previewed here.
-          </span>
-        </ng-container>
-      </div>
-    </nz-col>
-  </nz-row>
-
-  <nz-row [nzGutter]="[6, 6]">
     <!-- input textarea -->
     <nz-col nzSpan="24">
       <textarea
@@ -153,9 +146,16 @@
         [ngModel]="inputValue$ | ngrxPush"
         (ngModelChange)="onInputChange$.next($event)"></textarea>
     </nz-col>
-    <nz-col nzSpan="24">
+    <nz-col
+      nzFlex="24"
+      style="text-align: right">
       <nz-space>
-        <span *nzSpaceItem> Append: </span>
+        <span
+          *nzSpaceItem
+          nz-typography
+          nzType="secondary">
+          Append:
+        </span>
         <button
           *nzSpaceItem
           type="button"
@@ -168,7 +168,7 @@
           nzType="primary"
           [nzPopoverContent]="appendVariant"
           nzPopoverPlacement="bottom">
-          Variant
+          <strong>Variant</strong>
         </button>
         <button
           *nzSpaceItem
@@ -178,7 +178,7 @@
           nzSize="small"
           nzShape="round"
           (click)="onAppendInput$.next('AND')">
-          AND
+          <strong>AND</strong>
         </button>
         <button
           *nzSpaceItem
@@ -188,7 +188,7 @@
           nzSize="small"
           nzShape="round"
           (click)="onAppendInput$.next('OR')">
-          OR
+          <strong>OR</strong>
         </button>
         <button
           *nzSpaceItem
@@ -198,7 +198,7 @@
           nzSize="small"
           nzShape="round"
           (click)="onAppendInput$.next('NOT')">
-          NOT
+          <strong>NOT</strong>
         </button>
         <button
           *nzSpaceItem
@@ -208,7 +208,7 @@
           nzSize="small"
           nzShape="round"
           (click)="onAppendInput$.next('(')">
-          (
+          <strong>(</strong>
         </button>
         <button
           *nzSpaceItem
@@ -218,7 +218,7 @@
           nzSize="small"
           nzShape="round"
           (click)="onAppendInput$.next(')')">
-          )
+          <strong>)</strong>
         </button>
       </nz-space>
       <ng-template #appendVariant>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -60,7 +60,12 @@
                 comprised of Variant tokens, boolean operators, and parentheses.
                 For example:
               </p>
-              <p><strong>#VID12 AND #VID2220</strong><br /></p>
+              <p>
+                <strong>#VID12 AND #VID2220</strong><br />
+                <strong>#VID12 AND #VID2220 OR (#VID456 AND #VID123)</strong
+                ><br />
+              </p>
+
               <p>
                 <strong>Variant Tokens</strong><br />
                 Variant tokens are composed of a CIViC Variant ID prepended with
@@ -150,8 +155,38 @@
         </ng-container>
       </ng-container>
 
-      <!-- ERROR - switch statement displays an errorAlert template
-           w/ differing contexts depending on alert type -->
+      <!-- ERROR ALERT TEMPLATE -->
+      <ng-template
+        #errorAlert
+        let-error
+        let-content="helpContent">
+        <nz-alert
+          nzType="error"
+          [nzMessage]="error.errorMessage"
+          [nzAction]="errorAction"
+          nzShowIcon></nz-alert>
+        <ng-template #errorAction>
+          <button
+            nz-button
+            nzDanger
+            nzType="dashed"
+            nzSize="small"
+            nzShape="round"
+            nz-popover
+            nzPopoverTrigger="click"
+            [nzPopoverTitle]="error.errorHelp"
+            [nzPopoverContent]="content">
+            <span
+              nz-icon
+              nzType="question-circle"
+              nzTheme="fill"></span>
+            SYNTAX ASSISTANCE
+          </button>
+        </ng-template>
+      </ng-template>
+
+      <!-- SYNTAX ASSISTANCE - switch statement displays an errorAlert template
+           w/ differing contexts w/ help template, depending on alert type -->
       <ng-container *ngIf="expressionError$ | ngrxPush as error">
         <ng-container [ngSwitch]="error.errorType">
           <!-- invalid variant alert -->
@@ -238,37 +273,12 @@
               <span>QUERY ERROR</span>
             </ng-template>
           </ng-container>
+          <ng-container *ngSwitchDefault>
+            <pre>
+              {{ error | json }}
+            </pre>
+          </ng-container>
         </ng-container>
-
-        <!-- ERROR ALERT TEMPLATE -->
-        <ng-template
-          #errorAlert
-          let-error
-          let-content="helpContent">
-          <nz-alert
-            nzType="error"
-            [nzMessage]="error.errorMessage"
-            [nzAction]="errorAction"
-            nzShowIcon></nz-alert>
-          <ng-template #errorAction>
-            <button
-              nz-button
-              nzDanger
-              nzType="dashed"
-              nzSize="small"
-              nzShape="round"
-              nz-popover
-              nzPopoverTrigger="click"
-              [nzPopoverTitle]="error.errorHelp"
-              [nzPopoverContent]="content">
-              <span
-                nz-icon
-                nzType="question-circle"
-                nzTheme="fill"></span>
-              SYNTAX ASSISTANCE
-            </button>
-          </ng-template>
-        </ng-template>
       </ng-container>
     </nz-col>
 

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -146,8 +146,9 @@
         [ngModel]="inputValue$ | ngrxPush"
         (ngModelChange)="onInputChange$.next($event)"></textarea>
     </nz-col>
-    <nz-col nzFlex="120px">
+    <nz-col nzFlex="80px">
       <button
+        nzBlock
         nz-button
         nzType="default"
         nzShape="round"
@@ -155,9 +156,9 @@
         nz-popover
         nzPopoverTitle="Example Molecular Profile Expressions"
         nzPopoverTrigger="click"
-        [nzPopoverContent]=""
-        nzBlock>
-        Example Expressions
+        [nzPopoverContent]="expressionExamples"
+        nzPopoverPlacement="bottom">
+        Examples
       </button>
     </nz-col>
     <nz-col
@@ -263,9 +264,13 @@
   </nz-row>
 </cvc-form-submission-status-display>
 
-<!-- APPEND VARIANT #VID POPOVER -->
+<!--
+     APPEND BUTTON POPOVER TEMPLATES
+-->
+
+<!-- append #VID -->
 <ng-template #appendVariant>
-  <div class="append-variant-content">
+  <div class="append-popover-contents">
     <nz-row [nzGutter]="[6, 8]">
       <nz-col nzSpan="24">
         <p
@@ -286,9 +291,9 @@
   </div>
 </ng-template>
 
-<!-- APPEND NOT + #VID POPOVER -->
+<!-- append NOT + #VID -->
 <ng-template #appendNotVariant>
-  <div class="append-variant-content">
+  <div class="append-popover-contents">
     <nz-row [nzGutter]="[6, 8]">
       <nz-col nzSpan="24">
         <p
@@ -305,6 +310,27 @@
             onVariantSelect$.next({ variant: $event, prependNot: true })
           ">
         </cvc-mp-finder>
+      </nz-col>
+    </nz-row>
+  </div>
+</ng-template>
+
+<!-- MP examples popover template -->
+<ng-template #expressionExamples>
+  <div class="append-popover-contents">
+    <nz-row [nzGutter]="[6, 8]">
+      <nz-col nzSpan="24">
+        <p
+          nz-typography
+          nzType="secondary"
+          style="margin: 0; padding-bottom: 6px">
+          Click a profile to view its expression in the editor.
+        </p>
+      </nz-col>
+      <nz-col nzSpan="24">
+        <nz-list>
+          <nz-list-item> </nz-list-item>
+        </nz-list>
       </nz-col>
     </nz-row>
   </div>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -74,7 +74,7 @@
           <ng-container *ngIf="mp !== undefined">
             <nz-alert
               nzType="success"
-              [nzMessage]="'Molecular Profile ' + mp.name + ' found.'"
+              [nzMessage]="foundMessage"
               [nzAction]="selectAction"
               nzShowIcon></nz-alert>
             <ng-template #selectAction>
@@ -84,8 +84,11 @@
                 nz-button
                 nzType="primary"
                 nzBlock>
-                Select&nbsp;<strong>{{ mp.name }}</strong>
+                Select this MP
               </button>
+            </ng-template>
+            <ng-template #foundMessage>
+             Molecular Profile <strong>{{ mp.name }}</strong> found.
             </ng-template>
           </ng-container>
 
@@ -93,7 +96,7 @@
           <ng-container *ngIf="mp === undefined">
             <nz-alert
               nzType="success"
-              [nzMessage]="'Create new Molecular Profile'"
+              [nzMessage]="createMessage"
               [nzAction]="createAction"
               nzShowIcon></nz-alert>
             <ng-template #createAction>
@@ -106,37 +109,13 @@
                 Create New MP
               </button>
             </ng-template>
+            <ng-template #createMessage>
+              Molecular Profile not found, create it?
+            </ng-template>
           </ng-container>
         </ng-container>
       </ng-container>
     </nz-col>
-    <!-- <nz-col
-          nzFlex="100px"
-          class="action-buttons">
-          <button
-            *ngIf="existingMp$ | ngrxPush as mp"
-            (click)="cvcOnSelect.next(mp)"
-            [disabled]="(expressionError$ | ngrxPush) === undefined"
-            type="button"
-            nz-button
-            nzType="primary"
-            nzBlock>
-            Select MP
-          </button>
-          <button
-            *ngIf="!(existingMp$ | ngrxPush)"
-            [disabled]="
-              (expressionError$ | ngrxPush) === undefined ||
-              !(expressionSegment$ | ngrxPush)
-            "
-            (click)="onCreateNewMp$.next()"
-            type="button"
-            nz-button
-            nzType="primary"
-            nzBlock>
-            Add MP
-          </button>
-        </nz-col> -->
   </nz-row>
 
   <nz-row

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -163,6 +163,9 @@
         nzPopoverTrigger="click"
         [nzPopoverContent]="appendVariant"
         nzPopoverPlacement="bottom">
+        <span
+          nz-icon
+          nzType="arrow-left"></span>
         Append&nbsp;#VID
       </button>
       <ng-template #appendVariant>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -219,6 +219,23 @@
             </ng-template>
           </ng-container>
 
+          <!-- incomplete NOT alert -->
+          <ng-container *ngSwitchCase="'incompleteNOT'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: {
+                  $implicit: error,
+                  helpContent: incompleteNOTHelp
+                }
+              ">
+            </ng-container>
+            <ng-template #incompleteNOTHelp>
+              <cvc-mp-editor-popover-help
+                cvcErrorType="incompleteNOT"></cvc-mp-editor-popover-help>
+            </ng-template>
+          </ng-container>
+
           <!-- query error alert -->
           <ng-container *ngSwitchCase="'queryError'">
             <ng-container
@@ -348,16 +365,16 @@
           (click)="onAppendInput$.next('OR')">
           <strong>OR</strong>
         </button>
-        <button
-          *nzSpaceItem
-          type="button"
-          nz-button
-          nzType="primary"
-          nzSize="small"
-          nzShape="round"
-          (click)="onAppendInput$.next('NOT')">
-          <strong>NOT</strong>
-        </button>
+        <!-- <button
+                  *nzSpaceItem
+                  type="button"
+                  nz-button
+                  nzType="primary"
+                  nzSize="small"
+                  nzShape="round"
+                  (click)="onAppendInput$.next('NOT')">
+                  <strong>NOT</strong>
+                </button> -->
         <span
           *nzSpaceItem
           class="btn-divider">

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -51,7 +51,9 @@
             nzShape="round">
             <span
               nz-tooltip
-              [nzTooltipTitle]="'Enter #VID[id] and boolean tokens to construct a Molecular Profile expression.'">
+              [nzTooltipTitle]="
+                'Enter #VID[id] and boolean tokens to construct a Molecular Profile expression.'
+              ">
               <span
                 nz-icon
                 nzType="question-circle"
@@ -66,12 +68,42 @@
         *ngIf="
           !(expressionError$ | ngrxPush) && !(expressionMessage$ | ngrxPush)
         ">
-        <nz-alert
-          nzType="success"
-          [nzMessage]="
-            'Select Molecular Profile by clicking the adjacent button ->'
-          "
-          nzShowIcon></nz-alert>
+        <!-- FOUND EXISTING MP -->
+        <ng-container *ngIf="existingMp$ | ngrxPush as mp">
+          <nz-alert
+            nzType="success"
+            [nzMessage]="'Molecular Profile ' + mp.name + ' found.'"
+            [nzAction]="selectAction"
+            nzShowIcon></nz-alert>
+          <ng-template #selectAction>
+            <button
+              (click)="cvcOnSelect.next(mp)"
+              type="button"
+              nz-button
+              nzType="primary"
+              nzBlock>
+              Select MP
+            </button>
+          </ng-template>
+        </ng-container>
+        <!-- CREATE NEW MP -->
+        <ng-container *ngIf="!(existingMp$ | ngrxPush)">
+          <nz-alert
+            nzType="success"
+            [nzMessage]="'Create new Molecular Profile'"
+            [nzAction]="createAction"
+            nzShowIcon></nz-alert>
+          <ng-template #createAction>
+          <button
+            (click)="onCreateNewMp$.next()"
+            type="button"
+            nz-button
+            nzType="primary"
+            nzBlock>
+            Create New MP
+          </button>
+          </ng-template>
+        </ng-container>
       </ng-container>
     </nz-col>
     <!-- <nz-col
@@ -107,10 +139,7 @@
     [nzGutter]="[6, 6]"
     class="preview-row">
     <!-- preview row -->
-    <nz-col nzFlex="100px">
-      <div class="finder-label">Preview:</div>
-    </nz-col>
-    <nz-col nzFlex="auto">
+    <nz-col nzSpan="24">
       <div
         class="expression-preview"
         [ngClass]="{ active: (expressionSegment$ | ngrxPush) !== undefined }">
@@ -122,7 +151,7 @@
             *ngIf="!segments"
             nz-typography
             nzType="secondary">
-            Preview
+            Valid Molecular Profile expressions will be previewed here.
           </span>
         </ng-container>
       </div>
@@ -131,15 +160,12 @@
 
   <nz-row [nzGutter]="[6, 6]">
     <!-- input textarea -->
-    <nz-col nzFlex="100px">
-      <div class="finder-label">Editor:</div>
-    </nz-col>
-    <nz-col nzFlex="auto">
+    <nz-col nzSpan="24">
       <textarea
         nz-input
         rows="1"
         style="width: 100%"
-        placeholder="Enter #VID[id] and boolean tokens to construct a Molecular Profile expression."
+        placeholder="Enter or edit a Molecular Expression here."
         [ngModel]="inputValue$ | ngrxPush"
         (ngModelChange)="onInputChange$.next($event)"></textarea>
     </nz-col>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -143,8 +143,9 @@
 
   <nz-row [nzGutter]="[6, 6]">
     <!-- input textarea -->
-    <nz-col nzFlex="auto">
+    <nz-col nzSpan="24">
       <textarea
+        #expressionEditor
         nz-input
         rows="1"
         style="width: 100%"
@@ -152,22 +153,74 @@
         [ngModel]="inputValue$ | ngrxPush"
         (ngModelChange)="onInputChange$.next($event)"></textarea>
     </nz-col>
-    <nz-col nzFlex="50px">
-      <button
-        type="button"
-        nz-button
-        nzType="default"
-        nzBlock
-        nz-popover
-        nzPopoverTitle="Append Variant #VID to Expression"
-        nzPopoverTrigger="click"
-        [nzPopoverContent]="appendVariant"
-        nzPopoverPlacement="bottom">
-        <span
-          nz-icon
-          nzType="arrow-left"></span>
-        Append&nbsp;#VID
-      </button>
+    <nz-col nzSpan="24">
+      <nz-space>
+        <span *nzSpaceItem> Append: </span>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nz-popover
+          nzPopoverTitle="Append Variant #VID"
+          nzPopoverTrigger="click"
+          nzSize="small"
+          nzShape="round"
+          nzType="primary"
+          [nzPopoverContent]="appendVariant"
+          nzPopoverPlacement="bottom">
+          Variant
+        </button>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nzType="primary"
+          nzSize="small"
+          nzShape="round"
+          (click)="onAppendInput$.next('AND')">
+          AND
+        </button>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nzType="primary"
+          nzSize="small"
+          nzShape="round"
+          (click)="onAppendInput$.next('OR')">
+          OR
+        </button>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nzType="primary"
+          nzSize="small"
+          nzShape="round"
+          (click)="onAppendInput$.next('NOT')">
+          NOT
+        </button>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nzType="primary"
+          nzSize="small"
+          nzShape="round"
+          (click)="onAppendInput$.next('(')">
+          (
+        </button>
+        <button
+          *nzSpaceItem
+          type="button"
+          nz-button
+          nzType="primary"
+          nzSize="small"
+          nzShape="round"
+          (click)="onAppendInput$.next(')')">
+          )
+        </button>
+      </nz-space>
       <ng-template #appendVariant>
         <div style="min-width: 350px">
           <p

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -181,14 +181,4 @@
       </ng-template>
     </nz-col>
   </nz-row>
-  <!--  <nz-row [nzGutter]="[6, 6]">
-    <nz-col nzFlex="100px">
-      <div class="finder-label">Append #VID:</div>
-    </nz-col>
-    <nz-col nzFlex="auto">
-      <cvc-mp-finder
-        (cvcOnVariantSelect)="onVariantSelect$.next($event)"></cvc-mp-finder>
-    </nz-col>
-  </nz-row>
-  -->
 </cvc-form-submission-status-display>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -145,19 +145,18 @@
            w/ differing contexts w/ help template, depending on alert type -->
       <ng-container *ngIf="expressionError$ | ngrxPush as error">
         <ng-container [ngSwitch]="error.errorType">
-          <!-- invalid variant alert -->
-          <ng-container *ngSwitchCase="'invalidVariant'">
+          <!-- invalid token alert -->
+          <ng-container *ngSwitchCase="'invalidToken'">
             <ng-container
               *ngTemplateOutlet="
                 errorAlert;
-                context: { $implicit: error, helpContent: invalidVariantHelp }
+                context: { $implicit: error, helpContent: invalidTokenHelp }
               ">
             </ng-container>
             <!-- trailing boolean help -->
-            <ng-template #invalidVariantHelp>
-              ERROR TYPE: {{ error.errorType }}
+            <ng-template #invalidTokenHelp>
               <cvc-mp-editor-popover-help
-                cvcErrorType="invalidVariant"></cvc-mp-editor-popover-help>
+                cvcErrorType="invalidToken"></cvc-mp-editor-popover-help>
             </ng-template>
           </ng-container>
 
@@ -232,8 +231,19 @@
               ">
             </ng-container>
             <ng-template #queryErrorHelp>
-              <cvc-mp-editor-popover-help
-                cvcErrorType="queryError"></cvc-mp-editor-popover-help>
+              <!-- handle query error "You may not use the same variant multiple times in one MP expression." -->
+              <ng-container
+                *ngIf="error.errorMessage.split(' ').includes('multiple')">
+                <cvc-mp-editor-popover-help
+                  cvcErrorType="identicalVariants"></cvc-mp-editor-popover-help>
+              </ng-container>
+
+              <!-- handle query error "Variants with ID [...] were not found." -->
+              <ng-container
+                *ngIf="error.errorMessage.split(' ').includes('found.')">
+                <cvc-mp-editor-popover-help
+                  cvcErrorType="unknownVariant"></cvc-mp-editor-popover-help>
+              </ng-container>
             </ng-template>
           </ng-container>
           <ng-container *ngSwitchDefault>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -27,29 +27,51 @@
     <nz-col nzSpan="24">
       <!-- ERROR -->
       <ng-container *ngIf="expressionError$ | ngrxPush as error">
-        <nz-alert
-          nzType="error"
-          [nzMessage]="error.errorMessage"
-          [nzAction]="errorAction"
-          nzShowIcon></nz-alert>
-        <ng-template #errorAction>
-          <button
-            nz-button
-            nzDanger
-            nzType="dashed"
-            nzSize="small"
-            nzShape="round">
-            <span
-              *ngIf="error.errorHelp as helptext"
-              nz-tooltip
-              [nzTooltipTitle]="helptext">
+        <ng-container [ngSwitch]="error.errorType">
+          <ng-container *ngSwitchCase="'invalidVariant'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: { $implicit: error, helpContent: invalidVariantHelp }
+              ">
+            </ng-container>
+          </ng-container>
+        </ng-container>
+
+        <!-- ERROR HELP TEMPLATES -->
+        <ng-template #invalidVariantHelp>
+          <span>INVALID VARIANT</span>
+        </ng-template>
+
+        <ng-template
+          #errorAlert
+          let-error
+          let-content="helpContent">
+          <nz-alert
+            nzType="error"
+            [nzMessage]="error.errorMessage"
+            [nzAction]="errorAction"
+            nzShowIcon></nz-alert>
+          <ng-template #errorAction>
+            <button
+              nz-button
+              nzDanger
+              nzType="dashed"
+              nzSize="small"
+              nzShape="round"
+              nz-popover
+              [nzPopoverContent]="content">
               <span
-                nz-icon
-                nzType="question-circle"
-                nzTheme="fill"></span>
-              SYNTAX ASSISTANCE
-            </span>
-          </button>
+                nz-tooltip
+                [nzTooltipTitle]="error.errorHelp">
+                <span
+                  nz-icon
+                  nzType="question-circle"
+                  nzTheme="fill"></span>
+                SYNTAX ASSISTANCE
+              </span>
+            </button>
+          </ng-template>
         </ng-template>
       </ng-container>
 
@@ -64,7 +86,7 @@
         <ng-template #messageAction>
           <button
             nz-button
-            nzType="dashed"
+            nzType="primary"
             nzSize="small"
             nzShape="round">
             <span
@@ -261,88 +283,88 @@
         </button>
       </nz-space>
     </nz-col>
+    <!--
+     APPEND BUTTON POPOVER TEMPLATES
+    -->
+
+    <!-- append #VID -->
+    <ng-template #appendVariant>
+      <div class="append-popover-contents">
+        <nz-row [nzGutter]="[6, 8]">
+          <nz-col nzSpan="24">
+            <p
+              nz-typography
+              nzType="secondary"
+              style="margin: 0; padding-bottom: 2px">
+              Select a Gene and Variant to append its #VID.
+            </p>
+          </nz-col>
+          <nz-col nzSpan="24">
+            <cvc-mp-finder
+              (cvcOnVariantSelect)="
+                onVariantSelect$.next({ variant: $event, prependNot: false })
+              ">
+            </cvc-mp-finder>
+          </nz-col>
+        </nz-row>
+      </div>
+    </ng-template>
+
+    <!-- append NOT + #VID -->
+    <ng-template #appendNotVariant>
+      <div class="append-popover-contents">
+        <nz-row [nzGutter]="[6, 8]">
+          <nz-col nzSpan="24">
+            <p
+              nz-typography
+              nzType="secondary"
+              style="margin: 0; padding-bottom: 2px">
+              Select a Gene and Variant to append its #VID, prepended with NOT
+              boolean.
+            </p>
+          </nz-col>
+          <nz-col nzSpan="24">
+            <cvc-mp-finder
+              (cvcOnVariantSelect)="
+                onVariantSelect$.next({ variant: $event, prependNot: true })
+              ">
+            </cvc-mp-finder>
+          </nz-col>
+        </nz-row>
+      </div>
+    </ng-template>
+
+    <!-- MP examples popover template -->
+    <ng-template #expressionExamples>
+      <div style="min-width: 500px; margin: -8px -12px">
+        <nz-list
+          nzSize="small"
+          nzItemLayout="horizontal">
+          <nz-list-item *ngFor="let example of exampleExpressions">
+            <nz-list-item-meta>
+              <nz-list-item-meta-title>
+                <cvc-entity-tag
+                  [cvcLinkableEntity]="example.mp"></cvc-entity-tag>
+              </nz-list-item-meta-title>
+              <nz-list-item-meta-description>
+                {{ example.description }}
+              </nz-list-item-meta-description>
+            </nz-list-item-meta>
+            <ul nz-list-item-actions>
+              <nz-list-item-action>
+                <button
+                  type="button"
+                  nz-button
+                  nzType="primary"
+                  nzSize="small"
+                  (click)="onSelectExample$.next(example)">
+                  Select
+                </button>
+              </nz-list-item-action>
+            </ul>
+          </nz-list-item>
+        </nz-list>
+      </div>
+    </ng-template>
   </nz-row>
 </cvc-form-submission-status-display>
-
-<!--
-     APPEND BUTTON POPOVER TEMPLATES
--->
-
-<!-- append #VID -->
-<ng-template #appendVariant>
-  <div class="append-popover-contents">
-    <nz-row [nzGutter]="[6, 8]">
-      <nz-col nzSpan="24">
-        <p
-          nz-typography
-          nzType="secondary"
-          style="margin: 0; padding-bottom: 2px">
-          Select a Gene and Variant to append its #VID.
-        </p>
-      </nz-col>
-      <nz-col nzSpan="24">
-        <cvc-mp-finder
-          (cvcOnVariantSelect)="
-            onVariantSelect$.next({ variant: $event, prependNot: false })
-          ">
-        </cvc-mp-finder>
-      </nz-col>
-    </nz-row>
-  </div>
-</ng-template>
-
-<!-- append NOT + #VID -->
-<ng-template #appendNotVariant>
-  <div class="append-popover-contents">
-    <nz-row [nzGutter]="[6, 8]">
-      <nz-col nzSpan="24">
-        <p
-          nz-typography
-          nzType="secondary"
-          style="margin: 0; padding-bottom: 2px">
-          Select a Gene and Variant to append its #VID, prepended with NOT
-          boolean.
-        </p>
-      </nz-col>
-      <nz-col nzSpan="24">
-        <cvc-mp-finder
-          (cvcOnVariantSelect)="
-            onVariantSelect$.next({ variant: $event, prependNot: true })
-          ">
-        </cvc-mp-finder>
-      </nz-col>
-    </nz-row>
-  </div>
-</ng-template>
-
-<!-- MP examples popover template -->
-<ng-template #expressionExamples>
-  <div style="min-width: 500px; margin: -8px -12px">
-    <nz-list
-      nzSize="small"
-      nzItemLayout="horizontal">
-      <nz-list-item *ngFor="let example of exampleExpressions">
-        <nz-list-item-meta>
-          <nz-list-item-meta-title>
-            <cvc-entity-tag [cvcLinkableEntity]="example.mp"></cvc-entity-tag>
-          </nz-list-item-meta-title>
-          <nz-list-item-meta-description>
-            {{ example.description }}
-          </nz-list-item-meta-description>
-        </nz-list-item-meta>
-        <ul nz-list-item-actions>
-          <nz-list-item-action>
-            <button
-              type="button"
-              nz-button
-              nzType="primary"
-              nzSize="small"
-              (click)="onSelectExample$.next(example)">
-              Select
-            </button>
-          </nz-list-item-action>
-        </ul>
-      </nz-list-item>
-    </nz-list>
-  </div>
-</ng-template>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -24,58 +24,10 @@
         </ng-container>
       </div>
     </nz-col>
+
+    <!-- MESSAGES & ALERTS ROW -->
     <nz-col nzSpan="24">
-      <!-- ERROR -->
-      <ng-container *ngIf="expressionError$ | ngrxPush as error">
-        <ng-container [ngSwitch]="error.errorType">
-          <ng-container *ngSwitchCase="'invalidVariant'">
-            <ng-container
-              *ngTemplateOutlet="
-                errorAlert;
-                context: { $implicit: error, helpContent: invalidVariantHelp }
-              ">
-            </ng-container>
-          </ng-container>
-        </ng-container>
-
-        <!-- ERROR HELP TEMPLATES -->
-        <ng-template #invalidVariantHelp>
-          <span>INVALID VARIANT</span>
-        </ng-template>
-
-        <ng-template
-          #errorAlert
-          let-error
-          let-content="helpContent">
-          <nz-alert
-            nzType="error"
-            [nzMessage]="error.errorMessage"
-            [nzAction]="errorAction"
-            nzShowIcon></nz-alert>
-          <ng-template #errorAction>
-            <button
-              nz-button
-              nzDanger
-              nzType="dashed"
-              nzSize="small"
-              nzShape="round"
-              nz-popover
-              [nzPopoverContent]="content">
-              <span
-                nz-tooltip
-                [nzTooltipTitle]="error.errorHelp">
-                <span
-                  nz-icon
-                  nzType="question-circle"
-                  nzTheme="fill"></span>
-                SYNTAX ASSISTANCE
-              </span>
-            </button>
-          </ng-template>
-        </ng-template>
-      </ng-container>
-
-      <!-- MESSAGE -->
+      <!-- INITIAL MESSAGE -->
       <ng-container *ngIf="expressionMessage$ | ngrxPush as message">
         <nz-alert
           nzType="info"
@@ -85,31 +37,72 @@
 
         <ng-template #messageAction>
           <button
+            type="button"
             nz-button
             nzType="primary"
             nzSize="small"
-            nzShape="round">
+            nzShape="round"
+            nz-popover
+            nzPopoverTrigger="click"
+            [nzPopoverContent]="gettingStartedHelp">
             <span
-              nz-tooltip
-              [nzTooltipTitle]="
-                'Enter #VID[id] and boolean tokens to construct a Molecular Profile expression.'
-              ">
-              <span
-                nz-icon
-                nzType="question-circle"
-                nzTheme="fill"></span>
-              GETTING STARTED
-            </span>
+              nz-icon
+              nzType="question-circle"
+              nzTheme="fill"></span>
+            GETTING STARTED
           </button>
+          <ng-template #gettingStartedHelp>
+            <div class="help-content">
+              <p>
+                The Molecular Profile editor allows the selection or creation of
+                complex Molecular Profiles by writing Molecular Profile
+                Expressions. MP Expressions are composed with a simple language
+                comprised of Variant tokens, boolean operators, and parentheses.
+                For example:
+              </p>
+              <p><strong>#VID12 AND #VID2220</strong><br /></p>
+              <p>
+                <strong>Variant Tokens</strong><br />
+                Variant tokens are composed of a CIViC Variant ID prepended with
+                <strong>#VID</strong>, and refer to specific CIViC Variants. For
+                example, <strong>#VID12</strong> refers to
+                <strong>BRAF V600E</strong>; <strong>#VID2220</strong> refers to
+                <strong>ALK FUSION</strong>.
+              </p>
+              <p>
+                <strong>Boolean Operators</strong><br />
+                MP Expressions with more than a single variant must include
+                boolean operators - <strong>AND</strong>, <strong>OR</strong>,
+                and <strong>NOT</strong> - indicating their relationship. For
+                example, the expression
+                <strong>#VID12 AND #VID2220</strong> describes a MP that
+                includes both <strong>BRAF V600E</strong> and
+                <strong>ALK FUSION</strong>.
+              </p>
+              <p>
+                <strong>Parentheses</strong><br />
+                Expressions cannot have both <strong>AND</strong> and
+                <strong>OR</strong> operators within the same expression. To
+                construct complex MPs that require multiple operators, one must
+                use parentheses to create embedded expressions.
+              </p>
+              <p>
+                <strong>NOTE:</strong> Be sure to read the help text provided
+                along with every alert message by clicking on the 'Syntax
+                Assistance' button at the right side of its alert box.
+              </p>
+            </div>
+          </ng-template>
         </ng-template>
       </ng-container>
-      <!-- SUCCESS -->
+
+      <!-- SUCCESS - displays either a 'Select MP' or 'Create MP' depending on specified MP's status -->
       <ng-container *ngrxLet="existingMp$ as mp">
         <ng-container
           *ngIf="
             !(expressionError$ | ngrxPush) && !(expressionMessage$ | ngrxPush)
           ">
-          <!-- FOUND EXISTING MP -->
+          <!-- Select MP - MP found -->
           <ng-container *ngIf="mp !== undefined">
             <nz-alert
               nzType="success"
@@ -132,7 +125,7 @@
             </ng-template>
           </ng-container>
 
-          <!-- CREATE NEW MP -->
+          <!-- Create New MP - MP not found -->
           <ng-container *ngIf="mp === undefined">
             <nz-alert
               nzType="success"
@@ -156,8 +149,130 @@
           </ng-container>
         </ng-container>
       </ng-container>
+
+      <!-- ERROR - switch statement displays an errorAlert template
+           w/ differing contexts depending on alert type -->
+      <ng-container *ngIf="expressionError$ | ngrxPush as error">
+        <ng-container [ngSwitch]="error.errorType">
+          <!-- invalid variant alert -->
+          <ng-container *ngSwitchCase="'invalidVariant'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: { $implicit: error, helpContent: invalidVariantHelp }
+              ">
+            </ng-container>
+            <!-- trailing boolean help -->
+            <ng-template #invalidVariantHelp>
+              <span>INVALID VARIANT</span>
+            </ng-template>
+          </ng-container>
+
+          <!-- trailing boolean alert -->
+          <ng-container *ngSwitchCase="'trailingBoolean'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: { $implicit: error, helpContent: trailingBooleanHelp }
+              ">
+            </ng-container>
+            <ng-template #trailingBooleanHelp>
+              <span>TRAILING BOOLEAN ERROR</span>
+            </ng-template>
+          </ng-container>
+
+          <!-- initial boolean alert -->
+          <ng-container *ngSwitchCase="'initialBoolean'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: { $implicit: error, helpContent: initialBooleanHelp }
+              ">
+            </ng-container>
+            <ng-template #initialBooleanHelp>
+              <span>INITIAL BOOLEAN ERROR</span>
+            </ng-template>
+          </ng-container>
+
+          <!-- multiple boolean alert -->
+          <ng-container *ngSwitchCase="'multipleBoolean'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: { $implicit: error, helpContent: multipleBooleanHelp }
+              ">
+            </ng-container>
+            <ng-template #multipleBooleanHelp>
+              <span>MULTIPLE BOOLEAN ERROR</span>
+            </ng-template>
+          </ng-container>
+
+          <!-- incomplete expression alert -->
+          <ng-container *ngSwitchCase="'incompleteExpression'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: {
+                  $implicit: error,
+                  helpContent: incompleteExpressionHelp
+                }
+              ">
+            </ng-container>
+            <ng-template #incompleteExpressionHelp>
+              <span>INCOMPLETE EXPRESSION ERROR</span>
+            </ng-template>
+          </ng-container>
+
+          <!-- query error alert -->
+          <ng-container *ngSwitchCase="'queryError'">
+            <ng-container
+              *ngTemplateOutlet="
+                errorAlert;
+                context: {
+                  $implicit: error,
+                  helpContent: queryErrorHelp
+                }
+              ">
+            </ng-container>
+            <ng-template #queryErrorHelp>
+              <span>QUERY ERROR</span>
+            </ng-template>
+          </ng-container>
+        </ng-container>
+
+        <!-- ERROR ALERT TEMPLATE -->
+        <ng-template
+          #errorAlert
+          let-error
+          let-content="helpContent">
+          <nz-alert
+            nzType="error"
+            [nzMessage]="error.errorMessage"
+            [nzAction]="errorAction"
+            nzShowIcon></nz-alert>
+          <ng-template #errorAction>
+            <button
+              nz-button
+              nzDanger
+              nzType="dashed"
+              nzSize="small"
+              nzShape="round"
+              nz-popover
+              nzPopoverTrigger="click"
+              [nzPopoverTitle]="error.errorHelp"
+              [nzPopoverContent]="content">
+              <span
+                nz-icon
+                nzType="question-circle"
+                nzTheme="fill"></span>
+              SYNTAX ASSISTANCE
+            </button>
+          </ng-template>
+        </ng-template>
+      </ng-container>
     </nz-col>
-    <!-- input textarea -->
+
+    <!-- INPUT TEXTAREA -->
     <nz-col nzSpan="24">
       <textarea
         #expressionEditor
@@ -168,6 +283,10 @@
         [ngModel]="inputValue$ | ngrxPush"
         (ngModelChange)="onInputChange$.next($event)"></textarea>
     </nz-col>
+  </nz-row>
+
+  <!-- BUTTON ROW -->
+  <nz-row class="btn-row">
     <nz-col nzFlex="80px">
       <button
         nzBlock

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -154,7 +154,7 @@
         nzShape="round"
         nzSize="small"
         nz-popover
-        nzPopoverTitle="Example Molecular Profile Expressions"
+        nzPopoverTitle="Select a Profile to view its expression"
         nzPopoverTrigger="click"
         [nzPopoverContent]="expressionExamples"
         nzPopoverPlacement="bottom">
@@ -276,8 +276,8 @@
         <p
           nz-typography
           nzType="secondary"
-          style="margin: 0; padding-bottom: 6px">
-          Select a Gene then a Variant to append its #VID.
+          style="margin: 0; padding-bottom: 2px">
+          Select a Gene and Variant to append its #VID.
         </p>
       </nz-col>
       <nz-col nzSpan="24">
@@ -299,8 +299,8 @@
         <p
           nz-typography
           nzType="secondary"
-          style="margin: 0; padding-bottom: 6px">
-          Select a Gene then a Variant to append its #VID, prepended with NOT
+          style="margin: 0; padding-bottom: 2px">
+          Select a Gene and Variant to append its #VID, prepended with NOT
           boolean.
         </p>
       </nz-col>
@@ -317,21 +317,32 @@
 
 <!-- MP examples popover template -->
 <ng-template #expressionExamples>
-  <div class="append-popover-contents">
-    <nz-row [nzGutter]="[6, 8]">
-      <nz-col nzSpan="24">
-        <p
-          nz-typography
-          nzType="secondary"
-          style="margin: 0; padding-bottom: 6px">
-          Click a profile to view its expression in the editor.
-        </p>
-      </nz-col>
-      <nz-col nzSpan="24">
-        <nz-list>
-          <nz-list-item> </nz-list-item>
-        </nz-list>
-      </nz-col>
-    </nz-row>
+  <div style="min-width: 500px; margin: -8px -12px">
+    <nz-list
+      nzSize="small"
+      nzItemLayout="horizontal">
+      <nz-list-item *ngFor="let example of exampleExpressions">
+        <nz-list-item-meta>
+          <nz-list-item-meta-title>
+            <cvc-entity-tag [cvcLinkableEntity]="example.mp"></cvc-entity-tag>
+          </nz-list-item-meta-title>
+          <nz-list-item-meta-description>
+            {{ example.description }}
+          </nz-list-item-meta-description>
+        </nz-list-item-meta>
+        <ul nz-list-item-actions>
+          <nz-list-item-action>
+            <button
+              type="button"
+              nz-button
+              nzType="primary"
+              nzSize="small"
+              (click)="onSelectExample$.next(example)">
+              Select
+            </button>
+          </nz-list-item-action>
+        </ul>
+      </nz-list-item>
+    </nz-list>
   </div>
 </ng-template>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -88,7 +88,7 @@
               </button>
             </ng-template>
             <ng-template #foundMessage>
-             Molecular Profile <strong>{{ mp.name }}</strong> found.
+              Molecular Profile <strong>{{ mp.name }}</strong> found.
             </ng-template>
           </ng-container>
 
@@ -143,7 +143,7 @@
 
   <nz-row [nzGutter]="[6, 6]">
     <!-- input textarea -->
-    <nz-col nzSpan="24">
+    <nz-col nzFlex="auto">
       <textarea
         nz-input
         rows="1"
@@ -152,9 +152,36 @@
         [ngModel]="inputValue$ | ngrxPush"
         (ngModelChange)="onInputChange$.next($event)"></textarea>
     </nz-col>
+    <nz-col nzFlex="50px">
+      <button
+        type="button"
+        nz-button
+        nzType="default"
+        nzBlock
+        nz-popover
+        nzPopoverTitle="Append Variant #VID to Expression"
+        nzPopoverTrigger="click"
+        [nzPopoverContent]="appendVariant"
+        nzPopoverPlacement="bottom">
+        Append&nbsp;#VID
+      </button>
+      <ng-template #appendVariant>
+        <div style="min-width: 350px">
+          <p
+            nz-typography
+            nzType="secondary"
+            style="margin: 0; padding-bottom: 6px">
+            Select a Gene then a Variant to append its VID:
+          </p>
+          <cvc-mp-finder
+            (cvcOnVariantSelect)="
+              onVariantSelect$.next($event)
+            "></cvc-mp-finder>
+        </div>
+      </ng-template>
+    </nz-col>
   </nz-row>
-  <nz-row [nzGutter]="[6, 6]">
-    <!-- mp-finder form -->
+  <!--  <nz-row [nzGutter]="[6, 6]">
     <nz-col nzFlex="100px">
       <div class="finder-label">Append #VID:</div>
     </nz-col>
@@ -163,4 +190,5 @@
         (cvcOnVariantSelect)="onVariantSelect$.next($event)"></cvc-mp-finder>
     </nz-col>
   </nz-row>
+  -->
 </cvc-form-submission-status-display>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -7,8 +7,8 @@
   <nz-row
     [nzGutter]="[6, 6]"
     class="info-row">
-    <!-- ERROR -->
     <nz-col nzSpan="24">
+      <!-- ERROR -->
       <ng-container *ngIf="expressionError$ | ngrxPush as error">
         <nz-alert
           nzType="error"
@@ -35,6 +35,7 @@
           </button>
         </ng-template>
       </ng-container>
+
       <!-- MESSAGE -->
       <ng-container *ngIf="expressionMessage$ | ngrxPush as message">
         <nz-alert
@@ -64,45 +65,48 @@
         </ng-template>
       </ng-container>
       <!-- SUCCESS -->
-      <ng-container
-        *ngIf="
-          !(expressionError$ | ngrxPush) && !(expressionMessage$ | ngrxPush)
-        ">
-        <!-- FOUND EXISTING MP -->
-        <ng-container *ngIf="existingMp$ | ngrxPush as mp">
-          <nz-alert
-            nzType="success"
-            [nzMessage]="'Molecular Profile ' + mp.name + ' found.'"
-            [nzAction]="selectAction"
-            nzShowIcon></nz-alert>
-          <ng-template #selectAction>
-            <button
-              (click)="cvcOnSelect.next(mp)"
-              type="button"
-              nz-button
-              nzType="primary"
-              nzBlock>
-              Select MP
-            </button>
-          </ng-template>
-        </ng-container>
-        <!-- CREATE NEW MP -->
-        <ng-container *ngIf="!(existingMp$ | ngrxPush)">
-          <nz-alert
-            nzType="success"
-            [nzMessage]="'Create new Molecular Profile'"
-            [nzAction]="createAction"
-            nzShowIcon></nz-alert>
-          <ng-template #createAction>
-          <button
-            (click)="onCreateNewMp$.next()"
-            type="button"
-            nz-button
-            nzType="primary"
-            nzBlock>
-            Create New MP
-          </button>
-          </ng-template>
+      <ng-container *ngrxLet="existingMp$ as mp">
+        <ng-container
+          *ngIf="
+            !(expressionError$ | ngrxPush) && !(expressionMessage$ | ngrxPush)
+          ">
+          <!-- FOUND EXISTING MP -->
+          <ng-container *ngIf="mp !== undefined">
+            <nz-alert
+              nzType="success"
+              [nzMessage]="'Molecular Profile ' + mp.name + ' found.'"
+              [nzAction]="selectAction"
+              nzShowIcon></nz-alert>
+            <ng-template #selectAction>
+              <button
+                (click)="cvcOnSelect.next(mp)"
+                type="button"
+                nz-button
+                nzType="primary"
+                nzBlock>
+                Select&nbsp;<strong>{{ mp.name }}</strong>
+              </button>
+            </ng-template>
+          </ng-container>
+
+          <!-- CREATE NEW MP -->
+          <ng-container *ngIf="mp === undefined">
+            <nz-alert
+              nzType="success"
+              [nzMessage]="'Create new Molecular Profile'"
+              [nzAction]="createAction"
+              nzShowIcon></nz-alert>
+            <ng-template #createAction>
+              <button
+                (click)="onCreateNewMp$.next()"
+                type="button"
+                nz-button
+                nzType="primary"
+                nzBlock>
+                Create New MP
+              </button>
+            </ng-template>
+          </ng-container>
         </ng-container>
       </ng-container>
     </nz-col>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.html
@@ -5,8 +5,7 @@
   <ng-template #success>Added new Molecular Profile</ng-template>
 
   <!-- PREVIEW ROW -->
-  <nz-row
-    [nzGutter]="[6, 8]">
+  <nz-row [nzGutter]="[6, 8]">
     <!-- preview row -->
     <nz-col nzSpan="24">
       <div
@@ -123,6 +122,7 @@
                 (click)="onCreateNewMp$.next()"
                 type="button"
                 nz-button
+                nzSize="small"
                 nzType="primary"
                 nzBlock>
                 Create New MP
@@ -197,16 +197,6 @@
           nzType="primary"
           nzSize="small"
           nzShape="round"
-          (click)="onAppendInput$.next('NOT')">
-          <strong>NOT</strong>
-        </button>
-        <button
-          *nzSpaceItem
-          type="button"
-          nz-button
-          nzType="primary"
-          nzSize="small"
-          nzShape="round"
           (click)="onAppendInput$.next('(')">
           <strong>(</strong>
         </button>
@@ -222,17 +212,30 @@
         </button>
       </nz-space>
       <ng-template #appendVariant>
-        <div style="min-width: 350px">
-          <p
-            nz-typography
-            nzType="secondary"
-            style="margin: 0; padding-bottom: 6px">
-            Select a Gene then a Variant to append its VID:
-          </p>
-          <cvc-mp-finder
-            (cvcOnVariantSelect)="
-              onVariantSelect$.next($event)
-            "></cvc-mp-finder>
+        <div class="append-variant-content">
+          <nz-row [nzGutter]="[6, 8]">
+            <nz-col nzSpan="24">
+              <p
+                nz-typography
+                nzType="secondary"
+                style="margin: 0; padding-bottom: 6px">
+                Select a Gene then a Variant to append its VID.
+              </p>
+            </nz-col>
+            <nz-col nzFlex="50px">
+              <label
+                nz-checkbox
+                [(ngModel)]="varSelectNOTChecked"
+              class="var-select-not">
+                Prepend <strong>NOT</strong>
+              </label>
+            </nz-col>
+            <nz-col nzFlex="auto">
+              <cvc-mp-finder
+                (cvcOnVariantSelect)="onVariantSelect$.next($event)">
+              </cvc-mp-finder>
+            </nz-col>
+          </nz-row>
         </div>
       </ng-template>
     </nz-col>

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -17,7 +17,7 @@
     background-color: white;
   }
 }
-.append-variant-content {
+.append-popover-contents {
   width: 450px;
 }
 .btn-divider {

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -1,3 +1,5 @@
+@import "themes/global-variables.less";
+
 :host {
   display: block;
   background-color: #f6f6f6;
@@ -28,4 +30,13 @@
   button {
     height: 38px;
   }
+}
+.append-variant-content {
+  width: 450px;
+}
+
+.var-select-not {
+  line-height: 26px;
+  color: fade(@black, 60%);
+  white-space: nowrap;
 }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -20,6 +20,13 @@
 .append-popover-contents {
   min-width: 450px;
 }
-.btn-divider {
-  color: #aaa;
+.help-content {
+  max-width: 500px;
+}
+.btn-row {
+  margin-top: 10px;
+  flex-wrap: nowrap;
+  .btn-divider {
+    color: #aaa;
+  }
 }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -1,21 +1,19 @@
 :host {
-    display: block;
-    background-color: #F6F6F6;
-    border: 1px solid #DEDEDE;
-    border-radius: 4px;
-    padding: 8px;
+  display: block;
+  background-color: #f6f6f6;
+  border: 1px solid #dedede;
+  border-radius: 4px;
+  padding: 8px;
 }
 
 .expression-preview {
-    width: 100%;
-    padding: 8px;
-    margin: 4px 0 8px 0;
-    // background-color: #FFF;
-    // border: 1px solid #EFEFEF;
-    // border-radius: 8px;
-    // &.active {
-    //   background-color: white;
-    // }
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #dedede;
+  border-radius: 4px;
+  &.active {
+    background-color: white;
+  }
 }
 
 .finder-label {
@@ -24,10 +22,6 @@
   text-align: right;
 }
 .info-row {
-  flex-wrap: nowrap;
-}
-.preview-row {
-  padding-top: 6px;
   flex-wrap: nowrap;
 }
 .action-buttons {

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -22,6 +22,15 @@
   line-height: 26px;
   text-align: right;
 }
-.preview-row {
+.info-row {
   flex-wrap: nowrap;
+}
+.preview-row {
+  padding-top: 6px;
+  flex-wrap: nowrap;
+}
+.action-buttons {
+  button {
+    height: 38px;
+  }
 }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -10,12 +10,12 @@
     width: 100%;
     padding: 8px;
     margin: 4px 0 8px 0;
-    background-color: #FFF;
-    border: 1px solid #EFEFEF;
-    border-radius: 8px;
-    &.active {
-      background-color: white;
-    }
+    // background-color: #FFF;
+    // border: 1px solid #EFEFEF;
+    // border-radius: 8px;
+    // &.active {
+    //   background-color: white;
+    // }
 }
 
 .finder-label {

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -18,7 +18,7 @@
   }
 }
 .append-popover-contents {
-  width: 450px;
+  min-width: 450px;
 }
 .btn-divider {
   color: #aaa;

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -8,10 +8,11 @@
 
 .expression-preview {
     width: 100%;
-    padding: 3px;
-    background-color: #f5f5f5;
-    border: 1px solid #CCCCCC;
-    border-radius: 2px;
+    padding: 8px;
+    margin: 4px 0 8px 0;
+    background-color: #FFF;
+    border: 1px solid #EFEFEF;
+    border-radius: 8px;
     &.active {
       background-color: white;
     }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.less
@@ -1,4 +1,4 @@
-@import "themes/global-variables.less";
+@import 'themes/global-variables.less';
 
 :host {
   display: block;
@@ -17,26 +17,9 @@
     background-color: white;
   }
 }
-
-.finder-label {
-  font-weight: 500;
-  line-height: 26px;
-  text-align: right;
-}
-.info-row {
-  flex-wrap: nowrap;
-}
-.action-buttons {
-  button {
-    height: 38px;
-  }
-}
 .append-variant-content {
   width: 450px;
 }
-
-.var-select-not {
-  line-height: 26px;
-  color: fade(@black, 60%);
-  white-space: nowrap;
+.btn-divider {
+  color: #aaa;
 }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -125,6 +125,9 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
   ngAfterViewInit(): void {
     this.onInputChange$
       .pipe(
+        tap((input) => {
+          if (!input) this.expressionSegment$.next(undefined)
+        }),
         filter(isNonNulled),
         tap((input) => {
           if (input.length === 0) {

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -150,6 +150,8 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
         }),
         // filter empty input strings
         filter((input: string) => input.length > 0),
+        // filter input strings w/ space at end
+        filter((input: string) => input[input.length - 1] !== ' '),
         map((input: string) => {
           let res: MpParseError | MolecularProfileComponentInput =
             parseMolecularProfile(input)

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -218,6 +218,7 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
               this.expressionError$.next({
                 errorType: 'queryError',
                 errorMessage: errors.map((e) => e.message).join('\n'),
+                errorHelp: 'CIViC could not parse the provided MP Expression',
               })
               this.expressionSegment$.next(undefined)
             } else {
@@ -359,7 +360,7 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
     ).then(({ data }) => {
       if (!data?.molecularProfile?.id) {
         console.error(
-          `MpExpressionEditor could not fetch MolecularProfile:${mpId} to prepulate editor fields.`
+          `MpExpressionEditor could not fetch MolecularProfile:${mpId} to prepolate editor fields.`
         )
         return
       }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -107,7 +107,7 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
     initial: 'Use the editor below to construct a molecular profile.',
   }
 
-  varSelectNOTChecked: boolean = false
+  // exampleExpressions: Map<>
 
   constructor(
     private previewMpGql: PreviewMolecularProfileName2GQL,
@@ -183,6 +183,7 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
             if (errors) {
               this.expressionMessage$.next(undefined)
               this.expressionError$.next({
+                errorType: 'queryError',
                 errorMessage: errors.map((e) => e.message).join('\n'),
               })
               this.expressionSegment$.next(undefined)

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -58,6 +58,7 @@ import { pluck } from 'rxjs-etc/dist/esm/operators/pluck'
 import { tag } from 'rxjs-spy/operators'
 
 type AppendableValue = 'AND' | 'OR' | 'NOT' | '(' | ')'
+type AppendVariant = { variant: Variant; prependNot: boolean }
 
 @UntilDestroy()
 @Component({
@@ -91,7 +92,7 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
   // SOURCE STREAMS
   onInputChange$: BehaviorSubject<Maybe<string>>
   onAppendInput$: Subject<AppendableValue>
-  onVariantSelect$: Subject<Variant>
+  onVariantSelect$: Subject<AppendVariant>
   onCreateNewMp$: Subject<void>
 
   // PRESENTATION STREAMS
@@ -119,10 +120,11 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
     )
     this.onInputChange$ = new BehaviorSubject<Maybe<string>>(undefined)
     this.onAppendInput$ = new Subject<AppendableValue>()
-    this.onVariantSelect$ = new Subject<Variant>()
+    this.onVariantSelect$ = new Subject<AppendVariant>()
     this.onCreateNewMp$ = new Subject<void>()
     this.inputValue$ = new BehaviorSubject<string>('')
     this.expressionError$ = new BehaviorSubject<Maybe<MpParseError>>(undefined)
+    this.expressionError$.pipe(tag('expressionError$')).subscribe()
     this.expressionHelp$ = new BehaviorSubject<Maybe<string>>(undefined)
     this.expressionMessage$ = new BehaviorSubject<Maybe<string>>(
       this.expressionMessages.initial
@@ -221,9 +223,11 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
     this.onVariantSelect$
       .pipe(
         withLatestFrom(this.onInputChange$),
-        map(([variant, input]) => {
+        map(([append, input]) => {
           // prepent 'NOT' if 'Prepend NOT' checked
-          const newVariant = `${this.varSelectNOTChecked ? 'NOT ' : ''}#VID${variant.id}`
+          const newVariant = `${append.prependNot ? 'NOT ' : ''}#VID${
+            append.variant.id
+          }`
           if (!input || input.trim().length == 0) {
             return newVariant
           } else {

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -94,7 +94,7 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
 
   expressionMessages = {
     initial:
-      'Start constructing a complex molecular profile to preview it here',
+      'Start constructing a complex molecular profile to preview below.',
   }
 
   constructor(

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -190,10 +190,10 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
       .pipe(
         withLatestFrom(this.onInputChange$),
         map(([variant, input]) => {
-          if (!input || input.length == 0) {
+          if (!input || input.trim().length == 0) {
             return `#VID${variant.id}`
           } else {
-            return `${input} #VID${variant.id}`
+            return `${input.trim()} #VID${variant.id}`
           }
         }),
         // tag('onVariantSelect$'),

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -119,6 +119,7 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
     )
     this.expressionSegment$ = new Subject<Maybe<PreviewMpName2Fragment[]>>()
     this.existingMp$ = new Subject<Maybe<MolecularProfile>>()
+    this.existingMp$.pipe(tag('existingMp$')).subscribe()
   }
 
   ngAfterViewInit(): void {

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -106,6 +106,8 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
     initial: 'Use the editor below to construct a molecular profile.',
   }
 
+  varSelectNOTChecked: boolean = false
+
   constructor(
     private previewMpGql: PreviewMolecularProfileName2GQL,
     private createMolecularProfileGql: CreateMolecularProfile2GQL,
@@ -199,27 +201,33 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
         }
       })
 
-    this.onAppendInput$.pipe(untilDestroyed(this)).subscribe((append: AppendableValue) => {
-      // if expressionEditor exists, append to its current value and set field value to results
-      if (this.expressionEditor) {
-        const editor = this.expressionEditor.nativeElement as HTMLInputElement
-        const current = editor.value
-        // append to current value, but only if it doesn't already end with a space
-        const newValue = `${current}${/\s+$/.test(append) ? append : ' ' + append}`
-        editor.value = newValue
-        this.inputValue$.next(newValue)
-        this.onInputChange$.next(newValue)
-      }
-    })
+    this.onAppendInput$
+      .pipe(untilDestroyed(this))
+      .subscribe((append: AppendableValue) => {
+        // if expressionEditor exists, append to its current value and set field value to results
+        if (this.expressionEditor) {
+          const editor = this.expressionEditor.nativeElement as HTMLInputElement
+          const current = editor.value
+          // append to current value, but only if it doesn't already end with a space
+          const newValue = `${current}${
+            /\s+$/.test(append) ? append : ' ' + append
+          }`
+          editor.value = newValue
+          this.inputValue$.next(newValue)
+          this.onInputChange$.next(newValue)
+        }
+      })
 
     this.onVariantSelect$
       .pipe(
         withLatestFrom(this.onInputChange$),
         map(([variant, input]) => {
+          // prepent 'NOT' if 'Prepend NOT' checked
+          const newVariant = `${this.varSelectNOTChecked ? 'NOT ' : ''}#VID${variant.id}`
           if (!input || input.trim().length == 0) {
-            return `#VID${variant.id}`
+            return newVariant
           } else {
-            return `${input.trim()} #VID${variant.id}`
+            return `${input.trim()} ${newVariant}`
           }
         }),
         // tag('onVariantSelect$'),

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -1,7 +1,6 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -36,7 +35,6 @@ import {
   PreviewMolecularProfileName2Query,
   PreviewMolecularProfileName2QueryVariables,
   PreviewMpName2Fragment,
-  QuicksearchGQL,
   QuicksearchQuery,
   QuicksearchQueryVariables,
   Variant,
@@ -45,18 +43,17 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { QueryRef } from 'apollo-angular'
 import {
   BehaviorSubject,
+  debounceTime,
   filter,
   lastValueFrom,
   map,
   Observable,
   Subject,
-  withLatestFrom,
   tap,
-  debounceTime,
+  withLatestFrom,
 } from 'rxjs'
 import { isNonNulled } from 'rxjs-etc'
 import { pluck } from 'rxjs-etc/dist/esm/operators/pluck'
-import { tag } from 'rxjs-spy/operators'
 
 type AppendableValue = 'AND' | 'OR' | 'NOT' | '(' | ')'
 type AppendVariant = { variant: Variant; prependNot: boolean }

--- a/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms2/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -64,7 +64,6 @@ import { tag } from 'rxjs-spy/operators'
 export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
   @Input() cvcPrepopulateWithId: Maybe<number>
   @Output() cvcOnSelect = new EventEmitter<MolecularProfile>()
-  @Output() cvcOnEditPrepopulated = new EventEmitter<boolean>()
 
   previewQueryRef?: QueryRef<
     PreviewMolecularProfileName2Query,
@@ -125,23 +124,24 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
   ngAfterViewInit(): void {
     this.onInputChange$
       .pipe(
+        // clear preview if input is empty
         tap((input) => {
           if (!input) this.expressionSegment$.next(undefined)
         }),
+        // filter undefined inputs
         filter(isNonNulled),
+        // reset error, message if input string is empty
         tap((input) => {
           if (input.length === 0) {
             this.expressionMessage$.next(this.expressionMessages.initial)
             this.expressionError$.next(undefined)
           }
         }),
+        // filter empty input strings
         filter((input: string) => input.length > 0),
         map((input: string) => {
           let res: MpParseError | MolecularProfileComponentInput =
             parseMolecularProfile(input)
-          if (this.cvcPrepopulateWithId !== undefined) {
-            this.cvcOnEditPrepopulated.next(true)
-          }
           if ('errorMessage' in res) {
             return res
           } else {

--- a/client/src/app/forms2/types/variant-select/variant-select.type.html
+++ b/client/src/app/forms2/types/variant-select/variant-select.type.html
@@ -1,27 +1,34 @@
 <nz-row [nzGutter]="[6, 6]">
   <nz-col nzFlex="auto">
-    <cvc-entity-select
-      [cvcAddEntity]="addVariant"
-      [cvcAddEntityModel]="onModel$ | ngrxPush"
-      [cvcSelectMode]="props.isMultiSelect ? 'multiple' : 'default'"
-      [cvcCustomTemplate]="selectedTemplate"
-      [cvcFormControl]="formControl"
-      [cvcFormlyAttributes]="field"
-      [cvcEntityName]="props.entityName"
-      [cvcPlaceholder]="props.placeholder"
-      [cvcResults]="result$ | ngrxPush"
-      [cvcDisabled]="props.requireGene && !(onGeneId$ | ngrxPush)"
-      [cvcOptions]="selectOption$ | ngrxPush"
-      [cvcSelectOpen]="selectOpen$ | ngrxPush"
-      [cvcShowError]="showError"
-      [cvcLoading]="isLoading$ | ngrxPush"
-      [cvcParamName]="onGeneName$ | ngrxPush"
-      (cvcOnSearch)="onSearch$.next($event)"
-      (cvcOnOpenChange)="onOpenChange$.next($event)"
-      (cvcOnModelChange)="props.change && props.change(field, $event)">
-    </cvc-entity-select>
+    <span
+      nz-tooltip
+      [nzTooltipTrigger]="(props.requireGene && !(onGeneId$ | ngrxPush)) ? 'hover' : null"
+      nzTooltipTitle="Select a Gene to enable field.">
+      <cvc-entity-select
+        [cvcAddEntity]="addVariant"
+        [cvcAddEntityModel]="onModel$ | ngrxPush"
+        [cvcSelectMode]="props.isMultiSelect ? 'multiple' : 'default'"
+        [cvcCustomTemplate]="selectedTemplate"
+        [cvcFormControl]="formControl"
+        [cvcFormlyAttributes]="field"
+        [cvcEntityName]="props.entityName"
+        [cvcPlaceholder]="props.placeholder"
+        [cvcResults]="result$ | ngrxPush"
+        [cvcDisabled]="props.requireGene && !(onGeneId$ | ngrxPush)"
+        [cvcOptions]="selectOption$ | ngrxPush"
+        [cvcSelectOpen]="selectOpen$ | ngrxPush"
+        [cvcShowError]="showError"
+        [cvcLoading]="isLoading$ | ngrxPush"
+        [cvcParamName]="onGeneName$ | ngrxPush"
+        (cvcOnSearch)="onSearch$.next($event)"
+        (cvcOnOpenChange)="onOpenChange$.next($event)"
+        (cvcOnModelChange)="props.change && props.change(field, $event)">
+      </cvc-entity-select>
+    </span>
   </nz-col>
-  <nz-col *ngIf="props.showManagerBtn" nzFlex="50px">
+  <nz-col
+    *ngIf="props.showManagerBtn"
+    nzFlex="50px">
     <button
       type="button"
       nz-button
@@ -44,8 +51,7 @@
     *ngIf="showMgr$ | ngrxPush">
     <cvc-variant-manager
       [cvcSelectedIds]="onVid$ | ngrxPush"
-      (cvcSelectedIdsChange)="onPopulate$.next($event)"
-      ></cvc-variant-manager>
+      (cvcSelectedIdsChange)="onPopulate$.next($event)"></cvc-variant-manager>
   </nz-col>
 </nz-row>
 

--- a/client/src/app/forms2/types/variant-select/variant-select.type.ts
+++ b/client/src/app/forms2/types/variant-select/variant-select.type.ts
@@ -271,7 +271,7 @@ export class CvcVariantSelectField
     if (!gid && this.props.requireGene) {
       this.resetField()
       this.props.description = this.props.requireGenePrompt
-      this.props.placeholder = 'Select A Gene'
+      this.props.placeholder = 'Select a Variant'
       this.props.extraType = 'prompt'
       this.onGeneName$.next(undefined)
     } else if (gid) {


### PR DESCRIPTION
Fixes a number of layout, style, and display logic issues/annoyances:
- improved layout of expression editor by reducing the number of UI elements, text
-- all error editor messages (errors, actions, buttons) moved out of the editor and/or preview window into alert components
-- errors shortened into message and 'help' components, help text available via tooltip in alert
-- removed editor/preview component labels
-- moved Append VID form into a button popover
- improved interaction of the parent mp-select and editor w/ improved messages & display logic
-- mp-select's tag or gene/variant form replaced w/ 'Select MP...' message if Editor is open
-- editor messages & button display 'Select' or 'Add' messaging/actions depending on MP's existence

**IMPROVED LAYOUT**
<img width="606" alt="Screen Shot 2023-04-27 at 12 53 49" src="https://user-images.githubusercontent.com/132909/234950815-fe131b78-9f14-44f3-9e34-3107792fae1a.png">

**IMPROVED ERROR MESSAGES**
<img width="628" alt="Screen Shot 2023-04-27 at 12 54 31" src="https://user-images.githubusercontent.com/132909/234950988-7c9a0155-d5ec-44e7-a815-5560c615e645.png">

**RELOCATED APPEND VID FORM**
<img width="735" alt="Screen Shot 2023-04-27 at 12 55 50" src="https://user-images.githubusercontent.com/132909/234951297-e48d0e84-9543-4646-b6de-bde93c8c4bdb.png">
