### PR TITLE
platform & gem updates for arm64 architecture

### DIFF
--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
       net-protocol
     net-ssh (7.1.0)
     nio4r (2.5.9)
+    nokogiri (1.14.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
@@ -456,6 +458,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 


### PR DESCRIPTION
These changes in Gemfile.lock were added by bundler. If they can be merged w/o breaking the server on other platforms it would be helpful, since I have been reverting these whenever they occur in order to keep them out of client-side commits.