### PR TITLE
restored missing forms gql files

### DIFF
--- a/client/src/app/forms/config/assertion-revise/assertion-revise.query.gql
+++ b/client/src/app/forms/config/assertion-revise/assertion-revise.query.gql
@@ -1,0 +1,80 @@
+query AssertionRevisableFields($assertionId: Int!) {
+  assertion(id: $assertionId) {
+    ...RevisableAssertionFields
+  }
+}
+
+fragment RevisableAssertionFields on Assertion {
+  id
+  summary
+  description
+  molecularProfile {
+    id
+    name
+    link
+  }
+  variantOrigin
+  significance
+  disease {
+    id
+    doid
+    name
+    displayName
+    link
+  }
+  therapies {
+    id
+    ncitId
+    name
+    link
+  }
+  therapyInteractionType
+  assertionDirection
+  assertionType
+  phenotypes {
+    id
+    hpoId
+    name
+  }
+  ampLevel
+  acmgCodes {
+    id
+    name
+    code
+    description
+    tooltip
+  }
+  clingenCodes {
+    id
+    code
+    description
+    name
+    tooltip
+    exclusive
+  }
+  nccnGuideline {
+    id
+    name
+  }
+  nccnGuidelineVersion
+  regulatoryApproval
+  fdaCompanionTest
+  evidenceItems {
+    id
+    name
+    link
+    status
+  }
+}
+
+mutation SuggestAssertionRevision($input: SuggestAssertionRevisionInput!) {
+  suggestAssertionRevision(input: $input) {
+    clientMutationId
+    assertion {
+      id
+    }
+    results {
+      newlyCreated
+    }
+  }
+}

--- a/client/src/app/forms/config/assertion-submit/assertion-submit.query.gql
+++ b/client/src/app/forms/config/assertion-submit/assertion-submit.query.gql
@@ -1,0 +1,8 @@
+mutation SubmitAssertion($input: SubmitAssertionInput!) {
+  submitAssertion(input: $input) {
+    clientMutationId
+    assertion {
+      id
+    }
+  }
+}

--- a/client/src/app/forms/config/evidence-revise/evidence-revise.form.ts
+++ b/client/src/app/forms/config/evidence-revise/evidence-revise.form.ts
@@ -1,30 +1,29 @@
 import {
-    AfterViewInit,
-    ChangeDetectionStrategy,
-    ChangeDetectorRef,
-    Component,
-    Input,
-    OnDestroy,
-    OnInit
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnDestroy,
+  OnInit,
 } from '@angular/core'
 import { UntypedFormGroup } from '@angular/forms'
 import { NetworkErrorsService } from '@app/core/services/network-errors.service'
 import {
-    MutationState,
-    MutatorWithState
+  MutationState,
+  MutatorWithState,
 } from '@app/core/utilities/mutation-state-wrapper'
 import { EvidenceReviseModel } from '@app/forms/models/evidence-revise.model'
 import { EvidenceState } from '@app/forms/states/evidence.state'
 import {
-    evidenceFormModelToReviseInput,
-    evidenceToModelFields
+  evidenceFormModelToReviseInput,
+  evidenceToModelFields,
 } from '@app/forms/utilities/evidence-to-model-fields'
 import {
-    EvidenceItemRevisableFields2GQL,
-    SuggestEvidenceItemRevision2GQL,
-    SuggestEvidenceItemRevisionGQL,
-    SuggestEvidenceItemRevisionMutation,
-    SuggestEvidenceItemRevisionMutationVariables
+  EvidenceItemRevisableFieldsGQL,
+  SuggestEvidenceItemRevisionGQL,
+  SuggestEvidenceItemRevisionMutation,
+  SuggestEvidenceItemRevisionMutationVariables,
 } from '@app/generated/civic.apollo'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core'
