### PR TITLE
Only show accepted/rejected by when that matches the current status

### DIFF
--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.html
@@ -183,10 +183,9 @@
             <!-- display accepted/rejected only if either exists -->
             <ng-container
               *ngIf="assertion.rejectionEvent !== null || assertion.acceptanceEvent !== null">
-              <!-- show acceptance only if no rejection event exists -->
-              <ng-container [ngSwitch]="assertion.rejectionEvent === null">
+              <!-- show acceptance only if no rejection event exists and the AID is accepted -->
+              <ng-container *ngIf="assertion.status == statusValues.Accepted && assertion.acceptanceEvent">
                 <nz-descriptions-item
-                  *ngSwitchCase="true"
                   [nzTitle]="acceptedTitle">
                   by
                   <cvc-user-tag [user]="assertion.acceptanceEvent!.originatingUser"></cvc-user-tag>
@@ -199,24 +198,25 @@
                     ({{ assertion.acceptanceEvent!.createdAt | timeAgo }})
                   </span>
                 </ng-template>
-
-                <nz-descriptions-item
-                  *ngSwitchCase="false"
-                  [nzTitle]="rejectedTitle">
-                  by {{ assertion.rejectionEvent!.createdAt | timeAgo }} by
-                  <cvc-user-tag
-                    [user]="assertion.rejectionEvent!.originatingUser"></cvc-user-tag>
-                </nz-descriptions-item>
-                <ng-template #rejectedTitle>
-                  Rejected
-                  <span
-                    nz-typography
-                    nzType="secondary">
-                    ({{ assertion.rejectionEvent!.createdAt | timeAgo }})
-                  </span>
-                </ng-template>
               </ng-container>
-            </ng-container>
+
+                <ng-container *ngIf="assertion.status == statusValues.Rejected && assertion.rejectionEvent">
+                  <nz-descriptions-item
+                    [nzTitle]="rejectedTitle">
+                    by {{ assertion.rejectionEvent!.createdAt | timeAgo }} by
+                    <cvc-user-tag
+                      [user]="assertion.rejectionEvent!.originatingUser"></cvc-user-tag>
+                  </nz-descriptions-item>
+                  <ng-template #rejectedTitle>
+                    Rejected
+                    <span
+                      nz-typography
+                      nzType="secondary">
+                      ({{ assertion.rejectionEvent!.createdAt | timeAgo }})
+                    </span>
+                  </ng-template>
+                </ng-container>
+              </ng-container>
           </nz-descriptions>
         </nz-col>
 

--- a/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.ts
+++ b/client/src/app/views/assertions/assertions-detail/assertions-summary/assertions-summary.page.ts
@@ -8,6 +8,7 @@ import {
   AssertionSummaryFieldsFragment,
   SubscribableInput,
   SubscribableEntities,
+  EvidenceStatus,
 } from '@app/generated/civic.apollo'
 import { QueryRef } from 'apollo-angular'
 import { startWith } from 'rxjs/operators'
@@ -29,6 +30,7 @@ export class AssertionsSummaryPage {
   assertion$: Observable<Maybe<AssertionSummaryFieldsFragment>>
 
   assertionRules = new AssertionState()
+  statusValues = EvidenceStatus
 
   subscribable: SubscribableInput
 

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.html
@@ -164,10 +164,9 @@
                 evidence.rejectionEvent !== null ||
                 evidence.acceptanceEvent !== null
               ">
-              <!-- show acceptance only if no rejection event exists -->
-              <ng-container [ngSwitch]="evidence.rejectionEvent === null">
+              <!-- show acceptance only if no rejection event exists and the EID is Accepted-->
+              <ng-container *ngIf="evidence.status == statusValues.Accepted && evidence.acceptanceEvent">
                 <nz-descriptions-item
-                  *ngSwitchCase="true"
                   [nzTitle]="acceptedTitle">
                   by
                   <cvc-user-tag
@@ -183,8 +182,9 @@
                     ({{ evidence.acceptanceEvent!.createdAt | timeAgo }})
                   </span>
                 </ng-template>
+              </ng-container>
+              <ng-container *ngIf="evidence.status == statusValues.Rejected && evidence.rejectionEvent">
                 <nz-descriptions-item
-                  *ngSwitchCase="false"
                   nzTitle="Rejected">
                   by
                   <cvc-user-tag

--- a/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-summary/evidence-summary.page.ts
@@ -8,6 +8,7 @@ import {
   EvidenceSummaryFieldsFragment,
   SubscribableInput,
   SubscribableEntities,
+  EvidenceStatus,
 } from '@app/generated/civic.apollo'
 import { QueryRef } from 'apollo-angular'
 import { startWith } from 'rxjs/operators'
@@ -27,6 +28,7 @@ export class EvidenceSummaryPage {
   evidence$: Observable<Maybe<EvidenceSummaryFieldsFragment>>
 
   subscribable: SubscribableInput
+  statusValues = EvidenceStatus
 
   constructor(private gql: EvidenceSummaryGQL, private route: ActivatedRoute) {
     var queryEvidenceId: number

--- a/server/app/models/assertion.rb
+++ b/server/app/models/assertion.rb
@@ -30,12 +30,12 @@ class Assertion < ActiveRecord::Base
     class_name: 'Event'
   has_one :submitter, through: :submission_event, source: :originating_user
   has_one :acceptance_event,
-    ->() { where(action: 'assertion accepted').includes(:originating_user) },
+    ->() { where(action: 'assertion accepted').includes(:originating_user).order('events.created_at desc') },
     as: :subject,
     class_name: 'Event'
   has_one :acceptor, through: :acceptance_event, source: :originating_user
   has_one :rejection_event,
-    ->() { where(action: 'assertion rejected').includes(:originating_user) },
+    ->() { where(action: 'assertion rejected').includes(:originating_user).order('events.created_at desc') },
     as: :subject,
     class_name: 'Event'
   has_one :rejector, through: :rejection_event, source: :originating_user

--- a/server/app/models/evidence_item.rb
+++ b/server/app/models/evidence_item.rb
@@ -30,12 +30,12 @@ class EvidenceItem < ActiveRecord::Base
     class_name: 'Event'
   has_one :submitter, through: :submission_event, source: :originating_user
   has_one :acceptance_event,
-    ->() { where(action: 'accepted').includes(:originating_user) },
+    ->() { where(action: 'accepted').includes(:originating_user).order('events.created_at desc') },
     as: :subject,
     class_name: 'Event'
   has_one :acceptor, through: :acceptance_event, source: :originating_user
   has_one :rejection_event,
-    ->() { where(action: 'rejected').includes(:originating_user) },
+    ->() { where(action: 'rejected').includes(:originating_user).order('events.created_at desc') },
     as: :subject,
     class_name: 'Event'
   has_one :rejector, through: :rejection_event, source: :originating_user


### PR DESCRIPTION
Also, when there is more than one acceptance event (say, in the case of a reverted EID, always display the most recent one)

closes #834