### PR TITLE
Allow creation of new EIDs based on existing EIDs

### DIFF
--- a/client/src/app/forms2/config/evidence-submit/evidence-submit.form.html
+++ b/client/src/app/forms2/config/evidence-submit/evidence-submit.form.html
@@ -20,6 +20,7 @@
     <br/>
   </ng-container>
   <form
+    *ngIf="model; else loadingModel"
     nz-form
     nzLayout="vertical"
     [formGroup]="form"
@@ -33,6 +34,7 @@
       (modelChange)="model = $event; onModelChange($event)">
     </formly-form>
   </form>
+  <ng-template #loadingModel> Loading Evidence Item... </ng-template>
 </cvc-form-submission-status-display>
 <!-- <nz-row style="background-color: #eef">
      <nz-col nzSpan="12">

--- a/client/src/app/forms2/config/evidence-submit/evidence-submit.form.ts
+++ b/client/src/app/forms2/config/evidence-submit/evidence-submit.form.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   OnDestroy,
   OnInit,
@@ -13,8 +14,9 @@ import {
 } from '@app/core/utilities/mutation-state-wrapper'
 import { EvidenceSubmitModel } from '@app/forms2/models/evidence-submit.model'
 import { EvidenceState } from '@app/forms2/states/evidence.state'
-import { evidenceFormModelToInput } from '@app/forms2/utilities/evidence-to-model-fields'
+import { evidenceToModelFields, evidenceFormModelToInput,  } from '@app/forms2/utilities/evidence-to-model-fields'
 import {
+    EvidenceItemRevisableFields2GQL,
   ExistingEvidenceCountGQL,
   ExistingEvidenceCountQuery,
   ExistingEvidenceCountQueryVariables,
@@ -27,8 +29,9 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core'
 import { evidenceSubmitFields } from './evidence-submit.form.config'
 import { QueryRef } from 'apollo-angular'
-import { Observable, filter, map } from 'rxjs'
+import { Observable, filter, map, Subscription } from 'rxjs'
 import { isNonNulled } from 'rxjs-etc'
+import { ActivatedRoute } from '@angular/router'
 
 @UntilDestroy()
 @Component({
@@ -37,7 +40,7 @@ import { isNonNulled } from 'rxjs-etc'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
-  model: EvidenceSubmitModel
+  model?: EvidenceSubmitModel
   form: UntypedFormGroup
   fields: FormlyFieldConfig[]
   state: EvidenceState
@@ -55,21 +58,47 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
 
   selectedSourceId?: number
   selectedMpId?: number
-  
+  existingEvidenceId?: number
+  routeSub: Subscription
+
   countQueryRef?: QueryRef<ExistingEvidenceCountQuery, ExistingEvidenceCountQueryVariables>
   existingEvidenceCount$?: Observable<number>
 
   constructor(
+    private revisableFieldsGQL: EvidenceItemRevisableFields2GQL,
     private submitEvidenceGQL: SubmitEvidenceItemGQL,
     private existingEvidenceGQL: ExistingEvidenceCountGQL,
-    private networkErrorService: NetworkErrorsService
+    private cdr: ChangeDetectorRef,
+    private route: ActivatedRoute,
+    networkErrorService: NetworkErrorsService
   ) {
     this.form = new UntypedFormGroup({})
     this.fields = evidenceSubmitFields
-    this.model = { fields: {} }
     this.state = new EvidenceState()
     this.options = { formState: this.state }
     this.submitEvidenceMutator = new MutatorWithState(networkErrorService)
+    this.routeSub = this.route.queryParams.subscribe((params) => {
+      if (params.existingEvidenceId) {
+        this.existingEvidenceId = +params.existingEvidenceId
+
+        let direction = this.getFieldConfig('direction-select')
+        if(direction) {
+          direction.props!.formMode = 'clone'
+        }
+        let significance = this.getFieldConfig('significance-select')
+        if(significance) {
+          significance.props!.formMode = 'clone'
+        }
+      } else {
+        this.model = { fields: {} }
+      }
+    })
+  }
+
+  getFieldConfig(fieldKey: string) {
+    return this.fields?.[0]
+      .fieldGroup?.find(f => f.key === 'fields')
+      ?.fieldGroup?.find(f => f.type === fieldKey)
   }
 
 
@@ -83,7 +112,32 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
   }
 
   ngAfterViewInit(): void {
-    this.state.formReady$.next(true)
+    if(this.existingEvidenceId) {
+      this.revisableFieldsGQL
+        .fetch({ evidenceId: this.existingEvidenceId })
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: ({ data: { evidenceItem } }) => {
+            if (evidenceItem) {
+              this.model = {
+                fields: evidenceToModelFields(evidenceItem),
+              }
+              //clear statement on cloned EIDs
+              this.model.fields.description = undefined
+              this.cdr.detectChanges()
+            }
+          },
+          error: (error) => {
+            console.error('Error retrieving evidenceItem.')
+            console.error(error)
+          },
+          complete: () => {
+            this.state.formReady$.next(true)
+          },
+        })
+    } else {
+      this.state.formReady$.next(true)
+    }
   }
 
   onSubmit(model: EvidenceSubmitModel) {
@@ -93,8 +147,8 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
         this.submitEvidenceGQL,
         { input: input },
         undefined,
-        (data) => { 
-          this.newEvidenceId = data.submitEvidence?.evidenceItem.id 
+        (data) => {
+          this.newEvidenceId = data.submitEvidence?.evidenceItem.id
           this.newEvidenceUrl = `/evidence/${this.newEvidenceId}/summary`
         }
       )
@@ -110,7 +164,7 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
           molecularProfileId: newModel.fields.molecularProfileId,
           sourceId: newModel.fields.sourceId
         })
