### PR TITLE
organization selection feature moved to header viewer button

### DIFF
--- a/client/src/app/components/layout/viewer-button/viewer-button.component.html
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.html
@@ -86,6 +86,7 @@
     <ul nz-menu>
       <!-- INVALID COI STATEMENT GROUP -->
       <li
+        *ngIf="viewer.invalidCoi"
         nz-menu-group
         [nzTitle]="coiGroupTitle">
         <ng-template #coiGroupTitle>
@@ -98,7 +99,7 @@
             Conflict of Interest Invalid
           </span>
         </ng-template>
-        <ul *ngIf="viewer.invalidCoi">
+        <ul>
           <li nz-menu-item>
             <button
               *ngIf="viewer.invalidCoi"
@@ -142,11 +143,6 @@
             [routerLink]="['/users', viewer.id]">
             Edit Profile
           </li>
-          <li
-            nz-menu-item
-            (click)="signOut()">
-            Sign Out
-          </li>
         </ul>
       </li>
       <li
@@ -165,6 +161,12 @@
             <a href="/jobs"> Background Workers </a>
           </li>
         </ul>
+      </li>
+      <li nz-menu-divider></li>
+      <li
+        nz-menu-item
+        (click)="signOut()">
+        Sign Out
       </li>
     </ul>
   </nz-dropdown-menu>

--- a/client/src/app/components/layout/viewer-button/viewer-button.component.html
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.html
@@ -72,6 +72,20 @@
             {{ viewer.username }}
           </div>
         </ng-container>
+        <ng-container *ngIf="viewer.mostRecentOrg">
+          <span
+            *nzSpaceItem
+            class="org-label">
+            for
+          </span>
+          <span *nzSpaceItem>
+            <cvc-organization-avatar
+              [size]="18"
+              shape="square"
+              [organization]="viewer.mostRecentOrg">
+            </cvc-organization-avatar>
+          </span>
+        </ng-container>
         <i
           nz-icon
           nzType="caret-down"
@@ -120,8 +134,14 @@
         nzTitle="Curation">
         <ul>
           <li
+            nz-menu-item
+            nzMatchRouter
+            [routerLink]="['/users', viewer.id]">
+            Edit Profile
+          </li>
+          <li
             *ngIf="viewer.organizations.length > 1"
-            nz-submenu
+            nz-menu-group
             nzTitle="Change Organization">
             <ul>
               <li
@@ -136,12 +156,6 @@
                 <span class="org-name">{{ org.name }}</span>
               </li>
             </ul>
-          </li>
-          <li
-            nz-menu-item
-            nzMatchRouter
-            [routerLink]="['/users', viewer.id]">
-            Edit Profile
           </li>
         </ul>
       </li>

--- a/client/src/app/components/layout/viewer-button/viewer-button.component.html
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.html
@@ -189,27 +189,28 @@
       <li
         nz-menu-item
         routerLink="/evidence/add/submit">
-        <a> Evidence Item </a>
+        Evidence Item
       </li>
       <li
         nz-menu-item
         routerLink="/assertions/add/submit">
-        <a> Assertion </a>
+        Assertion
       </li>
       <li
         nz-menu-item
         routerLink="/sources/add">
-        <a> Source Suggestion </a>
+        Source Suggestion
       </li>
       <li
         nz-menu-item
-        *ngIf="viewer.isEditor">
-        <a (click)="this.addVariantModalVisible = true"> Variant </a>
+        *ngIf="viewer.isEditor"
+        (click)="addVariantModalVisible$.next(true)">
+        Variant
       </li>
       <li
         nz-menu-item
         routerLink="/variant-groups/add/submit">
-        <a> Variant Group </a>
+        Variant Group
       </li>
     </ul>
   </nz-dropdown-menu>
@@ -231,11 +232,11 @@
 </nz-modal>
 
 <nz-modal
-  [(nzVisible)]="this.addVariantModalVisible"
+  [nzVisible]="addVariantModalVisible$ | ngrxPush"
   [nzContent]="variantModalContent"
   [nzTitle]="variantModalTitle"
   [nzFooter]="null"
-  (nzOnCancel)="this.addVariantModalVisible = false">
+  (nzOnCancel)="addVariantModalVisible$.next(false)">
   <ng-template #variantModalTitle><span>Add New Variant</span></ng-template>
   <ng-template #variantModalContent>
     <cvc-variant-submit-form></cvc-variant-submit-form>

