### PR TITLE
Display HPO term definitions when available

### DIFF
--- a/client/src/app/generated/civic.apollo-helpers.ts
+++ b/client/src/app/generated/civic.apollo-helpers.ts
@@ -1067,17 +1067,19 @@ export type PageInfoFieldPolicy = {
 	hasPreviousPage?: FieldPolicy<any> | FieldReadFunction<any>,
 	startCursor?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PhenotypeKeySpecifier = ('hpoId' | 'id' | 'link' | 'name' | 'url' | PhenotypeKeySpecifier)[];
+export type PhenotypeKeySpecifier = ('description' | 'hpoId' | 'id' | 'link' | 'name' | 'url' | PhenotypeKeySpecifier)[];
 export type PhenotypeFieldPolicy = {
+	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	hpoId?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	link?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type PhenotypePopoverKeySpecifier = ('assertionCount' | 'evidenceItemCount' | 'hpoId' | 'id' | 'link' | 'molecularProfileCount' | 'name' | 'url' | PhenotypePopoverKeySpecifier)[];
+export type PhenotypePopoverKeySpecifier = ('assertionCount' | 'description' | 'evidenceItemCount' | 'hpoId' | 'id' | 'link' | 'molecularProfileCount' | 'name' | 'url' | PhenotypePopoverKeySpecifier)[];
 export type PhenotypePopoverFieldPolicy = {
 	assertionCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItemCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	hpoId?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -2836,6 +2836,7 @@ export type PageInfo = {
 
 export type Phenotype = {
   __typename: 'Phenotype';
+  description?: Maybe<Scalars['String']>;
   hpoId: Scalars['String'];
   id: Scalars['Int'];
   link: Scalars['String'];
@@ -2846,6 +2847,7 @@ export type Phenotype = {
 export type PhenotypePopover = {
   __typename: 'PhenotypePopover';
   assertionCount: Scalars['Int'];
+  description?: Maybe<Scalars['String']>;
   evidenceItemCount: Scalars['Int'];
   hpoId: Scalars['String'];
   id: Scalars['Int'];
@@ -6757,7 +6759,7 @@ export type PhenotypeDetailQueryVariables = Exact<{
 }>;
 
 
-export type PhenotypeDetailQuery = { __typename: 'Query', phenotype?: { __typename: 'Phenotype', id: number, name: string, hpoId: string, url: string, link: string } | undefined };
+export type PhenotypeDetailQuery = { __typename: 'Query', phenotype?: { __typename: 'Phenotype', id: number, name: string, description?: string | undefined, hpoId: string, url: string, link: string } | undefined };
 
 export type DataReleasesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -13468,6 +13470,7 @@ export const PhenotypeDetailDocument = gql`
   phenotype(id: $phenotypeId) {
     id
     name
+    description
     hpoId
     url
     link

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -4556,6 +4556,7 @@ type PageInfo {
 }
 
 type Phenotype {
+  description: String
   hpoId: String!
   id: Int!
   link: String!
@@ -4565,6 +4566,7 @@ type Phenotype {
 
 type PhenotypePopover {
   assertionCount: Int!
+  description: String
   evidenceItemCount: Int!
   hpoId: String!
   id: Int!

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -20801,6 +20801,18 @@
           "description": null,
           "fields": [
             {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hpoId",
               "description": null,
               "args": [],
@@ -20903,6 +20915,18 @@
                   "name": "Int",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.component.html
+++ b/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.component.html
@@ -19,6 +19,14 @@
     </nz-page-header-extra>
     <nz-page-header-content>
       <div class="content">
+        <nz-space nzDirection="vertical" style="width: 100%;">
+          <nz-descriptions *nzSpaceItem [nzBordered]="true" nzLayout="vertical" [nzColumn]="1">
+            <nz-descriptions-item nzTitle="Definition">
+              {{phenotype.description | ifEmpty: '--'}}
+            </nz-descriptions-item>
+          </nz-descriptions>
+          <p *nzSpaceItem></p>
+        </nz-space>
         <router-outlet></router-outlet>
       </div>
     </nz-page-header-content>

--- a/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.module.ts
+++ b/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.module.ts
@@ -8,6 +8,9 @@ import { LetModule, PushModule } from '@ngrx/component'
 import { NzIconModule } from 'ng-zorro-antd/icon'
 import { NzPageHeaderModule } from 'ng-zorro-antd/page-header'
 import { PhenotypesDetailComponent } from './phenotypes-detail.component'
+import { NzCardModule } from 'ng-zorro-antd/card'
+import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions'
+import { NzSpaceModule } from 'ng-zorro-antd/space'
 
 @NgModule({
   declarations: [PhenotypesDetailComponent],
@@ -18,6 +21,8 @@ import { PhenotypesDetailComponent } from './phenotypes-detail.component'
     PushModule,
     NzPageHeaderModule,
     NzIconModule,
+    NzSpaceModule,
+    NzDescriptionsModule,
     CvcPipesModule,
     CvcLinkTagModule,
     CvcSectionNavigationModule,

--- a/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.query.gql
+++ b/client/src/app/views/phenotypes/phenotypes-detail/phenotypes-detail.query.gql
@@ -2,6 +2,7 @@ query PhenotypeDetail($phenotypeId: Int!) {
   phenotype(id: $phenotypeId) {
     id
     name
+    description
     hpoId
     url
     link

--- a/server/app/graphql/types/entities/phenotype_type.rb
+++ b/server/app/graphql/types/entities/phenotype_type.rb
@@ -3,11 +3,12 @@ module Types::Entities
     field :id, Int, null: false
     field :hpo_id, String, null: false
     field :name, String, null: false
+    field :description, String, null: true
     field :url, String, null: false
     field :link, String, null: false
 
     def name
-      object.hpo_class
+      object.hpo_class || ''
     end
   end
 end

--- a/server/app/lib/scrapers/human_phenotype_ontology.rb
+++ b/server/app/lib/scrapers/human_phenotype_ontology.rb
@@ -16,8 +16,9 @@ module Scrapers
         if about.starts_with?('http://purl.obolibrary.org/obo/HP_')
           hpo_id = about[/http:\/\/purl\.obolibrary\.org\/obo\/(HP_[0-9]*)/, 1]
           hpo_id = hpo_id.sub('_', ':')
-          name = row.at_xpath('rdfs:label').text
-          Phenotype.create(hpo_id: hpo_id, hpo_class: name)
+          name = row.at_xpath('rdfs:label')&.text
+          desc = row.at_xpath('obo:IAO_0000115')&.text
+          Phenotype.create(hpo_id: hpo_id, hpo_class: name, description: desc)
           i = i+  1
         end
       end
@@ -32,7 +33,8 @@ module Scrapers
         if about.starts_with?('http://purl.obolibrary.org/obo/HP_')
           hpo_id = about[/http:\/\/purl\.obolibrary\.org\/obo\/(HP_[0-9]*)/, 1]
           hpo_id = hpo_id.sub('_', ':')
-          name = row.at_xpath('rdfs:label').text
+          name = row.at_xpath('rdfs:label')&.text
+          desc = row.at_xpath('obo:IAO_0000115')&.text
           if !row.at_xpath('owl:deprecated').nil? && row.at_xpath('owl:deprecated').text == 'true'
             p = Phenotype.find_by(hpo_id: hpo_id)
             if !p.nil?
@@ -55,6 +57,7 @@ module Scrapers
           else
             p = Phenotype.where(hpo_id: hpo_id).first_or_create
             p.hpo_class = name
+            p.description = desc
             p.save
           end
         end
@@ -63,7 +66,7 @@ module Scrapers
 
     private
     def self.url
-      "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.owl"
+      "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp-base.owl"
     end
 
     def self.extract_class_name_from_response_for_hpo_id(resp, hpo_id)

--- a/server/db/migrate/20230622140624_add_description_to_phenotypes.rb
+++ b/server/db/migrate/20230622140624_add_description_to_phenotypes.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToPhenotypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :phenotypes, :description, :text
+  end
+end


### PR DESCRIPTION
Save the definitions when we import HPO, and display them on the frontend.

closes #840 