### PR TITLE
Various admin fixes

### DIFF
--- a/server/app/admin/diseases_admin.rb
+++ b/server/app/admin/diseases_admin.rb
@@ -32,7 +32,11 @@ Trestle.resource(:diseases) do
     row do
       col(sm: 2) { static_field :id }
       col(sm: 2) { text_field :doid }
-      col(sm: 2) { check_box :deprecated }
+      col(sm: 2) do
+        form_group :deprecated, label: false do
+          check_box :deprecated 
+        end
+      end
     end
 
     row do

--- a/server/app/admin/diseases_admin.rb
+++ b/server/app/admin/diseases_admin.rb
@@ -1,4 +1,6 @@
 Trestle.resource(:diseases) do
+  remove_action :destroy
+
   collection do
     Disease.eager_load(:disease_aliases)
   end

--- a/server/app/admin/events_admin.rb
+++ b/server/app/admin/events_admin.rb
@@ -1,4 +1,5 @@
 Trestle.resource(:events) do
+  remove_action :destroy
   menu do
     item :events, icon: "fab fa-elementor"
   end

--- a/server/app/admin/revisions_admin.rb
+++ b/server/app/admin/revisions_admin.rb
@@ -1,4 +1,5 @@
 Trestle.resource(:revisions) do
+  remove_action :destroy
   menu do
     item :revisions, icon: "fa fa-edit"
   end

--- a/server/app/admin/therapies_admin.rb
+++ b/server/app/admin/therapies_admin.rb
@@ -1,4 +1,6 @@
 Trestle.resource(:therapies) do
+  remove_action :destroy
+
   menu do
     item :therapies, icon: "fa fa-pills"
   end

--- a/server/app/admin/therapies_admin.rb
+++ b/server/app/admin/therapies_admin.rb
@@ -25,7 +25,11 @@ Trestle.resource(:therapies) do
     row do
       col(sm: 2) { static_field :id }
       col(sm: 2) { text_field :ncit_id }
-      col(sm: 2) { check_box :deprecated }
+      col(sm: 2) do
+        form_group :deprecated, label: false do
+          check_box :deprecated 
+        end
+      end
     end
 
     col(sm: 6) { text_field :name }

--- a/server/app/admin/variants_admin.rb
+++ b/server/app/admin/variants_admin.rb
@@ -57,11 +57,8 @@ Trestle.resource(:variants) do
         end
       end
 
-      text_area :description
-
       select :variant_alias_ids, VariantAlias.order(:name), { label: "Variant Aliases" }, multiple: true
 
-      select :source_ids, Source.order(:description), { label: "Sources" }, multiple: true
 
       row do
         col(sm: 4) { text_field :allele_registry_id }


### PR DESCRIPTION
* error messages will now correctly display next to the "deprecated" checkbox
* variant admin wasn't loading due to including removed fields
* disallow deleting most entities in the admin