-      } 
+      }
     } else {
       this.countQueryRef?.refetch({molecularProfileId: 0, sourceId: 0})
     }
@@ -118,5 +172,6 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
 
   ngOnDestroy(): void {
     this.options.formState.onDestroy()
+    this.routeSub.unsubscribe()
   }
 }

--- a/client/src/app/forms2/types/direction-select/direction-select.type.ts
+++ b/client/src/app/forms2/types/direction-select/direction-select.type.ts
@@ -116,7 +116,7 @@ export interface CvcDirectionSelectFieldProps extends FormlyFieldProps {
   requireTypePromptFn: (entityName: string) => string
   tooltip?: string
   extraType?: CvcFormFieldExtraType,
-  formMode: 'revise' | 'add'
+  formMode: 'revise' | 'add' | 'clone'
 }
 
 export interface CvcDirectionSelectFieldConfig

--- a/client/src/app/forms2/types/significance-select/significance-select.type.ts
+++ b/client/src/app/forms2/types/significance-select/significance-select.type.ts
@@ -122,7 +122,7 @@ interface CvcSignificanceSelectFieldProps extends FormlyFieldProps {
   tooltip?: string
   description?: string
   extraType?: CvcFormFieldExtraType,
-  formMode: 'revise' | 'add'
+  formMode: 'revise' | 'add' | 'clone'
 }
 
 export interface CvcSignificanceSelectFieldConfig