--- a/client/src/app/components/layout/viewer-button/viewer-button.component.html
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.html
@@ -3,6 +3,7 @@
     nzDirection="horizontal"
     nzSize="middle"
     *ngrxLet="unreadCount$ as unreadCount">
+    <!-- ADD ENTITY DROPDOWN -->
     <button
       class="add-btn"
       nz-button
@@ -19,6 +20,8 @@
         nzType="caret-down"
         nzTheme="outline"></i>
     </button>
+
+    <!-- NOTIFICATION BUTTON -->
     <nz-badge
       [nzCount]="unreadCount"
       [nzOverflowCount]="999"
@@ -41,6 +44,8 @@
           nzTheme="outline"></i>
       </button>
     </nz-badge>
+
+    <!-- VIEWER BUTTON -->
     <button
       class="viewer-btn"
       nz-button
@@ -76,50 +81,90 @@
     </button>
   </nz-space>
 
+  <!-- VIEWER BUTTON DROPDOWN MENU -->
   <nz-dropdown-menu #userMenu="nzDropdownMenu">
     <ul nz-menu>
+      <!-- INVALID COI STATEMENT GROUP -->
       <li
-        nz-menu-item
-        *ngIf="viewer.invalidCoi">
-        <button
-          (click)="this.coiUpdateModalVisible = true"
-          nz-button
-          nzType="primary"
-          nzShape="round"
-          nzSize="small"
-          nzDanger
-          nzBlock>
-          <i
-            nz-icon
-            nzType="exclamation-circle"></i>
-          Please update COI statement
-        </button>
+        nz-menu-group
+        [nzTitle]="coiGroupTitle">
+        <ng-template #coiGroupTitle>
+          <span
+            nz-typography
+            nzType="danger">
+            <i
+              nz-icon
+              nzType="exclamation-circle"></i>
+            Conflict of Interest Invalid
+          </span>
+        </ng-template>
+        <ul *ngIf="viewer.invalidCoi">
+          <li nz-menu-item>
+            <button
+              *ngIf="viewer.invalidCoi"
+              (click)="coiUpdateModalVisible = true"
+              nz-button
+              nzType="primary"
+              nzShape="round"
+              nzSize="small"
+              nzDanger
+              nzBlock>
+              Please Update COI statement
+            </button>
+          </li>
+        </ul>
       </li>
       <li
-        nz-menu-divider
-        *ngIf="viewer.invalidCoi"></li>
-      <li
-        [routerLink]="['/users', viewer.id]"
-        nz-menu-item>
-        Your Profile
+        nz-menu-group
+        nzTitle="Curation">
+        <ul>
+          <li
+            *ngIf="viewer.organizations.length > 1"
+            nz-submenu
+            nzTitle="Change Organization">
+            <ul>
+              <li
+                *ngFor="let org of viewer.organizations"
+                (click)="menuSelection$.next(org.id)"
+                [ngClass]="{ selected: viewer.mostRecentOrg?.id === org.id }"
+                nz-menu-item>
+                <nz-avatar
+                  [nzSrc]="org?.profileImagePath"
+                  [nzSize]="14"
+                  [nzShape]="'square'"></nz-avatar>
+                <span class="org-name">{{ org.name }}</span>
+              </li>
+            </ul>
+          </li>
+          <li
+            nz-menu-item
+            nzMatchRouter
+            [routerLink]="['/users', viewer.id]">
+            Edit Profile
+          </li>
+          <li
+            nz-menu-item
+            (click)="signOut()">
+            Sign Out
+          </li>
+        </ul>
       </li>
       <li
-        nz-menu-item
-        href="/admin"
+        nz-menu-group
+        nzTitle="Administration"
         *ngIf="viewer.isAdmin">
-        <a href="/admin"> Admin Console </a>
-      </li>
-      <li
-        nz-menu-item
-        href="/jobs"
-        *ngIf="viewer.isAdmin">
-        <a href="/jobs"> Background Workers </a>
-      </li>
-      <li nz-menu-divider></li>
-      <li
-        nz-menu-item
-        (click)="signOut()">
-        Sign Out
+        <ul>
+          <li
+            nz-menu-item
+            href="/admin">
+            <a href="/admin"> Admin Console </a>
+          </li>
+          <li
+            nz-menu-item
+            href="/jobs">
+            <a href="/jobs"> Background Workers </a>
+          </li>
+        </ul>
       </li>
     </ul>
   </nz-dropdown-menu>