@@ -55,8 +54,8 @@ export class CvcEvidenceReviseForm implements OnInit, AfterViewInit, OnDestroy {
   mutationState?: MutationState
 
   constructor(
-    private revisableFieldsGQL: EvidenceItemRevisableFields2GQL,
-    private submitRevisionsGQL: SuggestEvidenceItemRevision2GQL,
+    private revisableFieldsGQL: EvidenceItemRevisableFieldsGQL,
+    private submitRevisionsGQL: SuggestEvidenceItemRevisionGQL,
     private networkErrorService: NetworkErrorsService,
     private cdr: ChangeDetectorRef
   ) {

--- a/client/src/app/forms/config/evidence-revise/evidence-revise.query.gql
+++ b/client/src/app/forms/config/evidence-revise/evidence-revise.query.gql
@@ -1,11 +1,10 @@
-
-query EvidenceItemRevisableFields2($evidenceId: Int!) {
+query EvidenceItemRevisableFields($evidenceId: Int!) {
   evidenceItem(id: $evidenceId) {
-    ...RevisableEvidenceFields2
+    ...RevisableEvidenceFields
   }
 }
 
-fragment RevisableEvidenceFields2 on EvidenceItem {
+fragment RevisableEvidenceFields on EvidenceItem {
   id
   molecularProfile {
     ...MolecularProfileSelectTypeaheadFields
@@ -32,7 +31,7 @@ fragment RevisableEvidenceFields2 on EvidenceItem {
   }
 }
 
-mutation SuggestEvidenceItemRevision2(
+mutation SuggestEvidenceItemRevision(
   $input: SuggestEvidenceItemRevisionInput!
 ) {
   suggestEvidenceItemRevision(input: $input) {

--- a/client/src/app/forms/config/evidence-submit/evidence-submit.form.ts
+++ b/client/src/app/forms/config/evidence-submit/evidence-submit.form.ts
@@ -14,9 +14,12 @@ import {
 } from '@app/core/utilities/mutation-state-wrapper'
 import { EvidenceSubmitModel } from '@app/forms/models/evidence-submit.model'
 import { EvidenceState } from '@app/forms/states/evidence.state'
-import { evidenceToModelFields, evidenceFormModelToInput,  } from '@app/forms/utilities/evidence-to-model-fields'
 import {
-    EvidenceItemRevisableFields2GQL,
+  evidenceToModelFields,
+  evidenceFormModelToInput,
+} from '@app/forms/utilities/evidence-to-model-fields'
+import {
+  EvidenceItemRevisableFieldsGQL,
   ExistingEvidenceCountGQL,
   ExistingEvidenceCountQuery,
   ExistingEvidenceCountQueryVariables,
@@ -61,11 +64,14 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
   existingEvidenceId?: number
   routeSub: Subscription
 
-  countQueryRef?: QueryRef<ExistingEvidenceCountQuery, ExistingEvidenceCountQueryVariables>
+  countQueryRef?: QueryRef<
+    ExistingEvidenceCountQuery,
+    ExistingEvidenceCountQueryVariables
+  >
   existingEvidenceCount$?: Observable<number>
 
   constructor(
-    private revisableFieldsGQL: EvidenceItemRevisableFields2GQL,
+    private revisableFieldsGQL: EvidenceItemRevisableFieldsGQL,
     private submitEvidenceGQL: SubmitEvidenceItemGQL,
     private existingEvidenceGQL: ExistingEvidenceCountGQL,
     private cdr: ChangeDetectorRef,
@@ -82,11 +88,11 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
         this.existingEvidenceId = +params.existingEvidenceId
 
         let direction = this.getFieldConfig('direction-select')
-        if(direction) {
+        if (direction) {
           direction.props!.formMode = 'clone'
         }
         let significance = this.getFieldConfig('significance-select')
-        if(significance) {
+        if (significance) {
           significance.props!.formMode = 'clone'
         }
       } else {
@@ -96,23 +102,25 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
   }
 
   getFieldConfig(fieldKey: string) {
-    return this.fields?.[0]
-      .fieldGroup?.find(f => f.key === 'fields')
-      ?.fieldGroup?.find(f => f.type === fieldKey)
+    return this.fields?.[0].fieldGroup
+      ?.find((f) => f.key === 'fields')
+      ?.fieldGroup?.find((f) => f.type === fieldKey)
   }
 
-
   ngOnInit(): void {
-    this.countQueryRef = this.existingEvidenceGQL.watch({molecularProfileId: 0, sourceId: 0})
+    this.countQueryRef = this.existingEvidenceGQL.watch({
+      molecularProfileId: 0,
+      sourceId: 0,
+    })
     this.existingEvidenceCount$ = this.countQueryRef?.valueChanges.pipe(
-        map(c => c.data?.evidenceItems?.totalCount),
-        filter(isNonNulled),
-        untilDestroyed(this)
+      map((c) => c.data?.evidenceItems?.totalCount),
+      filter(isNonNulled),
+      untilDestroyed(this)
     )
   }
 
   ngAfterViewInit(): void {
-    if(this.existingEvidenceId) {
+    if (this.existingEvidenceId) {
       this.revisableFieldsGQL
         .fetch({ evidenceId: this.existingEvidenceId })
         .pipe(untilDestroyed(this))
@@ -157,16 +165,19 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
 
   onModelChange(newModel: EvidenceSubmitModel) {
     if (newModel.fields.sourceId && newModel.fields.molecularProfileId) {
-      if (newModel.fields.sourceId != this.selectedSourceId || newModel.fields.molecularProfileId != this.selectedMpId)  {
+      if (
+        newModel.fields.sourceId != this.selectedSourceId ||
+        newModel.fields.molecularProfileId != this.selectedMpId
+      ) {
         this.selectedSourceId = newModel.fields.sourceId
         this.selectedMpId = newModel.fields.molecularProfileId
         this.countQueryRef?.refetch({
           molecularProfileId: newModel.fields.molecularProfileId,
-          sourceId: newModel.fields.sourceId
+          sourceId: newModel.fields.sourceId,
         })
       }
     } else {
-      this.countQueryRef?.refetch({molecularProfileId: 0, sourceId: 0})
+      this.countQueryRef?.refetch({ molecularProfileId: 0, sourceId: 0 })
     }
   }
 

--- a/client/src/app/forms/config/evidence-submit/evidence-submit.query.gql
+++ b/client/src/app/forms/config/evidence-submit/evidence-submit.query.gql
@@ -1,0 +1,73 @@
+query EvidenceFieldsFromSourceSuggestion(
+  $sourceId: Int
+  $molecularProfileId: Int
+  $diseaseId: Int
+) {
+  sourceSuggestionValues(
+    molecularProfileId: $molecularProfileId
+    diseaseId: $diseaseId
+    sourceId: $sourceId
+  ) {
+    molecularProfile {
+      id
+      name
+      link
+    }
+    disease {
+      id
+      name
+      link
+    }
+    source {
+      id
+      sourceType
+      citationId
+      citation
+      link
+    }
+  }
+}
+
+query EvidenceSubmittableFields($evidenceId: Int!) {
+  evidenceItem(id: $evidenceId) {
+    ...SubmittableEvidenceFields
+  }
+}
+
+fragment SubmittableEvidenceFields on EvidenceItem {
+  id
+  description
+  variantOrigin
+  evidenceType
+  significance
+  evidenceLevel
+  evidenceDirection
+  evidenceRating
+  therapyInteractionType
+  source {
+    id
+    citation
+    sourceType
+  }
+  phenotypes {
+    id
+    name
+  }
+  therapies {
+    id
+    name
+  }
+  disease {
+    id
+    name
+  }
+}
+
+mutation SubmitEvidenceItem($input: SubmitEvidenceItemInput!) {
+  submitEvidence(input: $input) {
+    clientMutationId
+    evidenceItem {
+      id
+    }
+  }
+}

--- a/client/src/app/forms/config/variantgroup-revise/variantgroup-revise.form.ts
+++ b/client/src/app/forms/config/variantgroup-revise/variantgroup-revise.form.ts
@@ -19,12 +19,11 @@ import {
   variantGroupToModelFields,
 } from '@app/forms/utilities/variant-group-to-model-fields'
 import {
-  SuggestEvidenceItemRevision2GQL,
-  SuggestVariantGroupRevision2GQL,
+  SuggestEvidenceItemRevisionGQL,
   SuggestVariantGroupRevisionGQL,
   SuggestVariantGroupRevisionMutation,
   SuggestVariantGroupRevisionMutationVariables,
-  VariantGroupRevisableFields2GQL,
+  VariantGroupRevisableFieldsGQL,
 } from '@app/generated/civic.apollo'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core'
@@ -57,8 +56,8 @@ export class CvcVariantgroupReviseForm
   url?: string
 
   constructor(
-    private revisableFieldsGQL: VariantGroupRevisableFields2GQL,
-    private submitRevisionsGQL: SuggestVariantGroupRevision2GQL,
+    private revisableFieldsGQL: VariantGroupRevisableFieldsGQL,
+    private submitRevisionsGQL: SuggestVariantGroupRevisionGQL,
     private networkErrorService: NetworkErrorsService,
     private cdr: ChangeDetectorRef
   ) {

--- a/client/src/app/forms/config/variantgroup-revise/variantgroup-revise.query.gql
+++ b/client/src/app/forms/config/variantgroup-revise/variantgroup-revise.query.gql
@@ -1,10 +1,10 @@
-query VariantGroupRevisableFields2($variantGroupId: Int!) {
+query VariantGroupRevisableFields($variantGroupId: Int!) {
   variantGroup(id: $variantGroupId) {
-    ...VariantGroupRevisableFields2
+    ...VariantGroupRevisableFields
   }
 }
 
-fragment VariantGroupRevisableFields2 on VariantGroup {
+fragment VariantGroupRevisableFields on VariantGroup {
   id
   name
   description
@@ -31,7 +31,7 @@ fragment VariantGroupRevisableFields2 on VariantGroup {
   }
 }
 
-mutation SuggestVariantGroupRevision2(
+mutation SuggestVariantGroupRevision(
   $input: SuggestVariantGroupRevisionInput!
 ) {
   suggestVariantGroupRevision(input: $input) {

--- a/client/src/app/forms/config/variantgroup-submit/variantgroup-submit.query.gql
+++ b/client/src/app/forms/config/variantgroup-submit/variantgroup-submit.query.gql
@@ -1,48 +1,38 @@
-query VariantGroupRevisableFields2($variantGroupId: Int!) {
+query VariantGroupSubmittableFields($variantGroupId: Int!) {
   variantGroup(id: $variantGroupId) {
-    ...VariantGroupRevisableFields2
+    ...SubmittableVariantGroupFields
   }
 }
 
-fragment VariantGroupRevisableFields2 on VariantGroup {
+fragment SubmittableVariantGroupFields on VariantGroup {
   id
   name
   description
-  variants {
-    totalCount
-    edges {
-      cursor
-      node {
+  variants(first: 50) {
+    nodes {
+      id
+      name
+      link
+      singleVariantMolecularProfile {
         id
         name
         link
       }
     }
-    nodes {
-      id
-      name
-      link
-    }
   }
   sources {
     id
-    name
     link
+    citation
+    sourceType
   }
 }
 
-mutation SuggestVariantGroupRevision2(
-  $input: SuggestVariantGroupRevisionInput!
-) {
-  suggestVariantGroupRevision(input: $input) {
+mutation SubmitVariantGroup($input: SubmitVariantGroupInput!) {
+  submitVariantGroup(input: $input) {
     clientMutationId
     variantGroup {
       id
-    }
-    results {
-      newlyCreated
-      id
-      fieldName
     }
   }
 }

--- a/client/src/app/forms/types/variant-select/variant-quick-add/variant-quick-add.query.gql
+++ b/client/src/app/forms/types/variant-select/variant-quick-add/variant-quick-add.query.gql
@@ -1,6 +1,6 @@
 mutation QuickAddVariant($name: String!, $geneId: Int!) {
   addVariant(input: { name: $name, geneId: $geneId }) {
-    ...AddVariantFields
+    ...QuickAddVariantFields
   }
 }
 

--- a/client/src/app/forms/utilities/variant-group-to-model-fields.ts
+++ b/client/src/app/forms/utilities/variant-group-to-model-fields.ts
@@ -7,12 +7,12 @@ import {
   Maybe,
   SubmitVariantGroupInput,
   SuggestVariantGroupRevisionInput,
-  VariantGroupRevisableFields2Fragment,
+  VariantGroupRevisableFieldsFragment,
 } from '@app/generated/civic.apollo'
 import { VariantGroupSubmitModel } from '../models/variant-group-submit.model'
 
 export function variantGroupToModelFields(
-  variantGroup: VariantGroupRevisableFields2Fragment
+  variantGroup: VariantGroupRevisableFieldsFragment
 ): VariantGroupFields {
   return {
     description: variantGroup.description,

--- a/client/src/app/forms/utilities/variant-group-to-model-fields.ts
+++ b/client/src/app/forms/utilities/variant-group-to-model-fields.ts
@@ -28,6 +28,7 @@ export function variantGroupFormModelToReviseInput(
 ): Maybe<SuggestVariantGroupRevisionInput> {
   let input = variantGroupFormModelToInput(model)
   if (input) {
+    delete input.organizationId
     return {
       id: gid,
       fields: {
@@ -54,6 +55,7 @@ export function variantGroupFormModelToInput(
       sourceIds: fields.sourceIds || [],
       name: fields.name!,
       variantIds: fields.variantIds || [],
+      organizationId: model.organizationId,
     }
   }
 }

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -6152,29 +6152,6 @@ export type ViewerNotificationCountQueryVariables = Exact<{ [key: string]: never
 
 export type ViewerNotificationCountQuery = { __typename: 'Query', notifications: { __typename: 'NotificationConnection', unreadCount: number } };
 
-export type AssertionRevisableFieldsQueryVariables = Exact<{
-  assertionId: Scalars['Int'];
-}>;
-
-
-export type AssertionRevisableFieldsQuery = { __typename: 'Query', assertion?: { __typename: 'Assertion', id: number, summary: string, description: string, variantOrigin: VariantOrigin, significance: AssertionSignificance, therapyInteractionType?: TherapyInteraction | undefined, assertionDirection: AssertionDirection, assertionType: AssertionType, ampLevel?: AmpLevel | undefined, nccnGuidelineVersion?: string | undefined, regulatoryApproval?: boolean | undefined, fdaCompanionTest?: boolean | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string }, disease?: { __typename: 'Disease', id: number, doid?: string | undefined, name: string, displayName: string, link: string } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, ncitId?: string | undefined, name: string, link: string }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, hpoId: string, name: string }>, acmgCodes: Array<{ __typename: 'AcmgCode', id: number, name: string, code: string, description: string, tooltip: string }>, clingenCodes: Array<{ __typename: 'ClingenCode', id: number, code: string, description: string, name: string, tooltip: string, exclusive: boolean }>, nccnGuideline?: { __typename: 'NccnGuideline', id: number, name: string } | undefined, evidenceItems: Array<{ __typename: 'EvidenceItem', id: number, name: string, link: string, status: EvidenceStatus }> } | undefined };
-
-export type RevisableAssertionFieldsFragment = { __typename: 'Assertion', id: number, summary: string, description: string, variantOrigin: VariantOrigin, significance: AssertionSignificance, therapyInteractionType?: TherapyInteraction | undefined, assertionDirection: AssertionDirection, assertionType: AssertionType, ampLevel?: AmpLevel | undefined, nccnGuidelineVersion?: string | undefined, regulatoryApproval?: boolean | undefined, fdaCompanionTest?: boolean | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string }, disease?: { __typename: 'Disease', id: number, doid?: string | undefined, name: string, displayName: string, link: string } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, ncitId?: string | undefined, name: string, link: string }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, hpoId: string, name: string }>, acmgCodes: Array<{ __typename: 'AcmgCode', id: number, name: string, code: string, description: string, tooltip: string }>, clingenCodes: Array<{ __typename: 'ClingenCode', id: number, code: string, description: string, name: string, tooltip: string, exclusive: boolean }>, nccnGuideline?: { __typename: 'NccnGuideline', id: number, name: string } | undefined, evidenceItems: Array<{ __typename: 'EvidenceItem', id: number, name: string, link: string, status: EvidenceStatus }> };
-
-export type SuggestAssertionRevisionMutationVariables = Exact<{
-  input: SuggestAssertionRevisionInput;
-}>;
-
-
-export type SuggestAssertionRevisionMutation = { __typename: 'Mutation', suggestAssertionRevision?: { __typename: 'SuggestAssertionRevisionPayload', clientMutationId?: string | undefined, assertion: { __typename: 'Assertion', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean }> } | undefined };
-
-export type SubmitAssertionMutationVariables = Exact<{
-  input: SubmitAssertionInput;
-}>;
-
-
-export type SubmitAssertionMutation = { __typename: 'Mutation', submitAssertion?: { __typename: 'SubmitAssertionPayload', clientMutationId?: string | undefined, assertion: { __typename: 'Assertion', id: number } } | undefined };
-
 export type AddCommentMutationVariables = Exact<{
   input: AddCommentInput;
 }>;
@@ -6211,235 +6188,26 @@ export type EntityTypeaheadQueryVariables = Exact<{
 
 export type EntityTypeaheadQuery = { __typename: 'Query', entityTypeahead: Array<{ __typename: 'CommentTagSegment', entityId: number, tagType: TaggableEntity, displayName: string }> };
 
-export type PreviewMolecularProfileNameQueryVariables = Exact<{
-  mpStructure?: InputMaybe<MolecularProfileComponentInput>;
-}>;
-
-
-export type PreviewMolecularProfileNameQuery = { __typename: 'Query', previewMolecularProfileName: { __typename: 'MolecularProfileNamePreview', existingMolecularProfile?: { __typename: 'MolecularProfile', id: number, name: string, link: string } | undefined, segments: Array<{ __typename: 'Gene', id: number, name: string, link: string } | { __typename: 'MolecularProfileTextSegment', text: string } | { __typename: 'Variant', id: number, name: string, link: string }>, deprecatedVariants: Array<{ __typename: 'Variant', id: number, name: string, link: string }> } };
-
-export type CreateMolecularProfileMutationVariables = Exact<{
-  mpStructure: MolecularProfileComponentInput;
-}>;
-
-
-export type CreateMolecularProfileMutation = { __typename: 'Mutation', createMolecularProfile?: { __typename: 'CreateMolecularProfilePayload', molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } | undefined };
-
-type PreviewMpName_Gene_Fragment = { __typename: 'Gene', id: number, name: string, link: string };
-
-type PreviewMpName_MolecularProfileTextSegment_Fragment = { __typename: 'MolecularProfileTextSegment', text: string };
-
-type PreviewMpName_Variant_Fragment = { __typename: 'Variant', id: number, name: string, link: string };
-
-export type PreviewMpNameFragment = PreviewMpName_Gene_Fragment | PreviewMpName_MolecularProfileTextSegment_Fragment | PreviewMpName_Variant_Fragment;
-
-export type AcmgCodeTypeaheadQueryVariables = Exact<{
-  code: Scalars['String'];
-}>;
-
-
-export type AcmgCodeTypeaheadQuery = { __typename: 'Query', acmgCodesTypeahead: Array<{ __typename: 'AcmgCode', id: number, code: string, description: string, name: string, tooltip: string }> };
-
-export type ClingenCodeTypeaheadQueryVariables = Exact<{
-  code: Scalars['String'];
-}>;
-
-
-export type ClingenCodeTypeaheadQuery = { __typename: 'Query', clingenCodesTypeahead: Array<{ __typename: 'ClingenCode', id: number, code: string, description: string, name: string, tooltip: string, exclusive: boolean }> };
-
-export type DiseaseTypeaheadQueryVariables = Exact<{
-  name: Scalars['String'];
-}>;
-
-
-export type DiseaseTypeaheadQuery = { __typename: 'Query', diseaseTypeahead: Array<{ __typename: 'Disease', id: number, name: string, displayName: string, doid?: string | undefined, diseaseAliases: Array<string> }> };
-
-export type AddDiseaseMutationVariables = Exact<{
-  name: Scalars['String'];
-  doid?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type AddDiseaseMutation = { __typename: 'Mutation', addDisease?: { __typename: 'AddDiseasePayload', new: boolean, disease: { __typename: 'Disease', id: number, name: string, displayName: string } } | undefined };
-
-export type AddDiseaseFieldsFragment = { __typename: 'AddDiseasePayload', new: boolean, disease: { __typename: 'Disease', id: number, name: string, displayName: string } };
-
-export type EvidenceTypeaheadQueryVariables = Exact<{
-  id: Scalars['Int'];
-}>;
-
-
-export type EvidenceTypeaheadQuery = { __typename: 'Query', evidenceItem?: { __typename: 'EvidenceItem', id: number, status: EvidenceStatus, name: string } | undefined };
-
-export type GeneTypeaheadQueryVariables = Exact<{
-  entrezSymbol: Scalars['String'];
-}>;
-
-
-export type GeneTypeaheadQuery = { __typename: 'Query', geneTypeahead: Array<{ __typename: 'Gene', id: number, name: string, geneAliases: Array<string>, entrezId: number }> };
-
-export type GeneTypeaheadFieldsFragment = { __typename: 'Gene', id: number, name: string, geneAliases: Array<string>, entrezId: number };
-
-export type NccnGuidelineTypeaheadQueryVariables = Exact<{
-  name: Scalars['String'];
-}>;
-
-
-export type NccnGuidelineTypeaheadQuery = { __typename: 'Query', nccnGuidelinesTypeahead: Array<{ __typename: 'NccnGuideline', id: number, name: string }> };
-
-export type PhenotypeTypeaheadQueryVariables = Exact<{
-  name: Scalars['String'];
-}>;
-
-
-export type PhenotypeTypeaheadQuery = { __typename: 'Query', phenotypeTypeahead: Array<{ __typename: 'Phenotype', hpoId: string, id: number, name: string }> };
-
-export type CitationExistenceCheckQueryVariables = Exact<{
-  sourceType: SourceSource;
-  citationId: Scalars['String'];
-}>;
-
-
-export type CitationExistenceCheckQuery = { __typename: 'Query', remoteCitation?: string | undefined };
-
-export type CreateSourceStubMutationVariables = Exact<{
-  input: AddRemoteCitationInput;
-}>;
-
-
-export type CreateSourceStubMutation = { __typename: 'Mutation', addRemoteCitation?: { __typename: 'AddRemoteCitationPayload', newSource: { __typename: 'SourceStub', id: number, citationId: number, sourceType: SourceSource } } | undefined };
-
-export type CitationTypeaheadQueryVariables = Exact<{
-  partialCitationId: Scalars['String'];
-  sourceType: SourceSource;
-}>;
-
-
-export type CitationTypeaheadQuery = { __typename: 'Query', sourceTypeahead: Array<{ __typename: 'Source', id: number, name: string, citation?: string | undefined, citationId: string, sourceType: SourceSource }> };
-
-export type SourceTypeaheadResultFragment = { __typename: 'Source', id: number, name: string, citation?: string | undefined, citationId: string, sourceType: SourceSource };
-
-export type CheckRemoteCitationQueryVariables = Exact<{
-  sourceType: SourceSource;
-  citationId: Scalars['String'];
-}>;
-
-
-export type CheckRemoteCitationQuery = { __typename: 'Query', remoteCitation?: string | undefined };
-
-export type AddRemoteCitationMutationVariables = Exact<{
-  input: AddRemoteCitationInput;
-}>;
-
-
-export type AddRemoteCitationMutation = { __typename: 'Mutation', addRemoteCitation?: { __typename: 'AddRemoteCitationPayload', newSource: { __typename: 'SourceStub', id: number, citationId: number, sourceType: SourceSource } } | undefined };
-
-export type SourceStubFieldsFragment = { __typename: 'SourceStub', id: number, citationId: number, sourceType: SourceSource };
-
-export type SourceTypeaheadQueryVariables = Exact<{
-  partialCitationId: Scalars['String'];
-  sourceType: SourceSource;
-}>;
-
-
-export type SourceTypeaheadQuery = { __typename: 'Query', sourceTypeahead: Array<{ __typename: 'Source', id: number, name: string, citation?: string | undefined, citationId: string, sourceType: SourceSource }> };
-
-export type SourceTypeaheadFieldsFragment = { __typename: 'Source', id: number, name: string, citation?: string | undefined, citationId: string, sourceType: SourceSource };
-
-export type TherapyTypeaheadQueryVariables = Exact<{
-  name: Scalars['String'];
-}>;
-
-
-export type TherapyTypeaheadQuery = { __typename: 'Query', therapyTypeahead: Array<{ __typename: 'Therapy', id: number, name: string, ncitId?: string | undefined, therapyAliases: Array<string> }> };
-
-export type AddTherapyMutationVariables = Exact<{
-  name: Scalars['String'];
-  ncitId?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type AddTherapyMutation = { __typename: 'Mutation', addTherapy?: { __typename: 'AddTherapyPayload', new: boolean, therapy: { __typename: 'Therapy', id: number, ncitId?: string | undefined, name: string } } | undefined };
-
-export type AddTherapyFieldsFragment = { __typename: 'AddTherapyPayload', new: boolean, therapy: { __typename: 'Therapy', id: number, ncitId?: string | undefined, name: string } };
-
-export type VariantTypeaheadQueryVariables = Exact<{
-  name: Scalars['String'];
-  geneId?: InputMaybe<Scalars['Int']>;
-}>;
-
-
-export type VariantTypeaheadQuery = { __typename: 'Query', variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, variantAliases: Array<string>, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> } };
-
-export type VariantTypeaheadFieldsFragment = { __typename: 'Variant', id: number, name: string, variantAliases: Array<string>, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } };
-
-export type AddVariantMutationVariables = Exact<{
-  name: Scalars['String'];
+export type LinkableGeneQueryVariables = Exact<{
   geneId: Scalars['Int'];
 }>;
 
 
-export type AddVariantMutation = { __typename: 'Mutation', addVariant?: { __typename: 'AddVariantPayload', clientMutationId?: string | undefined, new: boolean, variant: { __typename: 'Variant', id: number, name: string, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } } | undefined };
+export type LinkableGeneQuery = { __typename: 'Query', gene?: { __typename: 'Gene', id: number, name: string, link: string } | undefined };
 
-export type AddVariantFieldsFragment = { __typename: 'AddVariantPayload', clientMutationId?: string | undefined, new: boolean, variant: { __typename: 'Variant', id: number, name: string, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } };
-
-export type VariantSelectQueryVariables = Exact<{
-  name: Scalars['String'];
-  geneId?: InputMaybe<Scalars['Int']>;
+export type LinkableVariantQueryVariables = Exact<{
+  variantId: Scalars['Int'];
 }>;
 
 
-export type VariantSelectQuery = { __typename: 'Query', variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, variantAliases: Array<string>, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> } };
+export type LinkableVariantQuery = { __typename: 'Query', variant?: { __typename: 'Variant', id: number, name: string, link: string } | undefined };
 
-export type VariantSelectFieldsFragment = { __typename: 'Variant', id: number, name: string, variantAliases: Array<string>, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } };
-
-export type VariantTypeTypeaheadQueryVariables = Exact<{
-  name: Scalars['String'];
+export type LinkableTherapyQueryVariables = Exact<{
+  therapyId: Scalars['Int'];
 }>;
 
 
-export type VariantTypeTypeaheadQuery = { __typename: 'Query', variantTypeTypeahead: Array<{ __typename: 'VariantType', name: string, soid: string, id: number }> };
-
-export type EvidenceItemRevisableFieldsQueryVariables = Exact<{
-  evidenceId: Scalars['Int'];
-}>;
-
-
-export type EvidenceItemRevisableFieldsQuery = { __typename: 'Query', evidenceItem?: { __typename: 'EvidenceItem', id: number, variantOrigin: VariantOrigin, description: string, significance: EvidenceSignificance, therapyInteractionType?: TherapyInteraction | undefined, evidenceDirection: EvidenceDirection, evidenceLevel: EvidenceLevel, evidenceType: EvidenceType, evidenceRating?: number | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> }, disease?: { __typename: 'Disease', id: number, name: string, link: string, displayName: string, doid?: string | undefined, diseaseAliases: Array<string> } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, name: string, link: string, ncitId?: string | undefined, therapyAliases: Array<string> }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string, link: string, hpoId: string }>, source: { __typename: 'Source', id: number, name: string, link: string, citation?: string | undefined, citationId: string, sourceType: SourceSource } } | undefined };
-
-export type RevisableEvidenceFieldsFragment = { __typename: 'EvidenceItem', id: number, variantOrigin: VariantOrigin, description: string, significance: EvidenceSignificance, therapyInteractionType?: TherapyInteraction | undefined, evidenceDirection: EvidenceDirection, evidenceLevel: EvidenceLevel, evidenceType: EvidenceType, evidenceRating?: number | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> }, disease?: { __typename: 'Disease', id: number, name: string, link: string, displayName: string, doid?: string | undefined, diseaseAliases: Array<string> } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, name: string, link: string, ncitId?: string | undefined, therapyAliases: Array<string> }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string, link: string, hpoId: string }>, source: { __typename: 'Source', id: number, name: string, link: string, citation?: string | undefined, citationId: string, sourceType: SourceSource } };
-
-export type SuggestEvidenceItemRevisionMutationVariables = Exact<{
-  input: SuggestEvidenceItemRevisionInput;
-}>;
-
-
-export type SuggestEvidenceItemRevisionMutation = { __typename: 'Mutation', suggestEvidenceItemRevision?: { __typename: 'SuggestEvidenceItemRevisionPayload', clientMutationId?: string | undefined, evidenceItem: { __typename: 'EvidenceItem', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean }> } | undefined };
-
-export type EvidenceFieldsFromSourceSuggestionQueryVariables = Exact<{
-  sourceId?: InputMaybe<Scalars['Int']>;
-  molecularProfileId?: InputMaybe<Scalars['Int']>;
-  diseaseId?: InputMaybe<Scalars['Int']>;
-}>;
-
-
-export type EvidenceFieldsFromSourceSuggestionQuery = { __typename: 'Query', sourceSuggestionValues: { __typename: 'SourceSuggestionValues', molecularProfile?: { __typename: 'MolecularProfile', id: number, name: string, link: string } | undefined, disease?: { __typename: 'Disease', id: number, name: string, link: string } | undefined, source?: { __typename: 'Source', id: number, sourceType: SourceSource, citationId: string, citation?: string | undefined, link: string } | undefined } };
-
-export type EvidenceSubmittableFieldsQueryVariables = Exact<{
-  evidenceId: Scalars['Int'];
-}>;
-
-
-export type EvidenceSubmittableFieldsQuery = { __typename: 'Query', evidenceItem?: { __typename: 'EvidenceItem', id: number, description: string, variantOrigin: VariantOrigin, evidenceType: EvidenceType, significance: EvidenceSignificance, evidenceLevel: EvidenceLevel, evidenceDirection: EvidenceDirection, evidenceRating?: number | undefined, therapyInteractionType?: TherapyInteraction | undefined, source: { __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource }, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string }>, therapies: Array<{ __typename: 'Therapy', id: number, name: string }>, disease?: { __typename: 'Disease', id: number, name: string } | undefined } | undefined };
-
-export type SubmittableEvidenceFieldsFragment = { __typename: 'EvidenceItem', id: number, description: string, variantOrigin: VariantOrigin, evidenceType: EvidenceType, significance: EvidenceSignificance, evidenceLevel: EvidenceLevel, evidenceDirection: EvidenceDirection, evidenceRating?: number | undefined, therapyInteractionType?: TherapyInteraction | undefined, source: { __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource }, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string }>, therapies: Array<{ __typename: 'Therapy', id: number, name: string }>, disease?: { __typename: 'Disease', id: number, name: string } | undefined };
-
-export type SubmitEvidenceItemMutationVariables = Exact<{
-  input: SubmitEvidenceItemInput;
-}>;
-
-
-export type SubmitEvidenceItemMutation = { __typename: 'Mutation', submitEvidence?: { __typename: 'SubmitEvidenceItemPayload', clientMutationId?: string | undefined, evidenceItem: { __typename: 'EvidenceItem', id: number } } | undefined };
+export type LinkableTherapyQuery = { __typename: 'Query', therapy?: { __typename: 'Therapy', id: number, name: string, link: string } | undefined };
 
 export type FlagEntityMutationVariables = Exact<{
   input: FlagEntityInput;
@@ -6454,45 +6222,6 @@ export type ResolveFlagMutationVariables = Exact<{
 
 
 export type ResolveFlagMutation = { __typename: 'Mutation', resolveFlag?: { __typename: 'ResolveFlagPayload', flag?: { __typename: 'Flag', id: number } | undefined } | undefined };
-
-export type GeneRevisableFieldsQueryVariables = Exact<{
-  geneId: Scalars['Int'];
-}>;
-
-
-export type GeneRevisableFieldsQuery = { __typename: 'Query', gene?: { __typename: 'Gene', id: number, description: string, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> } | undefined };
-
-export type RevisableGeneFieldsFragment = { __typename: 'Gene', id: number, description: string, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> };
-
-export type SuggestGeneRevisionMutationVariables = Exact<{
-  input: SuggestGeneRevisionInput;
-}>;
-
-
-export type SuggestGeneRevisionMutation = { __typename: 'Mutation', suggestGeneRevision?: { __typename: 'SuggestGeneRevisionPayload', clientMutationId?: string | undefined, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean, id: number, fieldName: string }> } | undefined };
-
-export type MolecularProfileRevisableFieldsQueryVariables = Exact<{
-  molecularProfileId: Scalars['Int'];
-}>;
-
-
-export type MolecularProfileRevisableFieldsQuery = { __typename: 'Query', molecularProfile?: { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, isComplex: boolean, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> } | undefined };
-
-export type RevisableMolecularProfileFieldsFragment = { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, isComplex: boolean, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> };
-
-export type SuggestMolecularProfileRevisionMutationVariables = Exact<{
-  input: SuggestMolecularProfileRevisionInput;
-}>;
-
-
-export type SuggestMolecularProfileRevisionMutation = { __typename: 'Mutation', suggestMolecularProfileRevision?: { __typename: 'SuggestMolecularProfileRevisionPayload', clientMutationId?: string | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean, id: number, fieldName: string }> } | undefined };
-
-export type SuggestSourceMutationVariables = Exact<{
-  input: SuggestSourceInput;
-}>;
-
-
-export type SuggestSourceMutation = { __typename: 'Mutation', suggestSource?: { __typename: 'SuggestSourcePayload', clientMutationId?: string | undefined, sourceSuggestion: { __typename: 'SourceSuggestion', id: number } } | undefined };
 
 export type UpdateSourceSuggestionMutationVariables = Exact<{
   input: UpdateSourceSuggestionStatusInput;
@@ -6537,65 +6266,69 @@ export type MolecularProfilesForVariantQueryVariables = Exact<{
 
 export type MolecularProfilesForVariantQuery = { __typename: 'Query', molecularProfiles: { __typename: 'MolecularProfileConnection', nodes: Array<{ __typename: 'MolecularProfile', id: number, name: string, link: string, evidenceCountsByStatus: { __typename: 'EvidenceItemsByStatus', submittedCount: number, acceptedCount: number } }> } };
 
-export type SuggestVariantGroupRevisionMutationVariables = Exact<{
-  input: SuggestVariantGroupRevisionInput;
+export type AssertionRevisableFieldsQueryVariables = Exact<{
+  assertionId: Scalars['Int'];
 }>;
 
 
-export type SuggestVariantGroupRevisionMutation = { __typename: 'Mutation', suggestVariantGroupRevision?: { __typename: 'SuggestVariantGroupRevisionPayload', clientMutationId?: string | undefined, variantGroup: { __typename: 'VariantGroup', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean, id: number, fieldName: string }> } | undefined };
+export type AssertionRevisableFieldsQuery = { __typename: 'Query', assertion?: { __typename: 'Assertion', id: number, summary: string, description: string, variantOrigin: VariantOrigin, significance: AssertionSignificance, therapyInteractionType?: TherapyInteraction | undefined, assertionDirection: AssertionDirection, assertionType: AssertionType, ampLevel?: AmpLevel | undefined, nccnGuidelineVersion?: string | undefined, regulatoryApproval?: boolean | undefined, fdaCompanionTest?: boolean | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string }, disease?: { __typename: 'Disease', id: number, doid?: string | undefined, name: string, displayName: string, link: string } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, ncitId?: string | undefined, name: string, link: string }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, hpoId: string, name: string }>, acmgCodes: Array<{ __typename: 'AcmgCode', id: number, name: string, code: string, description: string, tooltip: string }>, clingenCodes: Array<{ __typename: 'ClingenCode', id: number, code: string, description: string, name: string, tooltip: string, exclusive: boolean }>, nccnGuideline?: { __typename: 'NccnGuideline', id: number, name: string } | undefined, evidenceItems: Array<{ __typename: 'EvidenceItem', id: number, name: string, link: string, status: EvidenceStatus }> } | undefined };
 
-export type VariantGroupSubmittableFieldsQueryVariables = Exact<{
-  variantGroupId: Scalars['Int'];
+export type RevisableAssertionFieldsFragment = { __typename: 'Assertion', id: number, summary: string, description: string, variantOrigin: VariantOrigin, significance: AssertionSignificance, therapyInteractionType?: TherapyInteraction | undefined, assertionDirection: AssertionDirection, assertionType: AssertionType, ampLevel?: AmpLevel | undefined, nccnGuidelineVersion?: string | undefined, regulatoryApproval?: boolean | undefined, fdaCompanionTest?: boolean | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string }, disease?: { __typename: 'Disease', id: number, doid?: string | undefined, name: string, displayName: string, link: string } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, ncitId?: string | undefined, name: string, link: string }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, hpoId: string, name: string }>, acmgCodes: Array<{ __typename: 'AcmgCode', id: number, name: string, code: string, description: string, tooltip: string }>, clingenCodes: Array<{ __typename: 'ClingenCode', id: number, code: string, description: string, name: string, tooltip: string, exclusive: boolean }>, nccnGuideline?: { __typename: 'NccnGuideline', id: number, name: string } | undefined, evidenceItems: Array<{ __typename: 'EvidenceItem', id: number, name: string, link: string, status: EvidenceStatus }> };
+
+export type SuggestAssertionRevisionMutationVariables = Exact<{
+  input: SuggestAssertionRevisionInput;
 }>;
 
 
-export type VariantGroupSubmittableFieldsQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> } | undefined };
+export type SuggestAssertionRevisionMutation = { __typename: 'Mutation', suggestAssertionRevision?: { __typename: 'SuggestAssertionRevisionPayload', clientMutationId?: string | undefined, assertion: { __typename: 'Assertion', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean }> } | undefined };
 
-export type SubmittableVariantGroupFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> };
-
-export type SubmitVariantGroupMutationVariables = Exact<{
-  input: SubmitVariantGroupInput;
+export type SubmitAssertionMutationVariables = Exact<{
+  input: SubmitAssertionInput;
 }>;
 
 
-export type SubmitVariantGroupMutation = { __typename: 'Mutation', submitVariantGroup?: { __typename: 'SubmitVariantGroupPayload', clientMutationId?: string | undefined, variantGroup: { __typename: 'VariantGroup', id: number } } | undefined };
+export type SubmitAssertionMutation = { __typename: 'Mutation', submitAssertion?: { __typename: 'SubmitAssertionPayload', clientMutationId?: string | undefined, assertion: { __typename: 'Assertion', id: number } } | undefined };
 
-export type LinkableGeneQueryVariables = Exact<{
-  geneId: Scalars['Int'];
-}>;
-
-
-export type LinkableGeneQuery = { __typename: 'Query', gene?: { __typename: 'Gene', id: number, name: string, link: string } | undefined };
-
-export type LinkableVariantQueryVariables = Exact<{
-  variantId: Scalars['Int'];
-}>;
-
-
-export type LinkableVariantQuery = { __typename: 'Query', variant?: { __typename: 'Variant', id: number, name: string, link: string } | undefined };
-
-export type LinkableTherapyQueryVariables = Exact<{
-  therapyId: Scalars['Int'];
-}>;
-
-
-export type LinkableTherapyQuery = { __typename: 'Query', therapy?: { __typename: 'Therapy', id: number, name: string, link: string } | undefined };
-
-export type EvidenceItemRevisableFields2QueryVariables = Exact<{
+export type EvidenceItemRevisableFieldsQueryVariables = Exact<{
   evidenceId: Scalars['Int'];
 }>;
 
 
-export type EvidenceItemRevisableFields2Query = { __typename: 'Query', evidenceItem?: { __typename: 'EvidenceItem', id: number, variantOrigin: VariantOrigin, description: string, significance: EvidenceSignificance, therapyInteractionType?: TherapyInteraction | undefined, evidenceDirection: EvidenceDirection, evidenceLevel: EvidenceLevel, evidenceType: EvidenceType, evidenceRating?: number | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> }, disease?: { __typename: 'Disease', id: number, name: string, link: string, displayName: string, doid?: string | undefined, diseaseAliases: Array<string> } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, name: string, link: string, ncitId?: string | undefined, therapyAliases: Array<string> }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string, link: string, hpoId: string }>, source: { __typename: 'Source', id: number, name: string, link: string, citation?: string | undefined, citationId: string, sourceType: SourceSource } } | undefined };
+export type EvidenceItemRevisableFieldsQuery = { __typename: 'Query', evidenceItem?: { __typename: 'EvidenceItem', id: number, variantOrigin: VariantOrigin, description: string, significance: EvidenceSignificance, therapyInteractionType?: TherapyInteraction | undefined, evidenceDirection: EvidenceDirection, evidenceLevel: EvidenceLevel, evidenceType: EvidenceType, evidenceRating?: number | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> }, disease?: { __typename: 'Disease', id: number, name: string, link: string, displayName: string, doid?: string | undefined, diseaseAliases: Array<string> } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, name: string, link: string, ncitId?: string | undefined, therapyAliases: Array<string> }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string, link: string, hpoId: string }>, source: { __typename: 'Source', id: number, name: string, link: string, citation?: string | undefined, citationId: string, sourceType: SourceSource } } | undefined };
 
-export type RevisableEvidenceFields2Fragment = { __typename: 'EvidenceItem', id: number, variantOrigin: VariantOrigin, description: string, significance: EvidenceSignificance, therapyInteractionType?: TherapyInteraction | undefined, evidenceDirection: EvidenceDirection, evidenceLevel: EvidenceLevel, evidenceType: EvidenceType, evidenceRating?: number | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> }, disease?: { __typename: 'Disease', id: number, name: string, link: string, displayName: string, doid?: string | undefined, diseaseAliases: Array<string> } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, name: string, link: string, ncitId?: string | undefined, therapyAliases: Array<string> }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string, link: string, hpoId: string }>, source: { __typename: 'Source', id: number, name: string, link: string, citation?: string | undefined, citationId: string, sourceType: SourceSource } };
+export type RevisableEvidenceFieldsFragment = { __typename: 'EvidenceItem', id: number, variantOrigin: VariantOrigin, description: string, significance: EvidenceSignificance, therapyInteractionType?: TherapyInteraction | undefined, evidenceDirection: EvidenceDirection, evidenceLevel: EvidenceLevel, evidenceType: EvidenceType, evidenceRating?: number | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> }, disease?: { __typename: 'Disease', id: number, name: string, link: string, displayName: string, doid?: string | undefined, diseaseAliases: Array<string> } | undefined, therapies: Array<{ __typename: 'Therapy', id: number, name: string, link: string, ncitId?: string | undefined, therapyAliases: Array<string> }>, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string, link: string, hpoId: string }>, source: { __typename: 'Source', id: number, name: string, link: string, citation?: string | undefined, citationId: string, sourceType: SourceSource } };
 
-export type SuggestEvidenceItemRevision2MutationVariables = Exact<{
+export type SuggestEvidenceItemRevisionMutationVariables = Exact<{
   input: SuggestEvidenceItemRevisionInput;
 }>;
 
 
-export type SuggestEvidenceItemRevision2Mutation = { __typename: 'Mutation', suggestEvidenceItemRevision?: { __typename: 'SuggestEvidenceItemRevisionPayload', clientMutationId?: string | undefined, evidenceItem: { __typename: 'EvidenceItem', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean }> } | undefined };
+export type SuggestEvidenceItemRevisionMutation = { __typename: 'Mutation', suggestEvidenceItemRevision?: { __typename: 'SuggestEvidenceItemRevisionPayload', clientMutationId?: string | undefined, evidenceItem: { __typename: 'EvidenceItem', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean }> } | undefined };
+
+export type EvidenceFieldsFromSourceSuggestionQueryVariables = Exact<{
+  sourceId?: InputMaybe<Scalars['Int']>;
+  molecularProfileId?: InputMaybe<Scalars['Int']>;
+  diseaseId?: InputMaybe<Scalars['Int']>;
+}>;
+
+
+export type EvidenceFieldsFromSourceSuggestionQuery = { __typename: 'Query', sourceSuggestionValues: { __typename: 'SourceSuggestionValues', molecularProfile?: { __typename: 'MolecularProfile', id: number, name: string, link: string } | undefined, disease?: { __typename: 'Disease', id: number, name: string, link: string } | undefined, source?: { __typename: 'Source', id: number, sourceType: SourceSource, citationId: string, citation?: string | undefined, link: string } | undefined } };
+
+export type EvidenceSubmittableFieldsQueryVariables = Exact<{
+  evidenceId: Scalars['Int'];
+}>;
+
+
+export type EvidenceSubmittableFieldsQuery = { __typename: 'Query', evidenceItem?: { __typename: 'EvidenceItem', id: number, description: string, variantOrigin: VariantOrigin, evidenceType: EvidenceType, significance: EvidenceSignificance, evidenceLevel: EvidenceLevel, evidenceDirection: EvidenceDirection, evidenceRating?: number | undefined, therapyInteractionType?: TherapyInteraction | undefined, source: { __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource }, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string }>, therapies: Array<{ __typename: 'Therapy', id: number, name: string }>, disease?: { __typename: 'Disease', id: number, name: string } | undefined } | undefined };
+
+export type SubmittableEvidenceFieldsFragment = { __typename: 'EvidenceItem', id: number, description: string, variantOrigin: VariantOrigin, evidenceType: EvidenceType, significance: EvidenceSignificance, evidenceLevel: EvidenceLevel, evidenceDirection: EvidenceDirection, evidenceRating?: number | undefined, therapyInteractionType?: TherapyInteraction | undefined, source: { __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource }, phenotypes: Array<{ __typename: 'Phenotype', id: number, name: string }>, therapies: Array<{ __typename: 'Therapy', id: number, name: string }>, disease?: { __typename: 'Disease', id: number, name: string } | undefined };
+
+export type SubmitEvidenceItemMutationVariables = Exact<{
+  input: SubmitEvidenceItemInput;
+}>;
+
+
+export type SubmitEvidenceItemMutation = { __typename: 'Mutation', submitEvidence?: { __typename: 'SubmitEvidenceItemPayload', clientMutationId?: string | undefined, evidenceItem: { __typename: 'EvidenceItem', id: number } } | undefined };
 
 export type ExistingEvidenceCountQueryVariables = Exact<{
   molecularProfileId: Scalars['Int'];
@@ -6604,6 +6337,38 @@ export type ExistingEvidenceCountQueryVariables = Exact<{
 
 
 export type ExistingEvidenceCountQuery = { __typename: 'Query', evidenceItems: { __typename: 'EvidenceItemConnection', totalCount: number } };
+
+export type GeneRevisableFieldsQueryVariables = Exact<{
+  geneId: Scalars['Int'];
+}>;
+
+
+export type GeneRevisableFieldsQuery = { __typename: 'Query', gene?: { __typename: 'Gene', id: number, description: string, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> } | undefined };
+
+export type RevisableGeneFieldsFragment = { __typename: 'Gene', id: number, description: string, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> };
+
+export type SuggestGeneRevisionMutationVariables = Exact<{
+  input: SuggestGeneRevisionInput;
+}>;
+
+
+export type SuggestGeneRevisionMutation = { __typename: 'Mutation', suggestGeneRevision?: { __typename: 'SuggestGeneRevisionPayload', clientMutationId?: string | undefined, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean, id: number, fieldName: string }> } | undefined };
+
+export type MolecularProfileRevisableFieldsQueryVariables = Exact<{
+  molecularProfileId: Scalars['Int'];
+}>;
+
+
+export type MolecularProfileRevisableFieldsQuery = { __typename: 'Query', molecularProfile?: { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, isComplex: boolean, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> } | undefined };
+
+export type RevisableMolecularProfileFieldsFragment = { __typename: 'MolecularProfile', id: number, description?: string | undefined, molecularProfileAliases: Array<string>, isComplex: boolean, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> };
+
+export type SuggestMolecularProfileRevisionMutationVariables = Exact<{
+  input: SuggestMolecularProfileRevisionInput;
+}>;
+
+
+export type SuggestMolecularProfileRevisionMutation = { __typename: 'Mutation', suggestMolecularProfileRevision?: { __typename: 'SuggestMolecularProfileRevisionPayload', clientMutationId?: string | undefined, molecularProfile: { __typename: 'MolecularProfile', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean, id: number, fieldName: string }> } | undefined };
 
 export type SubmitSourceMutationVariables = Exact<{
   input: SuggestSourceInput;
@@ -6630,21 +6395,37 @@ export type SuggestVariantRevisionMutationVariables = Exact<{
 
 export type SuggestVariantRevisionMutation = { __typename: 'Mutation', suggestVariantRevision?: { __typename: 'SuggestVariantRevisionPayload', clientMutationId?: string | undefined, variant: { __typename: 'Variant', id: number }, results: Array<{ __typename: 'RevisionResult', id: number, fieldName: string, newlyCreated: boolean }> } | undefined };
 
-export type VariantGroupRevisableFields2QueryVariables = Exact<{
+export type VariantGroupRevisableFieldsQueryVariables = Exact<{
   variantGroupId: Scalars['Int'];
 }>;
 
 
-export type VariantGroupRevisableFields2Query = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', totalCount: number, edges: Array<{ __typename: 'VariantEdge', cursor: string, node?: { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> } | undefined };
+export type VariantGroupRevisableFieldsQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', totalCount: number, edges: Array<{ __typename: 'VariantEdge', cursor: string, node?: { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> } | undefined };
 
-export type VariantGroupRevisableFields2Fragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', totalCount: number, edges: Array<{ __typename: 'VariantEdge', cursor: string, node?: { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> };
+export type VariantGroupRevisableFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', totalCount: number, edges: Array<{ __typename: 'VariantEdge', cursor: string, node?: { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> };
 
-export type SuggestVariantGroupRevision2MutationVariables = Exact<{
+export type SuggestVariantGroupRevisionMutationVariables = Exact<{
   input: SuggestVariantGroupRevisionInput;
 }>;
 
 
-export type SuggestVariantGroupRevision2Mutation = { __typename: 'Mutation', suggestVariantGroupRevision?: { __typename: 'SuggestVariantGroupRevisionPayload', clientMutationId?: string | undefined, variantGroup: { __typename: 'VariantGroup', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean, id: number, fieldName: string }> } | undefined };
+export type SuggestVariantGroupRevisionMutation = { __typename: 'Mutation', suggestVariantGroupRevision?: { __typename: 'SuggestVariantGroupRevisionPayload', clientMutationId?: string | undefined, variantGroup: { __typename: 'VariantGroup', id: number }, results: Array<{ __typename: 'RevisionResult', newlyCreated: boolean, id: number, fieldName: string }> } | undefined };
+
+export type VariantGroupSubmittableFieldsQueryVariables = Exact<{
+  variantGroupId: Scalars['Int'];
+}>;
+
+
+export type VariantGroupSubmittableFieldsQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> } | undefined };
+
+export type SubmittableVariantGroupFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> };
+
+export type SubmitVariantGroupMutationVariables = Exact<{
+  input: SubmitVariantGroupInput;
+}>;
+
+
+export type SubmitVariantGroupMutation = { __typename: 'Mutation', submitVariantGroup?: { __typename: 'SubmitVariantGroupPayload', clientMutationId?: string | undefined, variantGroup: { __typename: 'VariantGroup', id: number } } | undefined };
 
 export type EntityTagsTestQueryVariables = Exact<{
   molecularProfileId: Scalars['Int'];
@@ -6945,7 +6726,7 @@ export type QuickAddVariantMutationVariables = Exact<{
 }>;
 
 
-export type QuickAddVariantMutation = { __typename: 'Mutation', addVariant?: { __typename: 'AddVariantPayload', clientMutationId?: string | undefined, new: boolean, variant: { __typename: 'Variant', id: number, name: string, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } } | undefined };
+export type QuickAddVariantMutation = { __typename: 'Mutation', addVariant?: { __typename: 'AddVariantPayload', clientMutationId?: string | undefined, new: boolean, variant: { __typename: 'Variant', id: number, name: string, link: string, variantAliases: Array<string>, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> } } } | undefined };
 
 export type QuickAddVariantFieldsFragment = { __typename: 'AddVariantPayload', clientMutationId?: string | undefined, new: boolean, variant: { __typename: 'Variant', id: number, name: string, link: string, variantAliases: Array<string>, singleVariantMolecularProfileId: number, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string, molecularProfileAliases: Array<string> } } };
 
@@ -8369,6 +8150,30 @@ export const BrowseVariantsFieldsFragmentDoc = gql`
   }
 }
     `;
+export const PreviewCommentFragmentDoc = gql`
+    fragment previewComment on CommentBodySegment {
+  __typename
+  ... on CommentTagSegment {
+    entityId
+    displayName
+    tagType
+    link
+    status
+    deprecated
+    __typename
+  }
+  ... on CommentTextSegment {
+    text
+    __typename
+  }
+  ... on User {
+    id
+    displayName
+    role
+    __typename
+  }
+}
+    `;
 export const RevisableAssertionFieldsFragmentDoc = gql`
     fragment RevisableAssertionFields on Assertion {
   id
@@ -8430,143 +8235,6 @@ export const RevisableAssertionFieldsFragmentDoc = gql`
     name
     link
     status
-  }
-}
-    `;
-export const PreviewCommentFragmentDoc = gql`
-    fragment previewComment on CommentBodySegment {
-  __typename
-  ... on CommentTagSegment {
-    entityId
-    displayName
-    tagType
-    link
-    status
-    deprecated
-    __typename
-  }
-  ... on CommentTextSegment {
-    text
-    __typename
-  }
-  ... on User {
-    id
-    displayName
-    role
-    __typename
-  }
-}
-    `;
-export const PreviewMpNameFragmentDoc = gql`
-    fragment previewMpName on MolecularProfileSegment {
-  __typename
-  ... on MolecularProfileTextSegment {
-    text
-  }
-  ... on Gene {
-    id
-    name
-    link
-  }
-  ... on Variant {
-    id
-    name
-    link
-  }
-}
-    `;
-export const AddDiseaseFieldsFragmentDoc = gql`
-    fragment AddDiseaseFields on AddDiseasePayload {
-  new
-  disease {
-    id
-    name
-    displayName
-  }
-}
-    `;
-export const GeneTypeaheadFieldsFragmentDoc = gql`
-    fragment GeneTypeaheadFields on Gene {
-  id
-  name
-  geneAliases
-  entrezId
-}
-    `;
-export const SourceTypeaheadResultFragmentDoc = gql`
-    fragment SourceTypeaheadResult on Source {
-  id
-  name
-  citation
-  citationId
-  sourceType
-}
-    `;
-export const SourceStubFieldsFragmentDoc = gql`
-    fragment SourceStubFields on SourceStub {
-  id
-  citationId
-  sourceType
-}
-    `;
-export const SourceTypeaheadFieldsFragmentDoc = gql`
-    fragment SourceTypeaheadFields on Source {
-  id
-  name
-  citation
-  citationId
-  sourceType
-}
-    `;
-export const AddTherapyFieldsFragmentDoc = gql`
-    fragment AddTherapyFields on AddTherapyPayload {
-  new
-  therapy {
-    id
-    ncitId
-    name
-  }
-}
-    `;
-export const VariantTypeaheadFieldsFragmentDoc = gql`
-    fragment VariantTypeaheadFields on Variant {
-  id
-  name
-  variantAliases
-  singleVariantMolecularProfileId
-  singleVariantMolecularProfile {
-    id
-    name
-    link
-  }
-}
-    `;
-export const AddVariantFieldsFragmentDoc = gql`
-    fragment AddVariantFields on AddVariantPayload {
-  clientMutationId
-  new
-  variant {
-    id
-    name
-    singleVariantMolecularProfileId
-    singleVariantMolecularProfile {
-      id
-      name
-      link
-    }
-  }
-}
-    `;
-export const VariantSelectFieldsFragmentDoc = gql`
-    fragment VariantSelectFields on Variant {
-  id
-  name
-  variantAliases
-  singleVariantMolecularProfileId
-  singleVariantMolecularProfile {
-    id
-    name
-    link
   }
 }
     `;
@@ -8703,63 +8371,6 @@ export const RevisableMolecularProfileFieldsFragmentDoc = gql`
   isComplex
 }
     `;
-export const SubmittableVariantGroupFieldsFragmentDoc = gql`
-    fragment SubmittableVariantGroupFields on VariantGroup {
-  id
-  name
-  description
-  variants(first: 50) {
-    nodes {
-      id
-      name
-      link
-      singleVariantMolecularProfile {
-        id
-        name
-        link
-      }
-    }
-  }
-  sources {
-    id
-    link
-    citation
-    sourceType
-  }
-}
-    `;
-export const RevisableEvidenceFields2FragmentDoc = gql`
-    fragment RevisableEvidenceFields2 on EvidenceItem {
-  id
-  molecularProfile {
-    ...MolecularProfileSelectTypeaheadFields
-  }
-  variantOrigin
-  description
-  significance
-  disease {
-    ...DiseaseSelectTypeaheadFields
-  }
-  therapies {
-    ...TherapySelectTypeaheadFields
-  }
-  therapyInteractionType
-  evidenceDirection
-  evidenceLevel
-  evidenceType
-  phenotypes {
-    ...PhenotypeSelectTypeaheadFields
-  }
-  evidenceRating
-  source {
-    ...SourceSelectTypeaheadFields
-  }
-}
-    ${MolecularProfileSelectTypeaheadFieldsFragmentDoc}
-${DiseaseSelectTypeaheadFieldsFragmentDoc}
-${TherapySelectTypeaheadFieldsFragmentDoc}
-${PhenotypeSelectTypeaheadFieldsFragmentDoc}
-${SourceSelectTypeaheadFieldsFragmentDoc}`;
 export const CoordinateFieldsFragmentDoc = gql`
     fragment CoordinateFields on Coordinate {
   chromosome
@@ -8797,8 +8408,8 @@ export const RevisableVariantFieldsFragmentDoc = gql`
   variantBases
 }
     ${CoordinateFieldsFragmentDoc}`;
-export const VariantGroupRevisableFields2FragmentDoc = gql`
-    fragment VariantGroupRevisableFields2 on VariantGroup {
+export const VariantGroupRevisableFieldsFragmentDoc = gql`
+    fragment VariantGroupRevisableFields on VariantGroup {
   id
   name
   description
@@ -8822,6 +8433,31 @@ export const VariantGroupRevisableFields2FragmentDoc = gql`
     id
     name
     link
+  }
+}
+    `;
+export const SubmittableVariantGroupFieldsFragmentDoc = gql`
+    fragment SubmittableVariantGroupFields on VariantGroup {
+  id
+  name
+  description
+  variants(first: 50) {
+    nodes {
+      id
+      name
+      link
+      singleVariantMolecularProfile {
+        id
+        name
+        link
+      }
+    }
+  }
+  sources {
+    id
+    link
+    citation
+    sourceType
   }
 }
     `;
@@ -11891,69 +11527,6 @@ export const ViewerNotificationCountDocument = gql`
       super(apollo);
     }
   }
-export const AssertionRevisableFieldsDocument = gql`
-    query AssertionRevisableFields($assertionId: Int!) {
-  assertion(id: $assertionId) {
-    ...RevisableAssertionFields
-  }
-}
-    ${RevisableAssertionFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class AssertionRevisableFieldsGQL extends Apollo.Query<AssertionRevisableFieldsQuery, AssertionRevisableFieldsQueryVariables> {
-    document = AssertionRevisableFieldsDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SuggestAssertionRevisionDocument = gql`
-    mutation SuggestAssertionRevision($input: SuggestAssertionRevisionInput!) {
-  suggestAssertionRevision(input: $input) {
-    clientMutationId
-    assertion {
-      id
-    }
-    results {
-      newlyCreated
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SuggestAssertionRevisionGQL extends Apollo.Mutation<SuggestAssertionRevisionMutation, SuggestAssertionRevisionMutationVariables> {
-    document = SuggestAssertionRevisionDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SubmitAssertionDocument = gql`
-    mutation SubmitAssertion($input: SubmitAssertionInput!) {
-  submitAssertion(input: $input) {
-    clientMutationId
-    assertion {
-      id
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SubmitAssertionGQL extends Apollo.Mutation<SubmitAssertionMutation, SubmitAssertionMutationVariables> {
-    document = SubmitAssertionDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
 export const AddCommentDocument = gql`
     mutation AddComment($input: AddCommentInput!) {
   addComment(input: $input) {
@@ -12031,111 +11604,12 @@ export const EntityTypeaheadDocument = gql`
       super(apollo);
     }
   }
-export const PreviewMolecularProfileNameDocument = gql`
-    query previewMolecularProfileName($mpStructure: MolecularProfileComponentInput) {
-  previewMolecularProfileName(structure: $mpStructure) {
-    existingMolecularProfile {
-      id
-      name
-      link
-    }
-    segments {
-      ...previewMpName
-    }
-    deprecatedVariants {
-      id
-      name
-      link
-    }
-  }
-}
-    ${PreviewMpNameFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class PreviewMolecularProfileNameGQL extends Apollo.Query<PreviewMolecularProfileNameQuery, PreviewMolecularProfileNameQueryVariables> {
-    document = PreviewMolecularProfileNameDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const CreateMolecularProfileDocument = gql`
-    mutation createMolecularProfile($mpStructure: MolecularProfileComponentInput!) {
-  createMolecularProfile(input: {structure: $mpStructure}) {
-    molecularProfile {
-      id
-      name
-      link
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class CreateMolecularProfileGQL extends Apollo.Mutation<CreateMolecularProfileMutation, CreateMolecularProfileMutationVariables> {
-    document = CreateMolecularProfileDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const AcmgCodeTypeaheadDocument = gql`
-    query AcmgCodeTypeahead($code: String!) {
-  acmgCodesTypeahead(queryTerm: $code) {
-    id
-    code
-    description
-    name
-    tooltip
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class AcmgCodeTypeaheadGQL extends Apollo.Query<AcmgCodeTypeaheadQuery, AcmgCodeTypeaheadQueryVariables> {
-    document = AcmgCodeTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const ClingenCodeTypeaheadDocument = gql`
-    query ClingenCodeTypeahead($code: String!) {
-  clingenCodesTypeahead(queryTerm: $code) {
-    id
-    code
-    description
-    name
-    tooltip
-    exclusive
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class ClingenCodeTypeaheadGQL extends Apollo.Query<ClingenCodeTypeaheadQuery, ClingenCodeTypeaheadQueryVariables> {
-    document = ClingenCodeTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const DiseaseTypeaheadDocument = gql`
-    query DiseaseTypeahead($name: String!) {
-  diseaseTypeahead(queryTerm: $name) {
+export const LinkableGeneDocument = gql`
+    query LinkableGene($geneId: Int!) {
+  gene(id: $geneId) {
     id
     name
-    displayName
-    doid
-    diseaseAliases
+    link
   }
 }
     `;
@@ -12143,74 +11617,19 @@ export const DiseaseTypeaheadDocument = gql`
   @Injectable({
     providedIn: 'root'
   })
-  export class DiseaseTypeaheadGQL extends Apollo.Query<DiseaseTypeaheadQuery, DiseaseTypeaheadQueryVariables> {
-    document = DiseaseTypeaheadDocument;
+  export class LinkableGeneGQL extends Apollo.Query<LinkableGeneQuery, LinkableGeneQueryVariables> {
+    document = LinkableGeneDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
     }
   }
-export const AddDiseaseDocument = gql`
-    mutation AddDisease($name: String!, $doid: String) {
-  addDisease(input: {name: $name, doid: $doid}) {
-    ...AddDiseaseFields
-  }
-}
-    ${AddDiseaseFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class AddDiseaseGQL extends Apollo.Mutation<AddDiseaseMutation, AddDiseaseMutationVariables> {
-    document = AddDiseaseDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const EvidenceTypeaheadDocument = gql`
-    query EvidenceTypeahead($id: Int!) {
-  evidenceItem(id: $id) {
-    id
-    status
-    name
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class EvidenceTypeaheadGQL extends Apollo.Query<EvidenceTypeaheadQuery, EvidenceTypeaheadQueryVariables> {
-    document = EvidenceTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const GeneTypeaheadDocument = gql`
-    query GeneTypeahead($entrezSymbol: String!) {
-  geneTypeahead(queryTerm: $entrezSymbol) {
-    ...GeneTypeaheadFields
-  }
-}
-    ${GeneTypeaheadFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class GeneTypeaheadGQL extends Apollo.Query<GeneTypeaheadQuery, GeneTypeaheadQueryVariables> {
-    document = GeneTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const NccnGuidelineTypeaheadDocument = gql`
-    query NccnGuidelineTypeahead($name: String!) {
-  nccnGuidelinesTypeahead(queryTerm: $name) {
+export const LinkableVariantDocument = gql`
+    query LinkableVariant($variantId: Int!) {
+  variant(id: $variantId) {
     id
     name
+    link
   }
 }
     `;
@@ -12218,19 +11637,19 @@ export const NccnGuidelineTypeaheadDocument = gql`
   @Injectable({
     providedIn: 'root'
   })
-  export class NccnGuidelineTypeaheadGQL extends Apollo.Query<NccnGuidelineTypeaheadQuery, NccnGuidelineTypeaheadQueryVariables> {
-    document = NccnGuidelineTypeaheadDocument;
+  export class LinkableVariantGQL extends Apollo.Query<LinkableVariantQuery, LinkableVariantQueryVariables> {
+    document = LinkableVariantDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
     }
   }
-export const PhenotypeTypeaheadDocument = gql`
-    query PhenotypeTypeahead($name: String!) {
-  phenotypeTypeahead(queryTerm: $name) {
-    hpoId
+export const LinkableTherapyDocument = gql`
+    query LinkableTherapy($therapyId: Int!) {
+  therapy(id: $therapyId) {
     id
     name
+    link
   }
 }
     `;
@@ -12238,354 +11657,8 @@ export const PhenotypeTypeaheadDocument = gql`
   @Injectable({
     providedIn: 'root'
   })
-  export class PhenotypeTypeaheadGQL extends Apollo.Query<PhenotypeTypeaheadQuery, PhenotypeTypeaheadQueryVariables> {
-    document = PhenotypeTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const CitationExistenceCheckDocument = gql`
-    query CitationExistenceCheck($sourceType: SourceSource!, $citationId: String!) {
-  remoteCitation(sourceType: $sourceType, citationId: $citationId)
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class CitationExistenceCheckGQL extends Apollo.Query<CitationExistenceCheckQuery, CitationExistenceCheckQueryVariables> {
-    document = CitationExistenceCheckDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const CreateSourceStubDocument = gql`
-    mutation CreateSourceStub($input: AddRemoteCitationInput!) {
-  addRemoteCitation(input: $input) {
-    newSource {
-      id
-      citationId
-      sourceType
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class CreateSourceStubGQL extends Apollo.Mutation<CreateSourceStubMutation, CreateSourceStubMutationVariables> {
-    document = CreateSourceStubDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const CitationTypeaheadDocument = gql`
-    query CitationTypeahead($partialCitationId: String!, $sourceType: SourceSource!) {
-  sourceTypeahead(citationId: $partialCitationId, sourceType: $sourceType) {
-    ...SourceTypeaheadResult
-  }
-}
-    ${SourceTypeaheadResultFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class CitationTypeaheadGQL extends Apollo.Query<CitationTypeaheadQuery, CitationTypeaheadQueryVariables> {
-    document = CitationTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const CheckRemoteCitationDocument = gql`
-    query CheckRemoteCitation($sourceType: SourceSource!, $citationId: String!) {
-  remoteCitation(sourceType: $sourceType, citationId: $citationId)
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class CheckRemoteCitationGQL extends Apollo.Query<CheckRemoteCitationQuery, CheckRemoteCitationQueryVariables> {
-    document = CheckRemoteCitationDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const AddRemoteCitationDocument = gql`
-    mutation AddRemoteCitation($input: AddRemoteCitationInput!) {
-  addRemoteCitation(input: $input) {
-    newSource {
-      ...SourceStubFields
-    }
-  }
-}
-    ${SourceStubFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class AddRemoteCitationGQL extends Apollo.Mutation<AddRemoteCitationMutation, AddRemoteCitationMutationVariables> {
-    document = AddRemoteCitationDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SourceTypeaheadDocument = gql`
-    query SourceTypeahead($partialCitationId: String!, $sourceType: SourceSource!) {
-  sourceTypeahead(citationId: $partialCitationId, sourceType: $sourceType) {
-    ...SourceTypeaheadResult
-  }
-}
-    ${SourceTypeaheadResultFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SourceTypeaheadGQL extends Apollo.Query<SourceTypeaheadQuery, SourceTypeaheadQueryVariables> {
-    document = SourceTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const TherapyTypeaheadDocument = gql`
-    query TherapyTypeahead($name: String!) {
-  therapyTypeahead(queryTerm: $name) {
-    id
-    name
-    ncitId
-    therapyAliases
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class TherapyTypeaheadGQL extends Apollo.Query<TherapyTypeaheadQuery, TherapyTypeaheadQueryVariables> {
-    document = TherapyTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const AddTherapyDocument = gql`
-    mutation AddTherapy($name: String!, $ncitId: String) {
-  addTherapy(input: {name: $name, ncitId: $ncitId}) {
-    ...AddTherapyFields
-  }
-}
-    ${AddTherapyFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class AddTherapyGQL extends Apollo.Mutation<AddTherapyMutation, AddTherapyMutationVariables> {
-    document = AddTherapyDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const VariantTypeaheadDocument = gql`
-    query VariantTypeahead($name: String!, $geneId: Int) {
-  variants(name: $name, geneId: $geneId, first: 20) {
-    nodes {
-      ...VariantTypeaheadFields
-    }
-  }
-}
-    ${VariantTypeaheadFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class VariantTypeaheadGQL extends Apollo.Query<VariantTypeaheadQuery, VariantTypeaheadQueryVariables> {
-    document = VariantTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const AddVariantDocument = gql`
-    mutation AddVariant($name: String!, $geneId: Int!) {
-  addVariant(input: {name: $name, geneId: $geneId}) {
-    ...AddVariantFields
-  }
-}
-    ${AddVariantFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class AddVariantGQL extends Apollo.Mutation<AddVariantMutation, AddVariantMutationVariables> {
-    document = AddVariantDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const VariantSelectDocument = gql`
-    query VariantSelect($name: String!, $geneId: Int) {
-  variants(name: $name, first: 20, geneId: $geneId) {
-    nodes {
-      ...VariantTypeaheadFields
-    }
-  }
-}
-    ${VariantTypeaheadFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class VariantSelectGQL extends Apollo.Query<VariantSelectQuery, VariantSelectQueryVariables> {
-    document = VariantSelectDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const VariantTypeTypeaheadDocument = gql`
-    query VariantTypeTypeahead($name: String!) {
-  variantTypeTypeahead(queryTerm: $name) {
-    name
-    soid
-    id
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class VariantTypeTypeaheadGQL extends Apollo.Query<VariantTypeTypeaheadQuery, VariantTypeTypeaheadQueryVariables> {
-    document = VariantTypeTypeaheadDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const EvidenceItemRevisableFieldsDocument = gql`
-    query EvidenceItemRevisableFields($evidenceId: Int!) {
-  evidenceItem(id: $evidenceId) {
-    ...RevisableEvidenceFields
-  }
-}
-    ${RevisableEvidenceFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class EvidenceItemRevisableFieldsGQL extends Apollo.Query<EvidenceItemRevisableFieldsQuery, EvidenceItemRevisableFieldsQueryVariables> {
-    document = EvidenceItemRevisableFieldsDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SuggestEvidenceItemRevisionDocument = gql`
-    mutation SuggestEvidenceItemRevision($input: SuggestEvidenceItemRevisionInput!) {
-  suggestEvidenceItemRevision(input: $input) {
-    clientMutationId
-    evidenceItem {
-      id
-    }
-    results {
-      newlyCreated
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SuggestEvidenceItemRevisionGQL extends Apollo.Mutation<SuggestEvidenceItemRevisionMutation, SuggestEvidenceItemRevisionMutationVariables> {
-    document = SuggestEvidenceItemRevisionDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const EvidenceFieldsFromSourceSuggestionDocument = gql`
-    query EvidenceFieldsFromSourceSuggestion($sourceId: Int, $molecularProfileId: Int, $diseaseId: Int) {
-  sourceSuggestionValues(
-    molecularProfileId: $molecularProfileId
-    diseaseId: $diseaseId
-    sourceId: $sourceId
-  ) {
-    molecularProfile {
-      id
-      name
-      link
-    }
-    disease {
-      id
-      name
-      link
-    }
-    source {
-      id
-      sourceType
-      citationId
-      citation
-      link
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class EvidenceFieldsFromSourceSuggestionGQL extends Apollo.Query<EvidenceFieldsFromSourceSuggestionQuery, EvidenceFieldsFromSourceSuggestionQueryVariables> {
-    document = EvidenceFieldsFromSourceSuggestionDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const EvidenceSubmittableFieldsDocument = gql`
-    query EvidenceSubmittableFields($evidenceId: Int!) {
-  evidenceItem(id: $evidenceId) {
-    ...SubmittableEvidenceFields
-  }
-}
-    ${SubmittableEvidenceFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class EvidenceSubmittableFieldsGQL extends Apollo.Query<EvidenceSubmittableFieldsQuery, EvidenceSubmittableFieldsQueryVariables> {
-    document = EvidenceSubmittableFieldsDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SubmitEvidenceItemDocument = gql`
-    mutation SubmitEvidenceItem($input: SubmitEvidenceItemInput!) {
-  submitEvidence(input: $input) {
-    clientMutationId
-    evidenceItem {
-      id
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SubmitEvidenceItemGQL extends Apollo.Mutation<SubmitEvidenceItemMutation, SubmitEvidenceItemMutationVariables> {
-    document = SubmitEvidenceItemDocument;
+  export class LinkableTherapyGQL extends Apollo.Query<LinkableTherapyQuery, LinkableTherapyQueryVariables> {
+    document = LinkableTherapyDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
@@ -12626,112 +11699,6 @@ export const ResolveFlagDocument = gql`
   })
   export class ResolveFlagGQL extends Apollo.Mutation<ResolveFlagMutation, ResolveFlagMutationVariables> {
     document = ResolveFlagDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const GeneRevisableFieldsDocument = gql`
-    query GeneRevisableFields($geneId: Int!) {
-  gene(id: $geneId) {
-    ...RevisableGeneFields
-  }
-}
-    ${RevisableGeneFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class GeneRevisableFieldsGQL extends Apollo.Query<GeneRevisableFieldsQuery, GeneRevisableFieldsQueryVariables> {
-    document = GeneRevisableFieldsDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SuggestGeneRevisionDocument = gql`
-    mutation SuggestGeneRevision($input: SuggestGeneRevisionInput!) {
-  suggestGeneRevision(input: $input) {
-    clientMutationId
-    results {
-      newlyCreated
-      id
-      fieldName
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SuggestGeneRevisionGQL extends Apollo.Mutation<SuggestGeneRevisionMutation, SuggestGeneRevisionMutationVariables> {
-    document = SuggestGeneRevisionDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const MolecularProfileRevisableFieldsDocument = gql`
-    query MolecularProfileRevisableFields($molecularProfileId: Int!) {
-  molecularProfile(id: $molecularProfileId) {
-    ...RevisableMolecularProfileFields
-  }
-}
-    ${RevisableMolecularProfileFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class MolecularProfileRevisableFieldsGQL extends Apollo.Query<MolecularProfileRevisableFieldsQuery, MolecularProfileRevisableFieldsQueryVariables> {
-    document = MolecularProfileRevisableFieldsDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SuggestMolecularProfileRevisionDocument = gql`
-    mutation SuggestMolecularProfileRevision($input: SuggestMolecularProfileRevisionInput!) {
-  suggestMolecularProfileRevision(input: $input) {
-    clientMutationId
-    molecularProfile {
-      id
-    }
-    results {
-      newlyCreated
-      id
-      fieldName
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SuggestMolecularProfileRevisionGQL extends Apollo.Mutation<SuggestMolecularProfileRevisionMutation, SuggestMolecularProfileRevisionMutationVariables> {
-    document = SuggestMolecularProfileRevisionDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SuggestSourceDocument = gql`
-    mutation SuggestSource($input: SuggestSourceInput!) {
-  suggestSource(input: $input) {
-    clientMutationId
-    sourceSuggestion {
-      id
-    }
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class SuggestSourceGQL extends Apollo.Mutation<SuggestSourceMutation, SuggestSourceMutationVariables> {
-    document = SuggestSourceDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
@@ -12872,17 +11839,33 @@ export const MolecularProfilesForVariantDocument = gql`
       super(apollo);
     }
   }
-export const SuggestVariantGroupRevisionDocument = gql`
-    mutation SuggestVariantGroupRevision($input: SuggestVariantGroupRevisionInput!) {
-  suggestVariantGroupRevision(input: $input) {
+export const AssertionRevisableFieldsDocument = gql`
+    query AssertionRevisableFields($assertionId: Int!) {
+  assertion(id: $assertionId) {
+    ...RevisableAssertionFields
+  }
+}
+    ${RevisableAssertionFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class AssertionRevisableFieldsGQL extends Apollo.Query<AssertionRevisableFieldsQuery, AssertionRevisableFieldsQueryVariables> {
+    document = AssertionRevisableFieldsDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const SuggestAssertionRevisionDocument = gql`
+    mutation SuggestAssertionRevision($input: SuggestAssertionRevisionInput!) {
+  suggestAssertionRevision(input: $input) {
     clientMutationId
-    variantGroup {
+    assertion {
       id
     }
     results {
       newlyCreated
-      id
-      fieldName
     }
   }
 }
@@ -12891,36 +11874,18 @@ export const SuggestVariantGroupRevisionDocument = gql`
   @Injectable({
     providedIn: 'root'
   })
-  export class SuggestVariantGroupRevisionGQL extends Apollo.Mutation<SuggestVariantGroupRevisionMutation, SuggestVariantGroupRevisionMutationVariables> {
-    document = SuggestVariantGroupRevisionDocument;
+  export class SuggestAssertionRevisionGQL extends Apollo.Mutation<SuggestAssertionRevisionMutation, SuggestAssertionRevisionMutationVariables> {
+    document = SuggestAssertionRevisionDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
     }
   }
-export const VariantGroupSubmittableFieldsDocument = gql`
-    query VariantGroupSubmittableFields($variantGroupId: Int!) {
-  variantGroup(id: $variantGroupId) {
-    ...SubmittableVariantGroupFields
-  }
-}
-    ${SubmittableVariantGroupFieldsFragmentDoc}`;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class VariantGroupSubmittableFieldsGQL extends Apollo.Query<VariantGroupSubmittableFieldsQuery, VariantGroupSubmittableFieldsQueryVariables> {
-    document = VariantGroupSubmittableFieldsDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const SubmitVariantGroupDocument = gql`
-    mutation SubmitVariantGroup($input: SubmitVariantGroupInput!) {
-  submitVariantGroup(input: $input) {
+export const SubmitAssertionDocument = gql`
+    mutation SubmitAssertion($input: SubmitAssertionInput!) {
+  submitAssertion(input: $input) {
     clientMutationId
-    variantGroup {
+    assertion {
       id
     }
   }
@@ -12930,93 +11895,33 @@ export const SubmitVariantGroupDocument = gql`
   @Injectable({
     providedIn: 'root'
   })
-  export class SubmitVariantGroupGQL extends Apollo.Mutation<SubmitVariantGroupMutation, SubmitVariantGroupMutationVariables> {
-    document = SubmitVariantGroupDocument;
+  export class SubmitAssertionGQL extends Apollo.Mutation<SubmitAssertionMutation, SubmitAssertionMutationVariables> {
+    document = SubmitAssertionDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
     }
   }
-export const LinkableGeneDocument = gql`
-    query LinkableGene($geneId: Int!) {
-  gene(id: $geneId) {
-    id
-    name
-    link
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class LinkableGeneGQL extends Apollo.Query<LinkableGeneQuery, LinkableGeneQueryVariables> {
-    document = LinkableGeneDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const LinkableVariantDocument = gql`
-    query LinkableVariant($variantId: Int!) {
-  variant(id: $variantId) {
-    id
-    name
-    link
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class LinkableVariantGQL extends Apollo.Query<LinkableVariantQuery, LinkableVariantQueryVariables> {
-    document = LinkableVariantDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const LinkableTherapyDocument = gql`
-    query LinkableTherapy($therapyId: Int!) {
-  therapy(id: $therapyId) {
-    id
-    name
-    link
-  }
-}
-    `;
-
-  @Injectable({
-    providedIn: 'root'
-  })
-  export class LinkableTherapyGQL extends Apollo.Query<LinkableTherapyQuery, LinkableTherapyQueryVariables> {
-    document = LinkableTherapyDocument;
-    
-    constructor(apollo: Apollo.Apollo) {
-      super(apollo);
-    }
-  }
-export const EvidenceItemRevisableFields2Document = gql`
-    query EvidenceItemRevisableFields2($evidenceId: Int!) {
+export const EvidenceItemRevisableFieldsDocument = gql`
+    query EvidenceItemRevisableFields($evidenceId: Int!) {
   evidenceItem(id: $evidenceId) {
-    ...RevisableEvidenceFields2
+    ...RevisableEvidenceFields
   }
 }
-    ${RevisableEvidenceFields2FragmentDoc}`;
+    ${RevisableEvidenceFieldsFragmentDoc}`;
 
   @Injectable({
     providedIn: 'root'
   })
-  export class EvidenceItemRevisableFields2GQL extends Apollo.Query<EvidenceItemRevisableFields2Query, EvidenceItemRevisableFields2QueryVariables> {
-    document = EvidenceItemRevisableFields2Document;
+  export class EvidenceItemRevisableFieldsGQL extends Apollo.Query<EvidenceItemRevisableFieldsQuery, EvidenceItemRevisableFieldsQueryVariables> {
+    document = EvidenceItemRevisableFieldsDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
     }
   }
-export const SuggestEvidenceItemRevision2Document = gql`
-    mutation SuggestEvidenceItemRevision2($input: SuggestEvidenceItemRevisionInput!) {
+export const SuggestEvidenceItemRevisionDocument = gql`
+    mutation SuggestEvidenceItemRevision($input: SuggestEvidenceItemRevisionInput!) {
   suggestEvidenceItemRevision(input: $input) {
     clientMutationId
     evidenceItem {
@@ -13032,8 +11937,85 @@ export const SuggestEvidenceItemRevision2Document = gql`
   @Injectable({
     providedIn: 'root'
   })
-  export class SuggestEvidenceItemRevision2GQL extends Apollo.Mutation<SuggestEvidenceItemRevision2Mutation, SuggestEvidenceItemRevision2MutationVariables> {
-    document = SuggestEvidenceItemRevision2Document;
+  export class SuggestEvidenceItemRevisionGQL extends Apollo.Mutation<SuggestEvidenceItemRevisionMutation, SuggestEvidenceItemRevisionMutationVariables> {
+    document = SuggestEvidenceItemRevisionDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const EvidenceFieldsFromSourceSuggestionDocument = gql`
+    query EvidenceFieldsFromSourceSuggestion($sourceId: Int, $molecularProfileId: Int, $diseaseId: Int) {
+  sourceSuggestionValues(
+    molecularProfileId: $molecularProfileId
+    diseaseId: $diseaseId
+    sourceId: $sourceId
+  ) {
+    molecularProfile {
+      id
+      name
+      link
+    }
+    disease {
+      id
+      name
+      link
+    }
+    source {
+      id
+      sourceType
+      citationId
+      citation
+      link
+    }
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class EvidenceFieldsFromSourceSuggestionGQL extends Apollo.Query<EvidenceFieldsFromSourceSuggestionQuery, EvidenceFieldsFromSourceSuggestionQueryVariables> {
+    document = EvidenceFieldsFromSourceSuggestionDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const EvidenceSubmittableFieldsDocument = gql`
+    query EvidenceSubmittableFields($evidenceId: Int!) {
+  evidenceItem(id: $evidenceId) {
+    ...SubmittableEvidenceFields
+  }
+}
+    ${SubmittableEvidenceFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class EvidenceSubmittableFieldsGQL extends Apollo.Query<EvidenceSubmittableFieldsQuery, EvidenceSubmittableFieldsQueryVariables> {
+    document = EvidenceSubmittableFieldsDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const SubmitEvidenceItemDocument = gql`
+    mutation SubmitEvidenceItem($input: SubmitEvidenceItemInput!) {
+  submitEvidence(input: $input) {
+    clientMutationId
+    evidenceItem {
+      id
+    }
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class SubmitEvidenceItemGQL extends Apollo.Mutation<SubmitEvidenceItemMutation, SubmitEvidenceItemMutationVariables> {
+    document = SubmitEvidenceItemDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
@@ -13052,6 +12034,91 @@ export const ExistingEvidenceCountDocument = gql`
   })
   export class ExistingEvidenceCountGQL extends Apollo.Query<ExistingEvidenceCountQuery, ExistingEvidenceCountQueryVariables> {
     document = ExistingEvidenceCountDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const GeneRevisableFieldsDocument = gql`
+    query GeneRevisableFields($geneId: Int!) {
+  gene(id: $geneId) {
+    ...RevisableGeneFields
+  }
+}
+    ${RevisableGeneFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class GeneRevisableFieldsGQL extends Apollo.Query<GeneRevisableFieldsQuery, GeneRevisableFieldsQueryVariables> {
+    document = GeneRevisableFieldsDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const SuggestGeneRevisionDocument = gql`
+    mutation SuggestGeneRevision($input: SuggestGeneRevisionInput!) {
+  suggestGeneRevision(input: $input) {
+    clientMutationId
+    results {
+      newlyCreated
+      id
+      fieldName
+    }
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class SuggestGeneRevisionGQL extends Apollo.Mutation<SuggestGeneRevisionMutation, SuggestGeneRevisionMutationVariables> {
+    document = SuggestGeneRevisionDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const MolecularProfileRevisableFieldsDocument = gql`
+    query MolecularProfileRevisableFields($molecularProfileId: Int!) {
+  molecularProfile(id: $molecularProfileId) {
+    ...RevisableMolecularProfileFields
+  }
+}
+    ${RevisableMolecularProfileFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class MolecularProfileRevisableFieldsGQL extends Apollo.Query<MolecularProfileRevisableFieldsQuery, MolecularProfileRevisableFieldsQueryVariables> {
+    document = MolecularProfileRevisableFieldsDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const SuggestMolecularProfileRevisionDocument = gql`
+    mutation SuggestMolecularProfileRevision($input: SuggestMolecularProfileRevisionInput!) {
+  suggestMolecularProfileRevision(input: $input) {
+    clientMutationId
+    molecularProfile {
+      id
+    }
+    results {
+      newlyCreated
+      id
+      fieldName
+    }
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class SuggestMolecularProfileRevisionGQL extends Apollo.Mutation<SuggestMolecularProfileRevisionMutation, SuggestMolecularProfileRevisionMutationVariables> {
+    document = SuggestMolecularProfileRevisionDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
@@ -13122,26 +12189,26 @@ export const SuggestVariantRevisionDocument = gql`
       super(apollo);
     }
   }
-export const VariantGroupRevisableFields2Document = gql`
-    query VariantGroupRevisableFields2($variantGroupId: Int!) {
+export const VariantGroupRevisableFieldsDocument = gql`
+    query VariantGroupRevisableFields($variantGroupId: Int!) {
   variantGroup(id: $variantGroupId) {
-    ...VariantGroupRevisableFields2
+    ...VariantGroupRevisableFields
   }
 }
-    ${VariantGroupRevisableFields2FragmentDoc}`;
+    ${VariantGroupRevisableFieldsFragmentDoc}`;
 
   @Injectable({
     providedIn: 'root'
   })
-  export class VariantGroupRevisableFields2GQL extends Apollo.Query<VariantGroupRevisableFields2Query, VariantGroupRevisableFields2QueryVariables> {
-    document = VariantGroupRevisableFields2Document;
+  export class VariantGroupRevisableFieldsGQL extends Apollo.Query<VariantGroupRevisableFieldsQuery, VariantGroupRevisableFieldsQueryVariables> {
+    document = VariantGroupRevisableFieldsDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
     }
   }
-export const SuggestVariantGroupRevision2Document = gql`
-    mutation SuggestVariantGroupRevision2($input: SuggestVariantGroupRevisionInput!) {
+export const SuggestVariantGroupRevisionDocument = gql`
+    mutation SuggestVariantGroupRevision($input: SuggestVariantGroupRevisionInput!) {
   suggestVariantGroupRevision(input: $input) {
     clientMutationId
     variantGroup {
@@ -13159,8 +12226,47 @@ export const SuggestVariantGroupRevision2Document = gql`
   @Injectable({
     providedIn: 'root'
   })
-  export class SuggestVariantGroupRevision2GQL extends Apollo.Mutation<SuggestVariantGroupRevision2Mutation, SuggestVariantGroupRevision2MutationVariables> {
-    document = SuggestVariantGroupRevision2Document;
+  export class SuggestVariantGroupRevisionGQL extends Apollo.Mutation<SuggestVariantGroupRevisionMutation, SuggestVariantGroupRevisionMutationVariables> {
+    document = SuggestVariantGroupRevisionDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const VariantGroupSubmittableFieldsDocument = gql`
+    query VariantGroupSubmittableFields($variantGroupId: Int!) {
+  variantGroup(id: $variantGroupId) {
+    ...SubmittableVariantGroupFields
+  }
+}
+    ${SubmittableVariantGroupFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class VariantGroupSubmittableFieldsGQL extends Apollo.Query<VariantGroupSubmittableFieldsQuery, VariantGroupSubmittableFieldsQueryVariables> {
+    document = VariantGroupSubmittableFieldsDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const SubmitVariantGroupDocument = gql`
+    mutation SubmitVariantGroup($input: SubmitVariantGroupInput!) {
+  submitVariantGroup(input: $input) {
+    clientMutationId
+    variantGroup {
+      id
+    }
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class SubmitVariantGroupGQL extends Apollo.Mutation<SubmitVariantGroupMutation, SubmitVariantGroupMutationVariables> {
+    document = SubmitVariantGroupDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);
@@ -13833,10 +12939,10 @@ export const VariantManagerDocument = gql`
 export const QuickAddVariantDocument = gql`
     mutation QuickAddVariant($name: String!, $geneId: Int!) {
   addVariant(input: {name: $name, geneId: $geneId}) {
-    ...AddVariantFields
+    ...QuickAddVariantFields
   }
 }
-    ${AddVariantFieldsFragmentDoc}`;
+    ${QuickAddVariantFieldsFragmentDoc}`;
 
   @Injectable({
     providedIn: 'root'


### PR DESCRIPTION
Copied over several gql query files had been missed in migrating those forms to the forms2 architecture, causing generate-apollo to fail, and TS compilation errors about missing, misnamed gql mutations.