### PR TITLE
Fix COSMIC linkouts

### DIFF
--- a/client/src/app/components/variants/my-variant-info/my-variant-info.component.html
+++ b/client/src/app/components/variants/my-variant-info/my-variant-info.component.html
@@ -83,7 +83,7 @@
               <ng-container *ngIf="variantInfo.cosmicId; else noValue">
                 <cvc-link-tag
                   href="http://cancer.sanger.ac.uk/cosmic/mutation/overview?id={{
-                    variantInfo.cosmicId
+                    variantInfo.cosmicId.replace('COSM', '')
                   }}"
                   tooltip="View on COSMIC">
                   {{ variantInfo.cosmicId }}


### PR DESCRIPTION
COSMIC updated their identifiers and COSM identifiers are now considered "legacy". Linkouts still work when the COSM prefixed is removed from the legacy ID.