### PR TITLE
Validate name uniqueness, but be aware of revision context

### DIFF
--- a/server/app/models/actions/suggest_revision_set.rb
+++ b/server/app/models/actions/suggest_revision_set.rb
@@ -14,6 +14,8 @@ class Actions::SuggestRevisionSet
   end
 
   def execute
+    updated_obj.in_revision_validation_context = true
+    updated_obj.revision_target_id = existing_obj.id
     updated_obj.validate!
 
     any_changes = false

--- a/server/app/models/concerns/moderated.rb
+++ b/server/app/models/concerns/moderated.rb
@@ -25,6 +25,8 @@ module Moderated
       ->() { where(action: 'revision suggested').includes(:originating_user).order('events.updated_at DESC') },
       as: :subject,
       class_name: 'Event'
+
+    attr_accessor :in_revision_validation_context, :revision_target_id
   end
 
   #TODO: Refactor to use new Revision format

--- a/server/app/models/molecular_profile.rb
+++ b/server/app/models/molecular_profile.rb
@@ -22,10 +22,7 @@ class MolecularProfile < ActiveRecord::Base
 
   validates :name, presence: true
 
-  #this breaks when we do updated_obj.validate! during propose revision set. we need a workaround
-  #validates_uniqueness_of :name,
-    #conditions: -> { where(deprecated: false) },
-    #message: 'must be unique'
+  validate :unique_name_in_context
 
   searchkick highlight: [:name, :aliases], callbacks: :async, word_start: [:name]
   scope :search_import, -> { includes(:molecular_profile_aliases, variants: [:gene])}
@@ -84,5 +81,31 @@ class MolecularProfile < ActiveRecord::Base
         .distinct
         .count
     }
+  end
+
+  def unique_name_in_context
+    base_query = self.class.where(
+      deprecated: false,
+      name: name
+    )
+
+    duplicate_name = if in_revision_validation_context
+                       base_query
+                         .where.not(id: revision_target_id)
+                         .exists?
+                     else
+                       if persisted?
+                         base_query
+                           .where.not(id: id)
+                           .exists?
+                       else
+                         base_query
+                           .exists?
+                       end
+                     end
+
+    if duplicate_name
+      errors.add(:name, 'must be unique. There is already a Molecular Profile with this name.')
+    end
   end
 end


### PR DESCRIPTION
Previously we had added a unique validation for MP and Variant names. Unfortunately, this broke validation when proposing revisions, as the way we validate those is to `new` up a copy with the revisions applied and run the validations.

This would always result in a duplicate name failure, so we had to back off the validation for that case as a temporary fix.

This introduces a more permanent fix. All `Moderated` entities now have an `in_revision_validation_context`. This will be set to `true` when the object is the result of a revision proposal and validations can take that into account in their logic.

As a result, the name validation can function appropriately.

closes #863 