### PR TITLE
Set allele_registry_id to None if the coordinates no longer resolve

### DIFF
--- a/server/app/jobs/set_allele_registry_id_single_variant.rb
+++ b/server/app/jobs/set_allele_registry_id_single_variant.rb
@@ -7,14 +7,14 @@ class SetAlleleRegistryIdSingleVariant < AlleleRegistryIds
     allele_registry_id = get_allele_registry_id(variant)
     if allele_registry_id == '_:CA' && old_allele_registry_id != 'unregistered'
       variant.allele_registry_id = 'unregistered'
-      variant.save
+      variant.save!
     elsif allele_registry_id.present? && allele_registry_id != '_:CA' && allele_registry_id != old_allele_registry_id
       variant.allele_registry_id = allele_registry_id
-      variant.save
+      variant.save!
       add_allele_registry_link(allele_registry_id)
     elsif old_allele_registry_id.present? && allele_registry_id.nil?
-      variant.allele_registry_id = None
-      variant.save
+      variant.allele_registry_id = nil
+      variant.save!
     end
     unless Variant.where(allele_registry_id: old_allele_registry_id).exists?
       if old_allele_registry_id != '_:CA' and old_allele_registry_id != 'undefined'

--- a/server/app/jobs/set_allele_registry_id_single_variant.rb
+++ b/server/app/jobs/set_allele_registry_id_single_variant.rb
@@ -3,14 +3,23 @@ require 'rbconfig'
 class SetAlleleRegistryIdSingleVariant < AlleleRegistryIds
 
   def perform(variant)
+    old_allele_registry_id = variant.allele_registry_id
     allele_registry_id = get_allele_registry_id(variant)
-    if allele_registry_id == '_:CA' && variant.allele_registry_id != 'unregistered'
+    if allele_registry_id == '_:CA' && old_allele_registry_id != 'unregistered'
       variant.allele_registry_id = 'unregistered'
       variant.save
-    elsif allele_registry_id.present? && allele_registry_id != '_:CA' && allele_registry_id != variant.allele_registry_id
+    elsif allele_registry_id.present? && allele_registry_id != '_:CA' && allele_registry_id != old_allele_registry_id
       variant.allele_registry_id = allele_registry_id
       variant.save
       add_allele_registry_link(allele_registry_id)
+    elsif old_allele_registry_id.present? && allele_registry_id.nil?
+      variant.allele_registry_id = None
+      variant.save
+    end
+    unless Variant.where(allele_registry_id: old_allele_registry_id).exists?
+      if old_allele_registry_id != '_:CA' and old_allele_registry_id != 'undefined'
+        delete_allele_registry_link(old_allele_registry_id)
+      end
     end
   end
 end

--- a/server/app/jobs/set_allele_registry_ids.rb
+++ b/server/app/jobs/set_allele_registry_ids.rb
@@ -7,10 +7,10 @@ class SetAlleleRegistryIds < AlleleRegistryIds
       allele_registry_id = get_allele_registry_id(v)
       if allele_registry_id == '_:CA'
         v.allele_registry_id = 'unregistered'
-        v.save
+        v.save!
       elsif allele_registry_id.present?
         v.allele_registry_id = allele_registry_id
-        v.save
+        v.save!
         add_allele_registry_link(allele_registry_id)
       end
     end

--- a/server/app/jobs/update_allele_registry_ids.rb
+++ b/server/app/jobs/update_allele_registry_ids.rb
@@ -9,14 +9,14 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
       if allele_registry_id != old_allele_registry_id || old_allele_registry_id == '_:CA'
         if allele_registry_id == '_:CA'
           v.allele_registry_id = 'unregistered'
-          v.save
+          v.save!
         elsif allele_registry_id.present?
           v.allele_registry_id = allele_registry_id
-          v.save
+          v.save!
           add_allele_registry_link(allele_registry_id)
         elsif old_allele_registry_id.present? && allele_registry_id.nil?
-          v.allele_registry_id = None
-          v.save
+          v.allele_registry_id = nil
+          v.save!
         end
         #delete the linkout if no other variant has this allele registry ID
         unless Variant.where(allele_registry_id: old_allele_registry_id).exists?

--- a/server/app/jobs/update_allele_registry_ids.rb
+++ b/server/app/jobs/update_allele_registry_ids.rb
@@ -14,6 +14,9 @@ class UpdateAlleleRegistryIds < AlleleRegistryIds
           v.allele_registry_id = allele_registry_id
           v.save
           add_allele_registry_link(allele_registry_id)
+        elsif old_allele_registry_id.present? && allele_registry_id.nil?
+          v.allele_registry_id = None
+          v.save
         end
         #delete the linkout if no other variant has this allele registry ID
         unless Variant.where(allele_registry_id: old_allele_registry_id).exists?


### PR DESCRIPTION
E.g., the coordinates for https://civicdb.org/variants/437/revisions were updated to a categorical variant (removing the ref and var alleles) so there is no longer an applicable allele registry entry. The current logic wasn't able to reset the allele registry id.