### PR TITLE
Make Simple MPs inherit aliases from their Variant

### DIFF
--- a/client/src/app/forms/molecular-profile-revise/molecular-profile-revise.queries.gql
+++ b/client/src/app/forms/molecular-profile-revise/molecular-profile-revise.queries.gql
@@ -14,6 +14,7 @@ fragment RevisableMolecularProfileFields on MolecularProfile {
     citationId
   }
   molecularProfileAliases
+  isComplex
 }
 
 mutation SuggestMolecularProfileRevision(

--- a/client/src/app/forms2/config/molecular-profile-revise/molecular-profile-revise.form.html
+++ b/client/src/app/forms2/config/molecular-profile-revise/molecular-profile-revise.form.html
@@ -12,7 +12,7 @@
       [form]="form"
       [fields]="fields"
       [model]="model"
-      [options]="{}"
+      [options]="options"
       (modelChange)="model = $event">
     </formly-form>
   </form>
@@ -29,5 +29,5 @@
 touched: {{ form.touched }}
     </pre>
   </nz-col>
-</nz-row> 
+</nz-row>
  -->

--- a/client/src/app/forms2/config/molecular-profile-revise/molecular-profile-revise.query.gql
+++ b/client/src/app/forms2/config/molecular-profile-revise/molecular-profile-revise.query.gql
@@ -14,6 +14,7 @@ fragment RevisableMolecularProfileFields on MolecularProfile {
     citationId
   }
   molecularProfileAliases
+  isComplex
 }
 
 mutation SuggestMolecularProfileRevision(

--- a/client/src/app/forms2/types/tag-input/tag-input.type.html
+++ b/client/src/app/forms2/types/tag-input/tag-input.type.html
@@ -1,11 +1,12 @@
 <div>
   <cvc-string-tag
     *ngFor="let tag of tags$ | ngrxPush"
-    [cvcMode]="'closeable'"
+    [cvcMode]="this.props.disabled ? 'default' : 'closeable'"
     [cvcLabel]="tag"
     (cvcOnClose)="tagClosed(tag)"></cvc-string-tag>
-    <input nz-input 
-      (keydown.enter)="onEnter($event)" 
+    <input nz-input
+      [disabled]="this.props.disabled"
+      (keydown.enter)="onEnter($event)"
       [placeholder]="this.props.placeholder" />
 </div>
 

--- a/client/src/app/forms2/types/tag-input/tag-input.type.ts
+++ b/client/src/app/forms2/types/tag-input/tag-input.type.ts
@@ -55,7 +55,7 @@ export class CvcBaseInputField extends BaseInputMixin implements AfterViewInit {
       placeholder: 'Enter value and hit Return'
     },
   }
-  
+
   tags$ = new Subject<string[]>()
   values = new Set<string>()
 
@@ -73,7 +73,7 @@ export class CvcBaseInputField extends BaseInputMixin implements AfterViewInit {
     this.tags$.next(arr)
     this.formControl.setValue(arr)
   }
