### PR TITLE
fixed NG0912 selector collision warnings

### DIFF
--- a/client/src/app/forms2/components/org-selector-btn-group/org-selector-btn-group.component.ts
+++ b/client/src/app/forms2/components/org-selector-btn-group/org-selector-btn-group.component.ts
@@ -20,7 +20,7 @@ import {
 
 @UntilDestroy()
 @Component({
-  selector: 'cvc-org-selector-btn-group',
+  selector: 'cvc-org-selector-btn-group2',
   templateUrl: './org-selector-btn-group.component.html',
   styleUrls: ['./org-selector-btn-group.component.less'],
 })

--- a/client/src/app/forms2/components/tables/table-counts/table-counts.component.ts
+++ b/client/src/app/forms2/components/tables/table-counts/table-counts.component.ts
@@ -30,7 +30,7 @@ export type EntityEdge = {
 }
 
 @Component({
-  selector: 'cvc-table-counts',
+  selector: 'cvc-table-counts2',
   templateUrl: './table-counts.component.html',
   styleUrls: ['./table-counts.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/client/src/app/forms2/mixins/base/base-field.ts
+++ b/client/src/app/forms2/mixins/base/base-field.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core'
+import { Component, Injectable, OnInit } from '@angular/core'
 import { BaseState } from '@app/forms2/states/base.state'
 import { Maybe } from '@app/generated/civic.apollo'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
@@ -16,7 +16,7 @@ export function BaseFieldType<
   V extends BaseFieldValue
 >() {
   @UntilDestroy()
-  @Component({ template: '' })
+  @Injectable()
   class BaseFieldType extends FieldType<FC> {
     state?: BaseState
 
@@ -30,10 +30,6 @@ export function BaseFieldType<
 
     // STATE OUTPUT STREAM
     stateValueChange$?: BehaviorSubject<Maybe<V>>
-
-    constructor() {
-      super() // call abstract FieldType's constructor
-    }
 
     configureBaseField(): void {
       if (!this.field?.options?.fieldChanges) {

--- a/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.component.html
+++ b/client/src/app/forms2/types/evidence-select/evidence-manager/evidence-manager.component.html
@@ -521,8 +521,8 @@
       </ng-container>
     </nz-col>
     <nz-col nzFlex="auto">
-      <cvc-table-counts
-        [cvcTableCountsConnection]="connection$"></cvc-table-counts>
+      <cvc-table-counts2
+        [cvcTableCountsConnection]="connection$"></cvc-table-counts2>
     </nz-col>
 
     <!-- card button row -->

--- a/client/src/app/forms2/types/variant-select/variant-manager/enum-filter-menu/enum-filter-menu.component.less
+++ b/client/src/app/forms2/types/variant-select/variant-manager/enum-filter-menu/enum-filter-menu.component.less
@@ -16,7 +16,7 @@
   }
   // #cdk-overlay-0
   //   > div
-  //   > cvc-enum-filter-menu
+  //   > cvc-variant-enum-filter-menu
   //   > ul
   //   > li.ant-dropdown-menu-item.ng-star-inserted.ant-dropdown-menu-item-selected;
 }

--- a/client/src/app/forms2/types/variant-select/variant-manager/enum-filter-menu/enum-filter-menu.component.ts
+++ b/client/src/app/forms2/types/variant-select/variant-manager/enum-filter-menu/enum-filter-menu.component.ts
@@ -1,10 +1,16 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core'
 import { Maybe } from 'graphql/jsutils/Maybe'
 import { NzTableFilterList } from 'ng-zorro-antd/table'
 import { CvcFilterChange } from '../variant-manager.types'
 
 @Component({
-  selector: 'cvc-enum-filter-menu',
+  selector: 'cvc-variant-enum-filter-menu',
   templateUrl: './enum-filter-menu.component.html',
   styleUrls: ['./enum-filter-menu.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -13,5 +19,5 @@ export class EnumFilterMenuComponent {
   @Input() cvcColumnKey!: string
   @Input() cvcFilterOptions!: NzTableFilterList
   @Input() cvcOption: Maybe<CvcFilterChange>
-  @Output() cvcOptionChange = new EventEmitter<CvcFilterChange>
+  @Output() cvcOptionChange = new EventEmitter<CvcFilterChange>()
 }

--- a/client/src/app/forms2/types/variant-select/variant-manager/table-filter-input/table-filter-input.component.ts
+++ b/client/src/app/forms2/types/variant-select/variant-manager/table-filter-input/table-filter-input.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
 
 @Component({
-  selector: 'cvc-table-filter-input',
+  selector: 'cvc-variant-table-filter-input',
   templateUrl: './table-filter-input.component.html',
   styleUrls: ['./table-filter-input.component.less'],
 })

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
@@ -170,7 +170,7 @@
                   nzTheme="fill"></span>
               </nz-filter-trigger>
               <nz-dropdown-menu #enumFilterMenu="nzDropdownMenu">
-                <cvc-enum-filter-menu
+                <cvc-variant-enum-filter-menu
                   [cvcColumnKey]="enumTagCol.key"
                   [cvcFilterOptions]="enumTagCol.filter.options"
                   [cvcOption]="enumTagCol.filter.changes | ngrxPush"
@@ -178,7 +178,7 @@
                     enumTagCol.filter.changes!.next($event);
                     enumTagFilterTrigger.nzVisible = false
                   ">
-                </cvc-enum-filter-menu>
+                </cvc-variant-enum-filter-menu>
               </nz-dropdown-menu>
             </th>
 

--- a/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
+++ b/client/src/app/forms2/types/variant-select/variant-manager/variant-manager.component.html
@@ -123,7 +123,7 @@
               [nzAlign]="entityTagCol.align ?? 'left'"
               [nzLeft]="entityTagCol.fixedLeft || false"
               [nzRight]="entityTagCol.fixedRight || false">
-              <cvc-table-filter-input
+              <cvc-variant-table-filter-input
                 *ngIf="entityTagCol.filter as filter"
                 [cvcInputType]="entityTagCol.filter.inputType"
                 [cvcPlaceholder]="entityTagCol.filter.options[0].key"
@@ -131,7 +131,7 @@
                 (cvcModelChange)="
                   filter.changes!.next({ key: entityTagCol.key, value: $event })
                 ">
-              </cvc-table-filter-input>
+              </cvc-variant-table-filter-input>
             </th>
 
             <!-- ENUM TAG FILTER -->
@@ -206,7 +206,7 @@
               <nz-dropdown-menu #textTagFilterMenu="nzDropdownMenu">
                 <div class="ant-table-filter-dropdown">
                   <div class="custom-input-dropdown">
-                    <cvc-table-filter-input
+                    <cvc-variant-table-filter-input
                       [cvcPlaceholder]="textTagCol.filter.options[0].key"
                       [cvcModel]="textTagCol.filter.options[0].value"
                       (cvcModelChange)="
@@ -215,7 +215,7 @@
                           value: $event
                         })
                       ">
-                    </cvc-table-filter-input>
+                    </cvc-variant-table-filter-input>
                   </div>
                 </div>
               </nz-dropdown-menu>
@@ -229,14 +229,14 @@
               [nzAlign]="defaultCol.align ?? 'left'"
               [nzLeft]="defaultCol.fixedLeft || false"
               [nzRight]="defaultCol.fixedRight || false">
-              <cvc-table-filter-input
+              <cvc-variant-table-filter-input
                 *ngIf="defaultCol.filter as filter"
                 [cvcPlaceholder]="defaultCol.filter.options[0].key"
                 [cvcModel]="defaultCol.filter.options[0].value"
                 (cvcModelChange)="
                   filter.changes!.next({ key: defaultCol.key, value: $event })
                 ">
-              </cvc-table-filter-input>
+              </cvc-variant-table-filter-input>
             </th>
           </ng-container>
         </ng-container>
@@ -606,8 +606,8 @@
       </ng-container>
     </nz-col>
     <nz-col nzFlex="auto">
-      <cvc-table-counts
-        [cvcTableCountsConnection]="connection$"></cvc-table-counts>
+      <cvc-table-counts2
+        [cvcTableCountsConnection]="connection$"></cvc-table-counts2>
     </nz-col>
 
     <!-- card button row -->


### PR DESCRIPTION
A few of these were identical selectors which were easily fixed with renaming. Most of the warnings were produced by the `base-field` mixin that all of the new form components use. All of those fields are compiling themselves using that same base class, and since it does not define a selector, NG gives it a default of 'ng-component'. The selector defined in the parent component's options does not override the base's selector, since those are set at compile-time (hence the requirement that selectors be strings and not variables or functions).

The solution turned out to be simple, replacing base-field's `@Component` decorator with `@Injectable`, which allows the use of `@UntilDestroy` within base-field and does not kick off NG's component compilation w/ its component collision testing. Now, the parent's component options aren't ignored, so its unique selector is used.