--- a/client/src/app/components/layout/viewer-button/viewer-button.component.less
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.less
@@ -55,18 +55,22 @@ li {
   color: #ccc;
   padding-left: 5px;
   padding-right: 10px;
-  cvc-user-avatar {
+  cvc-user-avatar,
+  cvc-organization-avatar {
     position: relative;
     top: -1px;
     left: 1px;
-    ::ng-deep .ant-avatar > img {
+    ::ng-deep nz-avatar {
       border-width: 1.5px;
       border-style: solid;
       border-color: @button-border;
-      border-radius: 22px;
     }
-    &.update-coi ::ng-deep .ant-avatar > img {
-      border-color: #f5222d;
-    }
+  }
+  cvc-user-avatar.update-coi ::ng-deep nz-avatar {
+    border-color: #f5222d;
+  }
+  .org-label {
+    margin: 0 -4px 0 0;
+    color: #aaaabb;
   }
 }

--- a/client/src/app/components/layout/viewer-button/viewer-button.component.less
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.less
@@ -37,6 +37,18 @@
   border: 1px solid @button-border;
 }
 
+li {
+  .org-name {
+    margin-left: 4px;
+  }
+  &.selected {
+    .org-name {
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
+}
+
 .viewer-btn {
   background-color: @button-background;
   border: none;

--- a/client/src/app/components/layout/viewer-button/viewer-button.component.ts
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.ts
@@ -1,15 +1,22 @@
-import { Component, Input, OnInit } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core'
 import { Viewer, ViewerService } from '@app/core/services/viewer/viewer.service'
 import { ViewerNotificationCountGQL } from '@app/generated/civic.apollo'
 import { Apollo, gql } from 'apollo-angular'
 import { environment } from 'environments/environment'
-import { Observable, Subject } from 'rxjs'
+import { BehaviorSubject, Observable, Subject } from 'rxjs'
+import { tag } from 'rxjs-spy/operators'
 import { map, startWith, withLatestFrom } from 'rxjs/operators'
 
 @Component({
   selector: 'cvc-viewer-button',
   templateUrl: './viewer-button.component.html',
   styleUrls: ['./viewer-button.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CvcViewerButtonComponent implements OnInit {
   @Input() cvcCollapsed: boolean = false
@@ -19,7 +26,7 @@ export class CvcViewerButtonComponent implements OnInit {
 
   menuSelection$: Subject<number>
   coiUpdateModalVisible: boolean = false
-  addVariantModalVisible: boolean = false
+  addVariantModalVisible$: BehaviorSubject<boolean>
 
   constructor(
     private queryService: ViewerService,
@@ -43,6 +50,10 @@ export class CvcViewerButtonComponent implements OnInit {
           startWith(0)
         )
     }
+    this.addVariantModalVisible$ = new BehaviorSubject<boolean>(false)
+    this.addVariantModalVisible$
+      .pipe(tag('addVariantModalVisible$'))
+      .subscribe()
   }
 
   ngOnInit(): void {

--- a/client/src/app/components/layout/viewer-button/viewer-button.module.ts
+++ b/client/src/app/components/layout/viewer-button/viewer-button.module.ts
@@ -13,6 +13,8 @@ import { NzModalModule } from 'ng-zorro-antd/modal'
 import { CvcUserCoiFormModule } from '@app/forms/user-coi/user-coi.module'
 import { NzButtonModule } from 'ng-zorro-antd/button'
 import { VariantSubmitFormModule } from '@app/forms/variant-submit/variant-submit.module'
+import { NzTypographyModule } from 'ng-zorro-antd/typography'
+import { NzAvatarModule } from 'ng-zorro-antd/avatar'
 
 @NgModule({
   declarations: [CvcViewerButtonComponent],
@@ -28,6 +30,8 @@ import { VariantSubmitFormModule } from '@app/forms/variant-submit/variant-submi
     NzBadgeModule,
     NzToolTipModule,
     NzModalModule,
+    NzTypographyModule,
+    NzAvatarModule,
     CvcUserAvatarModule,
     CvcUserCoiFormModule,
     VariantSubmitFormModule,

--- a/client/src/app/components/layout/viewer-button/viewer-button.module.ts
+++ b/client/src/app/components/layout/viewer-button/viewer-button.module.ts
@@ -15,6 +15,7 @@ import { NzButtonModule } from 'ng-zorro-antd/button'
 import { VariantSubmitFormModule } from '@app/forms/variant-submit/variant-submit.module'
 import { NzTypographyModule } from 'ng-zorro-antd/typography'
 import { NzAvatarModule } from 'ng-zorro-antd/avatar'
+import { CvcOrganizationAvatarModule } from '@app/components/organizations/organization-avatar/organization-avatar.module'
 
 @NgModule({
   declarations: [CvcViewerButtonComponent],
@@ -34,6 +35,7 @@ import { NzAvatarModule } from 'ng-zorro-antd/avatar'
     NzAvatarModule,
     CvcUserAvatarModule,
     CvcUserCoiFormModule,
+    CvcOrganizationAvatarModule,
     VariantSubmitFormModule,
   ],
   exports: [CvcViewerButtonComponent],

--- a/client/src/app/components/organizations/organization-avatar/organization-avatar.component.html
+++ b/client/src/app/components/organizations/organization-avatar/organization-avatar.component.html
@@ -1,13 +1,11 @@
 <nz-avatar
   *ngIf="organization.profileImagePath; else noAvatar"
-  nz-comment-avatar
   [nzSrc]="organization.profileImagePath"
   [nzShape]="shape ? shape : 'circle'"
   [nzSize]="size">
 </nz-avatar>
 <ng-template #noAvatar>
   <nz-avatar
-    nz-comment-avatar
     [nzShape]="shape ? shape : 'circle'"
     [nzText]="organization.name"
     [nzSize]="size"></nz-avatar>

--- a/client/src/app/components/organizations/organization-avatar/organization-avatar.component.ts
+++ b/client/src/app/components/organizations/organization-avatar/organization-avatar.component.ts
@@ -1,4 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core'
 
 export interface WithProfileImageAndName {
   name: string
@@ -9,6 +14,7 @@ export interface WithProfileImageAndName {
   selector: 'cvc-organization-avatar',
   templateUrl: './organization-avatar.component.html',
   styleUrls: ['./organization-avatar.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CvcOrganizationAvatarComponent implements OnInit {
   @Input() organization!: WithProfileImageAndName

--- a/client/src/app/components/users/user-avatar/user-avatar.component.html
+++ b/client/src/app/components/users/user-avatar/user-avatar.component.html
@@ -1,13 +1,11 @@
 <nz-avatar
   *ngIf="user.profileImagePath; else noAvatar"
-  nz-comment-avatar
   [nzSrc]="user.profileImagePath"
   [nzShape]="shape ? shape : 'circle'"
   [nzSize]="size">
 </nz-avatar>
 <ng-template #noAvatar>
   <nz-avatar
-    nz-comment-avatar
     [nzShape]="shape ? shape : 'circle'"
     [nzSize]="size"
     [nzText]="user.displayName.charAt(0) | uppercase"></nz-avatar>

--- a/client/src/app/components/users/user-avatar/user-avatar.component.ts
+++ b/client/src/app/components/users/user-avatar/user-avatar.component.ts
@@ -1,4 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core'
 
 export interface WithProfileImageAndDisplayName {
   displayName: string
@@ -9,6 +14,7 @@ export interface WithProfileImageAndDisplayName {
   selector: 'cvc-user-avatar',
   templateUrl: './user-avatar.component.html',
   styleUrls: ['./user-avatar.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CvcUserAvatarComponent implements OnInit {
   @Input() user!: WithProfileImageAndDisplayName

--- a/client/src/app/forms2/types/org-submit-button/org-submit-button.type.html
+++ b/client/src/app/forms2/types/org-submit-button/org-submit-button.type.html
@@ -4,67 +4,10 @@
   [formControl]="formControl"
   [formlyAttributes]="field" />
 
-<!-- base submit button -->
-<ng-template #submitButton>
-  <button
-    cvcOrgSubmitButton
-    type="submit"
-    nz-button
-    [disabled]="!form.valid"
-    [nzDanger]=""
-    nzType="primary">
-    {{ props.submitLabel }}
-  </button>
-</ng-template>
-
-<ng-container *ngIf="organizations$ | ngrxPush as organizations">
-  <!-- if 0 or 1 organization, display button template w/o btn-group wrapper -->
-  <ng-container *ngIf="organizations.length <= 1">
-    <ng-container *ngTemplateOutlet="submitButton"></ng-container>
-  </ng-container>
-
-  <!-- if multiple organizations, wrap in btn-group w/ selector btn -->
-  <ng-container *ngIf="organizations.length > 1">
-    <nz-button-group>
-      <ng-container *ngTemplateOutlet="submitButton"></ng-container>
-
-      <button
-        type="button"
-        nz-button
-        [ngClass]="(buttonClass$ | ngrxPush)!"
-        [hidden]="isHidden$ | ngrxPush"
-        [disabled]="isDisabled$ | ngrxPush"
-        nz-dropdown
-        nzTrigger="click"
-        [nzDropdownMenu]="orgMenu">
-        <span>for</span>
-        <ng-container *ngrxLet="mostRecentOrg$ as mrOrg">
-          <nz-avatar
-            [nzSrc]="mrOrg ? mrOrg.profileImagePath : organizations[0].profileImagePath"
-            [nzSize]="16"
-            [nzShape]="'square'">
-          </nz-avatar>
-        </ng-container>
-        <i
-          nz-icon
-          nzType="down"></i>
-      </button>
-    </nz-button-group>
-  </ng-container>
-
-  <!-- organization dropdown menu template -->
-  <nz-dropdown-menu #orgMenu="nzDropdownMenu">
-    <ul nz-menu>
-      <li
-        *ngFor="let org of organizations"
-        (click)="menuSelection$.next(org.id)"
-        nz-menu-item>
-        <nz-avatar
-          [nzSrc]="org?.profileImagePath"
-          [nzSize]="10"
-          [nzShape]="'square'"></nz-avatar>
-        {{ org.name }}
-      </li>
-    </ul>
-  </nz-dropdown-menu>
-</ng-container>
+<button
+  type="submit"
+  nz-button
+  [disabled]="!form.valid"
+  nzType="primary">
+  {{ props.submitLabel }}
+</button>

--- a/client/src/app/forms2/types/org-submit-button/org-submit-button.type.less
+++ b/client/src/app/forms2/types/org-submit-button/org-submit-button.type.less
@@ -1,25 +1,3 @@
 :host {
   display: inline-block;
-  // fixes the right border on the first button
-  ::ng-deep .ant-btn-dangerous.ant-btn-primary:first-child:not(:last-child) {
-    border-right-color: #ff4d4f;
-  }
-  ::ng-deep .ant-btn-dangerous.ant-btn-primary:hover,
-  ::ng-deep .ant-btn-dangerous.ant-btn-primary:focus {
-    border-right-color: #fd7978;
-  }
-}
-
-.org-dropdown-btn {
-  nz-avatar {
-    margin: 0 6px;
-    margin-top: -2px;
-    border: 1px solid rgba(255,255,255,.3);
-    background-color: rgba(255,255,255,.9);
-  }
-  // fixes the left border on the last button
-  &.ant-btn-dangerous:last-child:not(:first-child),
-  .ant-btn-dangerous + .ant-btn-dangerous {
-    border-left-color: #fd7978;
-  }
 }

--- a/client/src/app/forms2/types/org-submit-button/org-submit-button.type.module.ts
+++ b/client/src/app/forms2/types/org-submit-button/org-submit-button.type.module.ts
@@ -1,18 +1,22 @@
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
-import { LetDirective, PushPipe } from '@ngrx/component';
-import { FormlyModule } from '@ngx-formly/core';
-import { ConfigOption } from '@ngx-formly/core/lib/models';
-import { NzAvatarModule } from 'ng-zorro-antd/avatar';
-import { NzButtonModule } from 'ng-zorro-antd/button';
-import { NzDropDownModule } from 'ng-zorro-antd/dropdown';
-import { NzIconModule } from 'ng-zorro-antd/icon';
-import { CvcOrgSubmitButtonDirective } from './org-submit-button.directive';
-import { CvcOrgSubmitButtonComponent } from './org-submit-button.type';
+import { CommonModule } from '@angular/common'
+import { NgModule } from '@angular/core'
+import { ReactiveFormsModule } from '@angular/forms'
+import { CvcOrganizationTagModule } from '@app/components/organizations/organization-tag/organization-tag.module'
+import { LetDirective, PushPipe } from '@ngrx/component'
+import { FormlyModule } from '@ngx-formly/core'
+import { ConfigOption } from '@ngx-formly/core/lib/models'
+import { NzAvatarModule } from 'ng-zorro-antd/avatar'
+import { NzButtonModule } from 'ng-zorro-antd/button'
+import { NzDropDownModule } from 'ng-zorro-antd/dropdown'
+import { NzIconModule } from 'ng-zorro-antd/icon'
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
+import { CvcOrgSubmitButtonDirective } from './org-submit-button.directive'
+import { CvcOrgSubmitButtonComponent } from './org-submit-button.type'
 
 const typeConfig: ConfigOption = {
-  types: [{name: 'org-submit-button', component: CvcOrgSubmitButtonComponent}]
+  types: [
+    { name: 'org-submit-button', component: CvcOrgSubmitButtonComponent },
+  ],
 }
 
 @NgModule({
@@ -20,12 +24,15 @@ const typeConfig: ConfigOption = {
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    LetDirective, PushPipe,
+    LetDirective,
+    PushPipe,
     FormlyModule.forChild(typeConfig),
     NzIconModule,
     NzAvatarModule,
     NzButtonModule,
+    NzToolTipModule,
     NzDropDownModule,
+    CvcOrganizationTagModule,
   ],
   exports: [CvcOrgSubmitButtonComponent, CvcOrgSubmitButtonDirective],
 })

--- a/client/src/app/forms2/types/org-submit-button/org-submit-button.type.ts
+++ b/client/src/app/forms2/types/org-submit-button/org-submit-button.type.ts
@@ -1,22 +1,10 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  OnInit,
-  Type,
-  ViewChild,
-} from '@angular/core'
-import { Viewer, ViewerService } from '@app/core/services/viewer/viewer.service'
-import { Maybe, Organization } from '@app/generated/civic.apollo'
-import { UntilDestroy } from '@ngneat/until-destroy'
+import { ChangeDetectionStrategy, Component, Type } from '@angular/core'
 import {
   FieldType,
   FieldTypeConfig,
   FormlyFieldConfig,
   FormlyFieldProps,
 } from '@ngx-formly/core'
-import { Apollo, gql } from 'apollo-angular'
 import {
   BehaviorSubject,
   filter,
@@ -25,12 +13,6 @@ import {
   Subscription,
   withLatestFrom,
 } from 'rxjs'
-import { isNonNulled } from 'rxjs-etc'
-import { pluck } from 'rxjs-etc/operators'
-import {
-  ButtonMutation,
-  CvcOrgSubmitButtonDirective,
-} from './org-submit-button.directive'
 
 interface CvcOrgSubmitButtonProps extends FormlyFieldProps {
   submitLabel: string
@@ -41,119 +23,22 @@ export interface CvcOrgSubmitButtonFieldConfig
   type: 'org-submit-button' | Type<CvcOrgSubmitButtonComponent>
 }
 
-@UntilDestroy({ arrayName: 'subscriptions' })
 @Component({
   selector: 'cvc-org-submit-button',
   templateUrl: './org-submit-button.type.html',
   styleUrls: ['./org-submit-button.type.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CvcOrgSubmitButtonComponent
-  extends FieldType<FieldTypeConfig<CvcOrgSubmitButtonProps>>
-  implements OnInit, AfterViewInit
-{
-  // get a reference to submit button
-  @ViewChild(CvcOrgSubmitButtonDirective, { static: false })
-  button?: CvcOrgSubmitButtonDirective
-
-  // SOURCE STREAMS
-  viewer$: Observable<Viewer>
-  menuSelection$: Subject<number> = new Subject()
-
-  organizationId$!: BehaviorSubject<Maybe<number>>
-  selectedOrg$!: Observable<Maybe<Organization>>
-
-  // INTERMEDIATE STREAMS
-  organizations$: Observable<Organization[]>
-  mostRecentOrg$: Observable<Maybe<Organization>>
-
-  // these syncronize submit button & org dropdown button states, styles
-  isDisabled$: Subject<boolean>
-  isHidden$: Subject<boolean>
-  buttonClass$!: BehaviorSubject<string>
-  baseButtonClass = 'org-dropdown-btn'
-
-  formUpdate$!: BehaviorSubject<any>
-  subscriptions: Subscription[]
+export class CvcOrgSubmitButtonComponent extends FieldType<
+  FieldTypeConfig<CvcOrgSubmitButtonProps>
+> {
   defaultOptions: Partial<FieldTypeConfig<CvcOrgSubmitButtonProps>> = {
     props: {
       submitLabel: 'Submit',
     },
   }
 
-  constructor(
-    private viewerService: ViewerService,
-    private cdr: ChangeDetectorRef,
-    private apollo: Apollo
-  ) {
+  constructor() {
     super()
-    this.viewer$ = this.viewerService.viewer$
-    this.organizations$ = this.viewer$.pipe(pluck('organizations'))
-    this.mostRecentOrg$ = this.viewer$.pipe(pluck('mostRecentOrg'))
-    this.isDisabled$ = new Subject()
-    this.isHidden$ = new Subject<boolean>()
-    this.buttonClass$ = new BehaviorSubject<string>(this.baseButtonClass)
-    this.subscriptions = []
-  }
-
-  ngOnInit(): void {
-    // set defaults
-    // this.props.submitLabel = this.props.submitLabel || defaultProps.submitLabel
-    this.menuSelection$
-      .pipe(withLatestFrom(this.viewer$))
-      .subscribe(([mroId, viewer]: [number, Viewer]) => {
-        const fragment = {
-          id: `User:${viewer.id}`,
-          fragment: gql`
-            fragment UserMostRecentOrgId on User {
-              mostRecentOrganizationId
-            }
-          `,
-          data: {
-            mostRecentOrganizationId: mroId,
-          },
-        }
-        this.apollo.client.writeFragment(fragment)
-      })
-
-    // create subject for detecting changes on form update events,
-    // starting with initial form status (required for OnPush)
-    this.formUpdate$ = new BehaviorSubject(this.form.status)
-
-    // emit form update events from formUpdate$
-    const fcSub = this.form.statusChanges.subscribe((s) =>
-      this.formUpdate$.next(s)
-    )
-
-    // call detectChanges for each form update event
-    const scSub = this.formUpdate$.subscribe((_) => this.cdr.detectChanges())
-
-    // set field value to emitted orgId$ updates
-    const mroSub = this.mostRecentOrg$
-      .pipe(pluck('id'), filter(isNonNulled))
-      .subscribe((id) => {
-        this.formControl.setValue(id)
-      })
-    this.subscriptions = this.subscriptions.concat([fcSub, scSub, mroSub])
-  }
-
-  ngAfterViewInit() {
-    // subscribe to org-selector-btn.directive's domChange @Output,
-    // emit mutation events from the appropriate Subjects
-    if (this.button) {
-      if (this.button.domChange) {
-        const sub = this.button.domChange.subscribe((m: ButtonMutation) => {
-          if (m.type === 'class' && typeof m.change === 'string') {
-            // preserve base class by preprending it
-            this.buttonClass$.next(`${this.baseButtonClass} ${m.change}`)
-          } else if (m.type === 'disabled' && typeof m.change === 'boolean') {
-            this.isDisabled$.next(m.change)
-          } else if (m.type === 'hidden' && typeof m.change === 'boolean') {
-            this.isHidden$.next(m.change)
-          }
-        })
-        this.subscriptions.push(sub)
-      }
-    }
   }
 }

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -3508,6 +3508,7 @@ export type QueryMolecularProfileArgs = {
 
 export type QueryMolecularProfilesArgs = {
   after?: InputMaybe<Scalars['String']>;
+  alleleRegistryId?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   evidenceStatusFilter?: InputMaybe<MolecularProfileDisplayFilter>;
   first?: InputMaybe<Scalars['Int']>;
@@ -3791,6 +3792,7 @@ export type QueryVariantTypesArgs = {
 
 export type QueryVariantsArgs = {
   after?: InputMaybe<Scalars['String']>;
+  alleleRegistryId?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   geneId?: InputMaybe<Scalars['Int']>;

--- a/client/src/app/views/users/users-detail/users-detail.component.ts
+++ b/client/src/app/views/users/users-detail/users-detail.component.ts
@@ -110,6 +110,8 @@ export class UsersDetailComponent implements OnDestroy {
 
           this.tabs$.next([...this.defaultTabs, notificationTab])
           this.ownProfile$.next(true)
+        } else {
+          this.ownProfile$.next(false)
         }
       })
     })


### PR DESCRIPTION
Current selected organization avatar is now displayed next in the viewer-button component in the header. Organization selection options are listed in the viewer button's dropdown menu. Clicking on a listed organization will set it as the user's associated organization for subsequent curation actions.

**current organization display & menu selection**
<img width="340" alt="Screenshot 2023-10-11 at 2 04 53 PM" src="https://github.com/griffithlab/civic-v2/assets/132909/fcd6d5d0-f743-44a1-ae54-44053169c17b">