-  
+
   tagClosed(tag: string) {
     this.values.delete(tag)
     let arr = Array.from(this.values)

--- a/client/src/app/generated/civic.apollo-helpers.ts
+++ b/client/src/app/generated/civic.apollo-helpers.ts
@@ -797,7 +797,7 @@ export type ModeratedObjectFieldFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	link?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type MolecularProfileKeySpecifier = ('assertions' | 'comments' | 'deprecated' | 'deprecatedVariants' | 'deprecationEvent' | 'description' | 'events' | 'evidenceCountsByStatus' | 'evidenceItems' | 'flagged' | 'flags' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'molecularProfileAliases' | 'molecularProfileScore' | 'name' | 'parsedName' | 'rawName' | 'revisions' | 'sources' | 'variants' | MolecularProfileKeySpecifier)[];
+export type MolecularProfileKeySpecifier = ('assertions' | 'comments' | 'deprecated' | 'deprecatedVariants' | 'deprecationEvent' | 'description' | 'events' | 'evidenceCountsByStatus' | 'evidenceItems' | 'flagged' | 'flags' | 'id' | 'isComplex' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'molecularProfileAliases' | 'molecularProfileScore' | 'name' | 'parsedName' | 'rawName' | 'revisions' | 'sources' | 'variants' | MolecularProfileKeySpecifier)[];
 export type MolecularProfileFieldPolicy = {
 	assertions?: FieldPolicy<any> | FieldReadFunction<any>,
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -811,6 +811,7 @@ export type MolecularProfileFieldPolicy = {
 	flagged?: FieldPolicy<any> | FieldReadFunction<any>,
 	flags?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	isComplex?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastAcceptedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastSubmittedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -2051,6 +2051,7 @@ export type MolecularProfile = Commentable & EventOriginObject & EventSubject & 
   /** List and filter flags. */
   flags: FlagConnection;
   id: Scalars['Int'];
+  isComplex: Scalars['Boolean'];
   lastAcceptedRevisionEvent?: Maybe<Event>;
   lastCommentEvent?: Maybe<Event>;
   lastSubmittedRevisionEvent?: Maybe<Event>;
@@ -6111,9 +6112,9 @@ export type MolecularProfileRevisableFieldsQueryVariables = Exact<{
 }>;
 
 
-export type MolecularProfileRevisableFieldsQuery = { __typename: 'Query', molecularProfile?: { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> } | undefined };
+export type MolecularProfileRevisableFieldsQuery = { __typename: 'Query', molecularProfile?: { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, isComplex: boolean, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> } | undefined };
 
-export type RevisableMolecularProfileFieldsFragment = { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> };
+export type RevisableMolecularProfileFieldsFragment = { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, isComplex: boolean, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> };
 
 export type SuggestMolecularProfileRevisionMutationVariables = Exact<{
   input: SuggestMolecularProfileRevisionInput;
@@ -8313,6 +8314,7 @@ export const RevisableMolecularProfileFieldsFragmentDoc = gql`
     citationId
   }
   molecularProfileAliases
+  isComplex
 }
     `;
 export const SubmittableVariantGroupFieldsFragmentDoc = gql`

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -3508,6 +3508,7 @@ type MolecularProfile implements Commentable & EventOriginObject & EventSubject 
     state: FlagState
   ): FlagConnection!
   id: Int!
+  isComplex: Boolean!
   lastAcceptedRevisionEvent: Event
   lastCommentEvent: Event
   lastSubmittedRevisionEvent: Event

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -15923,6 +15923,22 @@
               "deprecationReason": null
             },
             {
+              "name": "isComplex",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "lastAcceptedRevisionEvent",
               "description": null,
               "args": [],

--- a/server/app/graphql/types/entities/molecular_profile_type.rb
+++ b/server/app/graphql/types/entities/molecular_profile_type.rb
@@ -27,6 +27,7 @@ module Types::Entities
     field :deprecation_event, Types::Entities::EventType, null: true
     field :molecular_profile_score, Float, null: false
     field :evidence_counts_by_status, Types::MolecularProfile::EvidenceItemsByStatusType, null: false
+    field :is_complex, Boolean, null: false
 
     def raw_name
       object.name
@@ -88,6 +89,12 @@ module Types::Entities
             submitted_count: 0,
           }
         end
+      end
+    end
+
+    def is_complex
+      Loaders::AssociationCountLoader.for(MolecularProfile, association: :variants).load(object.id).then do |count|
+        count > 1
       end
     end
   end

--- a/server/app/models/actions/suggest_molecular_profile_revision.rb
+++ b/server/app/models/actions/suggest_molecular_profile_revision.rb
@@ -1,9 +1,16 @@
 class Actions::SuggestMolecularProfileRevision < Actions::SuggestRevisionSet
   def editable_fields
-    [
-      :description,
-      :source_ids,
-      :molecular_profile_alias_ids,
-    ]
+    if existing_obj.is_complex?
+        [
+          :description,
+          :source_ids,
+          :molecular_profile_alias_ids,
+        ]
+      else
+        [
+          :description,
+          :source_ids,
+        ]
+      end
   end
 end

--- a/server/app/models/variant.rb
+++ b/server/app/models/variant.rb
@@ -85,6 +85,17 @@ class Variant < ApplicationRecord
   def on_revision_accepted
     SetAlleleRegistryIdSingleVariant.perform_later(self) if Rails.env.production?
     GenerateOpenCravatLink.perform_later(self)
+    update_single_variant_mp_aliases
+  end
+
+  def update_single_variant_mp_aliases
+    svmp = self.single_variant_molecular_profile
+    aliases = self.variant_aliases
+    mp_aliases = aliases.map do |a|
+      MolecularProfileAlias.where(name: a).first_or_create!
+    end
+
+    svmp.molecular_profile_aliases = mp_aliases
   end
 
   def unique_name_in_context

--- a/server/misc_scripts/liftover_variant_aliases.rb
+++ b/server/misc_scripts/liftover_variant_aliases.rb
@@ -1,0 +1,13 @@
+#for all variants, find the single variant MP, get a list of its aliases and the variant's alias. merge the lists and store as MP aliases
+Variant.find_each do |v|
+  if v.variant_aliases.any?
+    svmp = v.single_variant_molecular_profile
+    all_aliases = (svmp.molecular_profile_aliases.pluck(:name) + v.variant_aliases.pluck(:name)).uniq
+
+    alias_records = all_aliases.map do |a|
+      MolecularProfileAlias.where(name: a).first_or_create!
+    end
+
+    svmp.molecular_profile_aliases = alias_records
+  end
+end


### PR DESCRIPTION
* backfill script to perform initial sync
* MP edit form disables Aliases when editing a Simple MP
* When variant revisions are accepted, set the corresponding single variant MP's aliases to the variant's aliases
* Don't allow alias revisions to be created on the backend for simple MPs

closes #866 