### PR TITLE
hotfix for variant-submit form

### DIFF
--- a/client/src/app/forms/variant-submit/variant-submit.form.html
+++ b/client/src/app/forms/variant-submit/variant-submit.form.html
@@ -1,49 +1,30 @@
-<nz-spin
-  nzTip="Submitting"
-  [nzSpinning]="this.loading">
+<ng-container *ngIf="!(newVariant$ | ngrxPush); else variantCreated">
   <form
     nz-form
-    [formGroup]="formGroup"
-    style="width: 400px"
-    (ngSubmit)="submitVariant(formModel)"
-    nzLayout="vertical">
-    <ng-container *ngTemplateOutlet="formMessages"></ng-container>
-
+    [nzLayout]="layout"
+    [formGroup]="form">
     <formly-form
-      [form]="formGroup"
-      [fields]="formFields"
-      [model]="formModel"
-      [options]="formOptions"
-      (modelChange)="onFormModelChange($event)">
+      [form]="form"
+      [fields]="config"
+      [model]="model"
+      [options]="options"
+      (modelChange)="modelChange($event)">
     </formly-form>
   </form>
-</nz-spin>
-
-<ng-template #formMessages>
-  <nz-form-item *ngIf="this.errorMessages.length > 0">
-    <cvc-form-errors-alert [errors]="this.errorMessages">
-    </cvc-form-errors-alert>
-  </nz-form-item>
-  <ng-container *ngIf="this.success">
+</ng-container>
+<ng-template #variantCreated>
+  <ng-container *ngIf="newVariant$ | ngrxPush as variant">
     <nz-alert
       nzType="success"
-      [nzMessage]="this.isNew ? 'Variant Created' : 'Variant Already Exists'"
-      [nzDescription]="successMessage"
-      nzShowIcon></nz-alert>
-    <ng-template
-      #successMessage
-      nzSize="small">
-      <p>
-        View <a routerLink="/variants/{{this.newId}}/summary">its details</a>.
-      </p>
+      nzShowIcon
+      [nzMessage]="successMessage"
+      [nzDescription]="successDescription"></nz-alert>
+    <ng-template #successMessage>
+      New Variant {{ variant.name }} added.
+    </ng-template>
+    <ng-template #successDescription>
+      View its
+      <a [routerLink]="['/variants', variant.id, 'summary']">details here</a>.
     </ng-template>
   </ng-container>
 </ng-template>
-
-<!-- <div nz-row>
-    <div nz-col
-      nzSpan="24">
-      <ngx-json-viewer *ngIf="formModel"
-        [json]="formModel"></ngx-json-viewer>
-    </div>
-  </div> -->

--- a/client/src/app/forms/variant-submit/variant-submit.form.less
+++ b/client/src/app/forms/variant-submit/variant-submit.form.less
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  width: 100%;
+}

--- a/client/src/app/forms/variant-submit/variant-submit.module.ts
+++ b/client/src/app/forms/variant-submit/variant-submit.module.ts
@@ -1,60 +1,28 @@
-import { CommonModule } from '@angular/common'
-import { CvcCommentTextareaTypeModule } from '@app/forms/config/types/comment-textarea/comment-textarea.module'
-import { CvcFormButtonsModule } from '@app/forms/config/components/form-buttons/form-buttons.module'
-import { CvcFormErrorsAlertModule } from '@app/forms/config/components/form-errors-alert/form-errors-alert.module'
-import { CvcFormInfoWrapperModule } from '@app/forms/config/wrappers/form-info/form-info.module'
-import { CvcMultiFieldTypeModule } from '@app/forms/config/types/multi-field/multi-field.module'
-import { CvcTextareaBaseTypeModule } from '../config/types/textarea-base/textarea-base.module'
-import { FormlyModule } from '@ngx-formly/core'
 import { NgModule } from '@angular/core'
-import { NgxJsonViewerModule } from 'ngx-json-viewer'
-import { NzAlertModule } from 'ng-zorro-antd/alert'
-import { NzButtonModule } from 'ng-zorro-antd/button'
+import { CommonModule } from '@angular/common'
 import { NzFormModule } from 'ng-zorro-antd/form'
-import { NzGridModule } from 'ng-zorro-antd/grid'
-import { ReactiveFormsModule } from '@angular/forms'
+import { NzButtonModule } from 'ng-zorro-antd/button'
+import { CvcForms2Module } from '@app/forms2/forms2.module'
+import { NgxJsonViewerModule } from 'ngx-json-viewer'
+import { CvcFormSubmissionStatusDisplayModule } from '@app/forms2/components/form-submission-status-display/form-submission-status-display.module'
 import { RouterModule } from '@angular/router'
-import { CvcGeneArrayTypeModule } from '../config/types/gene-array/gene-array.module'
-import { NzSpinModule } from 'ng-zorro-antd/spin'
-import { CvcFormContainerWrapperModule } from '../config/wrappers/form-container/form-container.module'
-import { CvcCancelButtonModule } from '../config/types/cancel-button/cancel-button.module'
-import { NzCardModule } from 'ng-zorro-antd/card'
-import { NzSpaceModule } from 'ng-zorro-antd/space'
-import { NzTypographyModule } from 'ng-zorro-antd/typography'
 import { VariantSubmitForm } from './variant-submit.form'
-import { CvcSubmitButtonTypeModule } from '../config/types/submit-button/submit-button.module'
-import { CvcVariantInputTypeModule } from '../config/types/variant-input/variant-input.module'
-import { CvcVariantArrayTypeModule } from '../config/types/variant-array/variant-array.module'
+import { LetDirective, PushPipe } from '@ngrx/component'
+import { NzAlertModule } from 'ng-zorro-antd/alert'
 
 @NgModule({
   declarations: [VariantSubmitForm],
   imports: [
     CommonModule,
-    RouterModule,
-    ReactiveFormsModule,
-    NgxJsonViewerModule,
+    PushPipe,
+    LetDirective,
     NzFormModule,
-    NzAlertModule,
-    NzGridModule,
     NzButtonModule,
-    NzSpinModule,
-    NzCardModule,
-    NzSpaceModule,
-    NzTypographyModule,
-    FormlyModule,
-    CvcFormErrorsAlertModule,
-    CvcFormButtonsModule,
-    CvcFormInfoWrapperModule,
-    CvcMultiFieldTypeModule,
-    CvcTextareaBaseTypeModule,
-    CvcCommentTextareaTypeModule,
-    CvcGeneArrayTypeModule,
-    CvcFormContainerWrapperModule,
-    CvcCancelButtonModule,
-    CvcSubmitButtonTypeModule,
-    CvcVariantInputTypeModule,
-    CvcVariantArrayTypeModule,
-    NgxJsonViewerModule,
+    NzAlertModule,
+    RouterModule,
+    CvcForms2Module,
+    CvcFormSubmissionStatusDisplayModule,
+    NgxJsonViewerModule, // debug
   ],
   exports: [VariantSubmitForm],
 })


### PR DESCRIPTION
This updates the variant-submit form to use forms2 fields, with variant-select's built-in quick-add form for creating new variants. The form behaves similarly to the mp-select field, providing gene and variant fields. After a new variant is created, a success message is display, containing a link to the new variant's summary page.

