### PR TITLE
add orcid logo to oauth login option

### DIFF
--- a/client/src/app/components/layout/auth-options-list/auth-options-list.component.html
+++ b/client/src/app/components/layout/auth-options-list/auth-options-list.component.html
@@ -38,6 +38,10 @@
         nzType="default"
         nzSize="large"
         nzShape="round">
+        <img
+          src="assets/images/orcid-logo.svg"
+          class="orcid-logo"
+          alt="ORCID Logo" />
         Sign In with an ORCID Account
       </button>
     </form>

--- a/client/src/app/components/layout/auth-options-list/auth-options-list.component.less
+++ b/client/src/app/components/layout/auth-options-list/auth-options-list.component.less
@@ -5,3 +5,13 @@
 nz-list-item form {
   width: 100%;
 }
+
+.orcid-logo {
+  width: 16px;
+  margin-right: 4px;
+  line-height: 1;
+}
+
+i {
+  font-size: 16px;
+}

--- a/client/src/app/views/users/users-detail/users-detail.component.html
+++ b/client/src/app/views/users/users-detail/users-detail.component.html
@@ -77,7 +77,10 @@
                     href="https://orcid.org/{{ user.orcid }}"
                     target="_blank"
                     *nzSpaceItem>
-                    <span>ID</span>
+                    <img
+                    src="/assets/images/orcid-logo.svg"
+                    class="orcid-logo"
+                    alt="ORCID Logo" />
                   </a>
                 </ng-container>
               </nz-space>

--- a/client/src/app/views/users/users-detail/users-detail.component.less
+++ b/client/src/app/views/users/users-detail/users-detail.component.less
@@ -52,6 +52,16 @@
     margin-bottom: 16px;
   }
 
+  .user-socials i {
+    font-size: 16px;
+    color: black;
+  }
+
+  .orcid-logo {
+    width: 16px;
+    margin-top: -4px;
+  }
+
   .content {
     margin-bottom: 8px;
   }

--- a/client/src/assets/images/orcid-logo.svg
+++ b/client/src/assets/images/orcid-logo.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 256 256" style="enable-background:new 0 0 256 256;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#000000;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z"/>
+<g>
+	<path class="st1" d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z"/>
+	<path class="st1" d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5
+		c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/>
+	<path class="st1" d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1
+		C84.2,46.7,88.7,51.3,88.7,56.8z"/>
+</g>
+</svg>


### PR DESCRIPTION
The ORCID brand guidelines say not to use their logo smaller than 16x16 pixels and our other provider icons were 14x14 so I bumped them up to 16 so they'd all be the same size...

![Screenshot 2023-06-26 at 3 59 37 PM](https://github.com/griffithlab/civic-v2/assets/13370/2416347a-0d25-4c1f-ac93-00346c37398a)


closes #371