### PR TITLE
Exclude EID to be revised from duplication check

### DIFF
--- a/server/app/graphql/mutations/suggest_evidence_item_revision.rb
+++ b/server/app/graphql/mutations/suggest_evidence_item_revision.rb
@@ -39,7 +39,7 @@ class Mutations::SuggestEvidenceItemRevision < Mutations::MutationWithOrg
 
     @evidence_item = evidence_item
 
-    input_errors = InputAdaptors::EvidenceItemInputAdaptor.check_input_for_errors(evidence_input_object: fields)
+    input_errors = InputAdaptors::EvidenceItemInputAdaptor.check_input_for_errors(evidence_input_object: fields, revised_eid: id)
 
     if input_errors.any?
       raise GraphQL::ExecutionError, input_errors.join('|')

--- a/server/app/models/input_adaptors/evidence_item_input_adaptor.rb
+++ b/server/app/models/input_adaptors/evidence_item_input_adaptor.rb
@@ -10,7 +10,7 @@ class InputAdaptors::EvidenceItemInputAdaptor
     EvidenceItem.new(self.class.evidence_fields(input))
   end
 
-  def self.check_input_for_errors(evidence_input_object: )
+  def self.check_input_for_errors(evidence_input_object: , revised_eid: nil)
     errors = []
     fields = evidence_input_object
 
@@ -20,6 +20,9 @@ class InputAdaptors::EvidenceItemInputAdaptor
     query_fields.delete(:phenotype_ids)
 
     eid_query = EvidenceItem.where(query_fields)
+    if revised_eid.present?
+      eid_query = eid_query.where.not(id: revised_eid)
+    end
 
     if eid = eid_query.first
       if eid.therapy_ids.sort == fields.therapy_ids.sort && eid.phenotype_ids.sort == fields.phenotype_ids.sort


### PR DESCRIPTION
When revising only the description of an EID the current logic returns the revised EID as a duplicate because we're checking all fields except for description, which are still identical. This updated logic explicitly removes the revised EID from the duplication check.