--- a/client/src/app/views/evidence/evidence-detail/evidence-detail.module.ts
+++ b/client/src/app/views/evidence/evidence-detail/evidence-detail.module.ts
@@ -20,6 +20,7 @@ import { CvcContributorAvatarsModule } from '@app/components/shared/contributor-
 import { CvcMolecularProfileTagModule } from '@app/components/molecular-profiles/molecular-profile-tag/molecular-profile-tag.module'
 import { CvcPipesModule } from '@app/core/pipes/pipes.module'
 import { NgModule } from '@angular/core'
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
 
 @NgModule({
   declarations: [EvidenceDetailView],
@@ -37,6 +38,7 @@ import { NgModule } from '@angular/core'
     NzPageHeaderModule,
     NzSpaceModule,
     NzTypographyModule,
+    NzToolTipModule,
 
     CvcSectionNavigationModule,
     CvcFlaggableModule,

--- a/client/src/app/views/evidence/evidence-detail/evidence-detail.view.html
+++ b/client/src/app/views/evidence/evidence-detail/evidence-detail.view.html
@@ -3,6 +3,7 @@
     [displayName]="evidence.name"
     [relationsTpl]="evidenceRelations">
   </cvc-section-navigation>
+
   <ng-template #evidenceRelations>
     <nz-space nzDirection="horizontal">
       <!-- parent relations -->
@@ -100,6 +101,18 @@
               [entityId]="evidence.id"
               (onReverted)="onRevertCompleted($event)">
             </cvc-revert-entity-button>
+          </span>
+          <span *nzSpaceItem>
+            <button *ngIf="viewer.canCurate"
+              routerLink="/evidence/add/submit"
+              [queryParams]="{ existingEvidenceId: evidence.id }"
+              nz-button
+              nz-tooltip
+              nzTooltipTitle="Clone This EID"
+              nzSize="small"> <i
+                nz-icon
+                nzType="copy"></i>
+            </button>
           </span>
         </nz-space>
       </nz-page-header-extra>

--- a/server/app/models/input_adaptors/evidence_item_input_adaptor.rb
+++ b/server/app/models/input_adaptors/evidence_item_input_adaptor.rb
@@ -7,26 +7,30 @@ class InputAdaptors::EvidenceItemInputAdaptor
   end
 
   def perform
-    EvidenceItem.new(
-      molecular_profile_id: input.molecular_profile_id,
-      variant_origin: input.variant_origin,
-      source_id: input.source_id,
-      evidence_type: input.evidence_type,
-      significance: input.significance,
-      disease_id: input.disease_id,
-      description: input.description,
-      evidence_level: input.evidence_level,
-      evidence_direction: input.evidence_direction,
-      phenotype_ids: input.phenotype_ids,
-      rating: input.rating,
-      therapy_ids: input.therapy_ids,
-      therapy_interaction_type: input.therapy_interaction_type
-    )
+    EvidenceItem.new(self.class.evidence_fields(input))
   end
 
   def self.check_input_for_errors(evidence_input_object: )
     errors = []
     fields = evidence_input_object
+
+    query_fields = evidence_fields(fields)
+    query_fields.delete(:description)
+    query_fields.delete(:therapy_ids)
+    query_fields.delete(:phenotype_ids)
+
+    eid_query = EvidenceItem.where(query_fields)
+    if fields.phenotype_ids.any?
+      eid_query = eid_query.joins(:phenotypes).where("phenotypes.id" => fields.phenotype_ids)
+    end
+
+    if fields.therapy_ids.any?
+      eid_query = eid_query.joins(:therapies).where("therapies.id" => fields.therapy_ids)
+    end
+
+    if eid = eid_query.first
+      errors << "Existing identical Evidence Item found: EID#{eid.id}"
+    end
 
     existing_phenotype_ids = Phenotype.where(id: fields.phenotype_ids).pluck(:id)
     if existing_phenotype_ids.size != fields.phenotype_ids.size
@@ -55,4 +59,22 @@ class InputAdaptors::EvidenceItemInputAdaptor
 
     return errors
   end 
+
+  def self.evidence_fields(input)
+    {
+        molecular_profile_id: input.molecular_profile_id,
+        variant_origin: input.variant_origin,
+        source_id: input.source_id,
+        evidence_type: input.evidence_type,
+        significance: input.significance,
+        disease_id: input.disease_id,
+        description: input.description,
+        evidence_level: input.evidence_level,
+        evidence_direction: input.evidence_direction,
+        phenotype_ids: input.phenotype_ids,
+        rating: input.rating,
+        therapy_ids: input.therapy_ids,
+        therapy_interaction_type: input.therapy_interaction_type
+    }
+  end
 end


### PR DESCRIPTION
Evidence Pages have a "Clone this EID" button, which will take the user to the Evidence Submit page with all the fields pre-filled, minus the description.

Additional checks have been added to ensure an identical EID cannot be submitted.