### PR TITLE
Fix linkouts in comments

### DIFF
--- a/server/app/models/actions/format_comment_text.rb
+++ b/server/app/models/actions/format_comment_text.rb
@@ -15,13 +15,13 @@ module Actions
         .perform
         .segments
 
-      return reference_segments.map do |segment|
-        if segment.is_a?(String)
-          segment.strip + " "
+      return reference_segments.chunk { |segment| segment.is_a?(String) }.map do |(is_strings, segments)|
+        if is_strings
+          segments.map(&:strip).map { |s| s + ' ' }.join
         else
-          segment
+          segments
         end
-      end
+      end.flatten
     end
   end
 end


### PR DESCRIPTION
Collapse contiguous text segments so tags aren't broken. The previous behavior would result in

```
{
   CommentTextSegment
   "a"
},
{
   CommentTextSegment
   "href"
}
```
and each text segment gets displayed in its own span, so the tags didn't work. closes #839 