### PR TITLE
form field status display improved

### DIFF
--- a/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
+++ b/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
@@ -23,7 +23,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
     wrappers: ['form-layout'],
     props: <CvcFormLayoutWrapperProps>{
       submitLabel: 'Revise Evidence Item',
-      showDevPanel: false,
+      showDevPanel: true,
     },
     fieldGroup: [
       {

--- a/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
+++ b/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
@@ -22,7 +22,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
     wrappers: ['form-layout'],
     props: <CvcFormLayoutWrapperProps>{
       submitLabel: 'Revise Evidence Item',
-      showDevPanel: false,
+      showDevPanel: true,
     },
     fieldGroup: [
       {

--- a/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
+++ b/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
@@ -22,7 +22,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
     wrappers: ['form-layout'],
     props: <CvcFormLayoutWrapperProps>{
       submitLabel: 'Revise Evidence Item',
-      showDevPanel: true,
+      showDevPanel: false,
     },
     fieldGroup: [
       {

--- a/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
+++ b/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
@@ -12,7 +12,6 @@ import { CvcSourceSelectFieldOptions } from '@app/forms/types/source-select/sour
 import { CvcTherapySelectFieldOptions } from '@app/forms/types/therapy-select/therapy-select.type'
 import { CvcEntityTypeSelectFieldConfig } from '@app/forms/types/type-select/type-select.type'
 import assignFieldConfigDefaultValues from '@app/forms/utilities/assign-field-default-values'
-import { CvcFieldGridWrapperConfig } from '@app/forms/wrappers/field-grid/field-grid.wrapper'
 import { CvcFormCardWrapperProps } from '@app/forms/wrappers/form-card/form-card.wrapper'
 import { CvcFormLayoutWrapperProps } from '@app/forms/wrappers/form-layout/form-layout.wrapper'
 import { FormlyFieldConfig } from '@ngx-formly/core'

--- a/client/src/app/forms/config/evidence-submit/evidence-submit.form.config.ts
+++ b/client/src/app/forms/config/evidence-submit/evidence-submit.form.config.ts
@@ -21,7 +21,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
     wrappers: ['form-layout'],
     props: <CvcFormLayoutWrapperProps>{
       submitLabel: 'Submit Evidence Item',
-      showDevPanel: false,
+      showDevPanel: true,
     },
     fieldGroup: [
       {

--- a/client/src/app/forms/config/evidence-submit/evidence-submit.form.config.ts
+++ b/client/src/app/forms/config/evidence-submit/evidence-submit.form.config.ts
@@ -21,7 +21,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
     wrappers: ['form-layout'],
     props: <CvcFormLayoutWrapperProps>{
       submitLabel: 'Submit Evidence Item',
-      showDevPanel: true,
+      showDevPanel: false,
     },
     fieldGroup: [
       {

--- a/client/src/app/forms/config/evidence-submit/evidence-submit.form.config.ts
+++ b/client/src/app/forms/config/evidence-submit/evidence-submit.form.config.ts
@@ -45,7 +45,8 @@ const formFieldConfig: FormlyFieldConfig[] = [
             type: 'molecular-profile-select',
             props: {
               required: true,
-              tooltip: 'A single variant (Simple Molecular Profile) or a combination of variants (Complex Molecular Profile) relevant to the curated evidence.',
+              tooltip:
+                'A single variant (Simple Molecular Profile) or a combination of variants (Complex Molecular Profile) relevant to the curated evidence.',
               watchVariantMolecularProfileId: true,
             },
           },
@@ -143,11 +144,11 @@ const formFieldConfig: FormlyFieldConfig[] = [
             props: {
               label: 'Comment',
               required: false,
-              minLength: 10
+              minLength: 10,
             },
           },
           {
-            type: 'cvc-cancel-button'
+            type: 'cvc-cancel-button',
           },
           {
             key: 'organizationId',

--- a/client/src/app/forms/mixins/entity-select-field.mixin.ts
+++ b/client/src/app/forms/mixins/entity-select-field.mixin.ts
@@ -237,10 +237,9 @@ export function EntitySelectField<
           })
         ) // end this.response$
 
-        this.onOpenChange$
-          .subscribe((change: boolean) => {
-            if (change) this.onSearch$.next('')
-          })
+        this.onOpenChange$.subscribe((change: boolean) => {
+          if (change) this.onSearch$.next('')
+        })
 
         this.response$
           .pipe(
@@ -319,6 +318,7 @@ export function EntitySelectField<
               newValue = options[0]!.id
             }
             this.formControl.setValue(newValue)
+            this.formControl.markAsTouched()
             // if onPopulate$ is called from a quick-add form in the select dropdown,
             // this will close it and cause nz-select to display the new tag
             this.selectOpen$.next(false)

--- a/client/src/app/forms/test-pages/layout-tests/horizontal-form/horizontal-form.page.html
+++ b/client/src/app/forms/test-pages/layout-tests/horizontal-form/horizontal-form.page.html
@@ -1,6 +1,6 @@
 <form
   nz-form
-  [nzLayout]="formLayout"
+  nzLayout="horizontal"
   [formGroup]="form">
   <formly-form
     [form]="form"

--- a/client/src/app/forms/test-pages/layout-tests/inline-form/inline-form.page.html
+++ b/client/src/app/forms/test-pages/layout-tests/inline-form/inline-form.page.html
@@ -1,6 +1,6 @@
 <form
   nz-form
-  [nzLayout]="formLayout"
+  nzLayout="inline"
   [formGroup]="form">
   <formly-form
     [form]="form"

--- a/client/src/app/forms/types/direction-select/direction-select.type.ts
+++ b/client/src/app/forms/types/direction-select/direction-select.type.ts
@@ -115,7 +115,7 @@ export interface CvcDirectionSelectFieldProps extends FormlyFieldProps {
   isMultiSelect: boolean
   requireTypePromptFn: (entityName: string) => string
   tooltip?: string
-  extraType?: CvcFormFieldExtraType,
+  extraType?: CvcFormFieldExtraType
   formMode: 'revise' | 'add' | 'clone'
 }
 
@@ -164,7 +164,7 @@ export class CvcDirectionSelectField
         `Select ${entityType ? entityType + ' ' : ''}${entityName} Direction`,
       requireTypePromptFn: (entityName: string) =>
         `Select ${entityName} Type to select its Direction`,
-      formMode: 'add'
+      formMode: 'add',
     },
   }
 
@@ -274,6 +274,7 @@ export class CvcDirectionSelectField
         if (!et || !ed || !this.state) return
         this.props.extraType = 'description'
         this.props.description = optionText[this.state.entityName][et][ed]
+        this.field.formControl.markAsTouched()
       })
   }
 }

--- a/client/src/app/forms/types/disease-select/disease-select.type.ts
+++ b/client/src/app/forms/types/disease-select/disease-select.type.ts
@@ -95,10 +95,6 @@ export class CvcDiseaseSelectField
   extends DiseaseSelectMixin
   implements AfterViewInit
 {
-  // get template reference to quick-add form for add-entity-form wrapper props
-  @ViewChild('addDisease', { static: true })
-  addForm!: TemplateRef<any>
-
   // get option template query list to populate entity-select
   @ViewChildren('optionTemplates', { read: TemplateRef })
   optionTemplates?: QueryList<TemplateRef<any>>
@@ -173,11 +169,6 @@ export class CvcDiseaseSelectField
         })
     } else {
       this.configureField()
-    }
-
-    // configure add form props
-    if (this.addForm) {
-      this.field.props.addFormContent = this.addForm
     }
   } // ngAfterViewInit()
 

--- a/client/src/app/forms/types/interaction-select/interaction-select.type.ts
+++ b/client/src/app/forms/types/interaction-select/interaction-select.type.ts
@@ -191,6 +191,7 @@ export class CvcInteractionSelectField
           this.props.extraType = 'description'
         } else {
           this.props.extraType = 'prompt'
+          this.field.formControl.markAsTouched()
         }
       })
   }

--- a/client/src/app/forms/types/level-select/level-select.type.ts
+++ b/client/src/app/forms/types/level-select/level-select.type.ts
@@ -139,6 +139,7 @@ export class CvcLevelSelectField
           this.props.description = undefined
         } else {
           this.props.description = optionText.get(level)
+          this.field.formControl.markAsTouched()
         }
       })
   }

--- a/client/src/app/forms/types/molecular-profile-select/molecular-profile-select.type.ts
+++ b/client/src/app/forms/types/molecular-profile-select/molecular-profile-select.type.ts
@@ -205,6 +205,7 @@ export class CvcMolecularProfileSelectField
         if (this.editorOpen) this.onShowExpClick$.next()
         this.cdr.detectChanges()
         this.field.formControl.setValue(mp.id)
+        this.field.formControl.markAsTouched()
       })
   } // ngAfterViewInit
 

--- a/client/src/app/forms/types/molecular-profile-select/mp-finder/mp-finder.component.html
+++ b/client/src/app/forms/types/molecular-profile-select/mp-finder/mp-finder.component.html
@@ -1,7 +1,7 @@
 <form
   nz-form
-  [nzLayout]="layout"
-  [formGroup]="form">
+  [formGroup]="form"
+  [nzLayout]="finderState.formLayout">
   <formly-form
     [form]="form"
     [fields]="config"

--- a/client/src/app/forms/types/molecular-profile-select/mp-finder/mp-finder.component.ts
+++ b/client/src/app/forms/types/molecular-profile-select/mp-finder/mp-finder.component.ts
@@ -41,10 +41,9 @@ export class MpFinderComponent {
   model: MpFinderModel
   form: UntypedFormGroup
   config: FormlyFieldConfig[]
-  layout: NzFormLayoutType = 'horizontal'
 
   finderState: MpFinderState = {
-    formLayout: this.layout,
+    formLayout: 'horizontal',
     fields: {
       geneId$: new BehaviorSubject<Maybe<number>>(undefined),
       variantId$: new BehaviorSubject<Maybe<number>>(undefined),
@@ -102,17 +101,14 @@ export class MpFinderComponent {
     if (variant) {
       this.model = {
         geneId: undefined,
-        variantId: undefined
+        variantId: undefined,
       }
       this.cvcOnSelect.next(variant.singleVariantMolecularProfile)
       this.cvcOnVariantSelect.next(variant)
     }
-
   }
 
-  getSelectedVariant(
-    variantId: Maybe<number>,
-  ): Maybe<Variant> {
+  getSelectedVariant(variantId: Maybe<number>): Maybe<Variant> {
     if (!variantId) return
     const fragment = {
       id: `Variant:${variantId}`,
@@ -139,11 +135,9 @@ export class MpFinderComponent {
       console.error(err)
     }
     if (!variant) {
-      console.error(
-        `MpFinderForm could not resolve its Variant from the cache`
-      )
+      console.error(`MpFinderForm could not resolve its Variant from the cache`)
       return
     }
-      return variant
+    return variant
   }
 }

--- a/client/src/app/forms/types/origin-select/origin-select.type.ts
+++ b/client/src/app/forms/types/origin-select/origin-select.type.ts
@@ -142,6 +142,7 @@ export class CvcOriginSelectField
           this.props.description = undefined
         } else {
           this.props.description = optionMap.get(origin)
+          this.field.formControl.markAsTouched()
         }
       })
   }

--- a/client/src/app/forms/types/rating/rating.type.html
+++ b/client/src/app/forms/types/rating/rating.type.html
@@ -2,8 +2,11 @@
   type="hidden"
   [formControl]="formControl"
   [formlyAttributes]="field" />
-<nz-rate
-  [ngModel]="formControl.value"
-  [nzCount]="props.count"
-  [nzTooltips]="this.props.hoverText"
-  (ngModelChange)="rating$.next($event)"></nz-rate>
+
+<div class="rate-block">
+  <nz-rate
+    [ngModel]="formControl.value"
+    [nzCount]="props.count"
+    [nzTooltips]="this.props.hoverText"
+    (ngModelChange)="rating$.next($event)"></nz-rate>
+</div>

--- a/client/src/app/forms/types/rating/rating.type.less
+++ b/client/src/app/forms/types/rating/rating.type.less
@@ -1,5 +1,10 @@
 :host {
-  ::ng-deep nz-rate ul {
+  .rate-block {
+    display: inline-block;
+    background-color: #fff;
+    border-radius: 2px;
+    padding: 2px 4px;
+    margin-top: -4px;
   }
   ::ng-deep nz-rate .anticon {
     font-size: 160%;

--- a/client/src/app/forms/types/rating/rating.type.ts
+++ b/client/src/app/forms/types/rating/rating.type.ts
@@ -52,10 +52,7 @@ const RatingMixin = mixin(
   styleUrls: ['./rating.type.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CvcRatingField
-  extends RatingMixin
-  implements AfterViewInit
-{
+export class CvcRatingField extends RatingMixin implements AfterViewInit {
   // LOCAL SOURCE STREAMS
   rating$: BehaviorSubject<Maybe<number>>
 
@@ -81,7 +78,7 @@ export class CvcRatingField
     this.configureBaseField() // mixin fn
     this.configureStateConnections() // local fn
 
-    if(this.formControl.value) {
+    if (this.formControl.value) {
       this.rating$.next(this.formControl.value)
     }
 
@@ -105,6 +102,7 @@ export class CvcRatingField
           this.props.description = undefined
         } else {
           this.props.description = optionText[rating]
+          this.field.formControl.markAsTouched()
         }
       })
   }

--- a/client/src/app/forms/types/significance-select/significance-select.type.ts
+++ b/client/src/app/forms/types/significance-select/significance-select.type.ts
@@ -121,7 +121,7 @@ interface CvcSignificanceSelectFieldProps extends FormlyFieldProps {
   isMultiSelect: boolean
   tooltip?: string
   description?: string
-  extraType?: CvcFormFieldExtraType,
+  extraType?: CvcFormFieldExtraType
   formMode: 'revise' | 'add' | 'clone'
 }
 
@@ -170,7 +170,7 @@ export class CvcSignificanceSelectField
       requireTypePromptFn: (entityName: string) =>
         `Select ${entityName} Type to select its Significance`,
       tooltip: 'Clinical impact of the variant',
-      formMode: 'add'
+      formMode: 'add',
     },
   }
 
@@ -274,6 +274,7 @@ export class CvcSignificanceSelectField
         this.props.description = undefined
         this.props.extraType = 'description'
         this.props.description = optionText[this.state.entityName][et][cs]
+        this.field.formControl.markAsTouched()
       })
   }
 }

--- a/client/src/app/forms/types/type-select/type-select.type.ts
+++ b/client/src/app/forms/types/type-select/type-select.type.ts
@@ -123,6 +123,7 @@ export class CvcEntityTypeSelectField
         } else {
           this.props.description = optionText[v]
           this.props.extraType = 'description'
+          this.field.formControl.markAsTouched()
         }
       })
     if (!this.state) {

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
@@ -1,124 +1,33 @@
 <!-- <pre>Error State: {{ errorState | json }}</pre> -->
-<ng-container [ngSwitch]="formLayout">
-  <div
-    *ngSwitchCase="'horizontal'"
-    class="layout-horizontal">
-    <ng-container
-      *ngTemplateOutlet="horizontalFieldWrapper;
-      context: { $implicit: {
+<nz-form-item
+  [ngClass]="{
+      bordered: props.showBorder,
       disabled: props.disabled,
       error: showError,
       required: props.required,
-      valid: field.formControl!.status === 'VALID' }}"></ng-container>
-  </div>
-  <div
-    *ngSwitchCase="'inline'"
-    class="layout-inline">
-    <ng-container *ngTemplateOutlet="inlineFieldWrapper"></ng-container>
-  </div>
-  <div
-    *ngSwitchCase="'vertical'"
-    class="layout-vertical">
-    <ng-container *ngTemplateOutlet="verticalFieldWrapper"></ng-container>
-  </div>
-</ng-container>
-
-<ng-template
-  #horizontalFieldWrapper
-  let-ngclass>
-  <nz-form-item
-    [nzGutter]="wrapper.layout.item.gutter"
-    class="layout-horizontal"
-    [ngClass]="ngclass">
-    <ng-container *ngIf="props.label && props.hideLabel !== true">
-      <nz-form-label
-        *ngrxLet="wrapper.layout.label as label"
-        [nzRequired]="props.required"
-        [nzFor]="id"
-        [nzNoColon]="true"
-        [nzTooltipTitle]="props.tooltip"
-        [nzSpan]="label.span ? label.span : null">
-        <span
-          nz-typography
-          nzEllipsis
-          [nzContent]="props.label"></span>
-      </nz-form-label>
-    </ng-container>
-    <nz-form-control
-      *ngrxLet="wrapper.layout.control as control"
-      [nzExtra]="wrapper.showExtra && !showError ? descriptionTpl : undefined"
-      [nzValidateStatus]="errorState"
-      [nzErrorTip]="errorTpl"
-      [nzSpan]="props.hideLabel ? 24 : control.span ? control.span : null">
-      <ng-container #fieldComponent></ng-container>
-    </nz-form-control>
-  </nz-form-item>
-</ng-template>
-
-<ng-template
-  #verticalFieldWrapper
-  let-ngclass>
-  <nz-form-item
-    class="layout-vertical"
-    [ngClass]="ngclass">
-    <ng-container *ngIf="props.label && props.hideLabel !== true">
-      <nz-form-label
-        *ngrxLet="wrapper.layout.label as label"
-        [ngClass]="{ disabled: props.disabled, error: showError }"
-        [nzRequired]="props.required"
-        [nzFor]="id"
-        [nzTooltipTitle]="props.tooltip"
-        [nzNoColon]="true">
-        <span
-          class="label"
-          nz-typography
-          nzEllipsis
-          [nzContent]="props.label"></span>
-      </nz-form-label>
-    </ng-container>
-    <nz-form-control
-      *ngrxLet="wrapper.layout.control as control"
-      [nzExtra]="wrapper.showExtra && !showError ? descriptionTpl : undefined"
-      [nzValidateStatus]="errorState"
-      [nzErrorTip]="errorTpl">
-      <ng-container #fieldComponent></ng-container>
-    </nz-form-control>
-  </nz-form-item>
-</ng-template>
-
-<ng-template
-  #inlineFieldWrapper
-  let-ngclass>
-  <nz-form-item
-    class="layout-inline"
-    [ngClass]="ngclass">
-    <ng-container *ngIf="props.label && props.hideLabel !== true">
-      <nz-form-label
-        [nzRequired]="props.required"
-        [nzTooltipTitle]="props.tooltip"
-        [nzFor]="id"
-        [nzNoColon]="true">
-        <span
-          class="label"
-          nz-typography
-          nzEllipsis
-          [nzContent]="props.label"></span>
-      </nz-form-label>
-    </ng-container>
-    <nz-form-control
-      *ngrxLet="wrapper.layout.control as control"
-      [nzExtra]="wrapper.showExtra && !showError ? descriptionTpl : undefined"
-      [nzValidateStatus]="errorState"
-      [nzErrorTip]="errorTpl">
-      <ng-container #fieldComponent></ng-container>
-      <ng-template
-        #errorTpl
-        let-control>
-        <formly-validation-message [field]="field"></formly-validation-message>
-      </ng-template>
-    </nz-form-control>
-  </nz-form-item>
-</ng-template>
+      valid: field.formControl!.status === 'VALID',
+      }">
+  <ng-container *ngIf="props.label && props.hideLabel !== true">
+    <nz-form-label
+      [ngClass]="{ disabled: props.disabled, error: showError }"
+      [nzRequired]="props.required"
+      [nzFor]="id"
+      [nzTooltipTitle]="props.tooltip"
+      [nzNoColon]="true">
+      <span
+        class="label"
+        nz-typography
+        nzEllipsis
+        [nzContent]="props.label"></span>
+    </nz-form-label>
+  </ng-container>
+  <nz-form-control
+    [nzExtra]="wrapper.showExtra && !showError ? descriptionTpl : undefined"
+    [nzValidateStatus]="errorState"
+    [nzErrorTip]="errorTpl">
+    <ng-container #fieldComponent></ng-container>
+  </nz-form-control>
+</nz-form-item>
 
 <!-- SHARED COMPONENT TEMPLATES -->
 <!-- displays the field value description -->

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
@@ -2,30 +2,33 @@
   <div
     *ngSwitchCase="'horizontal'"
     class="layout-horizontal">
-    <ng-container [ngTemplateOutlet]="horizontalFieldWrapper"></ng-container>
+    <ng-container
+      *ngTemplateOutlet="horizontalFieldWrapper;
+      context: { $implicit: {
+      disabled: props.disabled,
+      error: showError,
+      required: props.required,
+      valid: field.formControl!.status === 'VALID' }}"></ng-container>
   </div>
   <div
     *ngSwitchCase="'inline'"
     class="layout-inline">
-    <ng-container [ngTemplateOutlet]="inlineFieldWrapper"></ng-container>
+    <ng-container *ngTemplateOutlet="inlineFieldWrapper"></ng-container>
   </div>
   <div
     *ngSwitchCase="'vertical'"
     class="layout-vertical">
-    <ng-container [ngTemplateOutlet]="verticalFieldWrapper"></ng-container>
+    <ng-container *ngTemplateOutlet="verticalFieldWrapper"></ng-container>
   </div>
 </ng-container>
 
-<ng-template #horizontalFieldWrapper>
+<ng-template
+  #horizontalFieldWrapper
+  let-ngclass>
   <nz-form-item
     [nzGutter]="wrapper.layout.item.gutter"
     class="layout-horizontal"
-    [ngClass]="{
-      disabled: props.disabled,
-      error: showError,
-      required: props.required,
-      valid: field.formControl!.status === 'VALID'
-    }">
+    [ngClass]="ngclass">
     <ng-container *ngIf="props.label && props.hideLabel !== true">
       <nz-form-label
         *ngrxLet="wrapper.layout.label as label"
@@ -51,15 +54,12 @@
   </nz-form-item>
 </ng-template>
 
-<ng-template #verticalFieldWrapper>
+<ng-template
+  #verticalFieldWrapper
+  let-ngclass>
   <nz-form-item
     class="layout-vertical"
-    [ngClass]="{
-      disabled: props.disabled,
-      error: showError,
-      required: props.required,
-      valid: field.formControl!.status === 'VALID'
-    }">
+    [ngClass]="ngclass">
     <ng-container *ngIf="props.label && props.hideLabel !== true">
       <nz-form-label
         *ngrxLet="wrapper.layout.label as label"
@@ -85,14 +85,12 @@
   </nz-form-item>
 </ng-template>
 
-<ng-template #inlineFieldWrapper>
-  <nz-form-item class="layout-inline"
-  [ngClass]="{
-      disabled: props.disabled,
-      error: showError,
-      required: props.required,
-      valid: field.formControl!.status === 'VALID'
-    }">
+<ng-template
+  #inlineFieldWrapper
+  let-ngclass>
+  <nz-form-item
+    class="layout-inline"
+    [ngClass]="ngclass">
     <ng-container *ngIf="props.label && props.hideLabel !== true">
       <nz-form-label
         [nzRequired]="props.required"

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
@@ -1,3 +1,4 @@
+<!-- <pre>Error State: {{ errorState | json }}</pre> -->
 <ng-container [ngSwitch]="formLayout">
   <div
     *ngSwitchCase="'horizontal'"

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.html
@@ -5,7 +5,7 @@
       disabled: props.disabled,
       error: showError,
       required: props.required,
-      valid: field.formControl!.status === 'VALID',
+      valid: field.formControl!.status === 'VALID' && field.formControl!.touched === true
       }">
   <ng-container *ngIf="props.label && props.hideLabel !== true">
     <nz-form-label

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
@@ -5,8 +5,8 @@
 @default-label-color: @blue-7;
 @default-icon-color: @blue-4;
 
-@disabled-border: 1px solid @grey-4;
-@disabled-bg-color: @grey-2;
+@disabled-border: 1px solid @grey-3;
+@disabled-bg-color: @grey-3;
 @disabled-label-color: @text-color-secondary;
 @disabled-icon-color: @grey-5;
 
@@ -19,6 +19,11 @@
 @error-bg-color: @red-1;
 @error-label-color: @red-7;
 @error-icon-color: @red-5;
+
+@valid-border: 1px solid @green-4;
+@valid-bg-color: @green-1;
+@valid-label-color: @green-7;
+@valid-icon-color: @green-5;
 
 @item-border-radius: 4px;
 @item-padding: 4px 8px;
@@ -75,6 +80,22 @@
         }
       }
     }
+    // valid state
+    &.valid {
+      > nz-form-label {
+        ::ng-deep label {
+          &:before {
+            border-color: @valid-label-color;
+          }
+          span.label {
+            color: @valid-label-color;
+          }
+          ::ng-deep span.anticon path {
+            color: @valid-icon-color;
+          }
+        }
+      }
+    }
     &.disabled {
       > nz-form-label {
         ::ng-deep label {
@@ -107,6 +128,10 @@
       background-color: @error-bg-color;
       border: @error-border;
     }
+    &.valid {
+      background-color: @valid-bg-color;
+      border: @valid-border;
+    }
     &.disabled {
       background-color: @disabled-bg-color;
       border: @disabled-border;
@@ -114,133 +139,21 @@
   }
 }
 
-// horizontal layout adjustments
-:host(.layout-horizontal) {
-  > nz-form-item {
-    > nz-form-label {
-    }
+.cvc-form-field-validation,
+.form-field-description {
+  // ensure consistent height of description, validation message line
+  min-height: 16px;
+  line-height: 1.2;
+  // font-size: 96%;
+  margin-top: 4px;
+  .extra-prompt {
+    font-weight: 400;
+  }
+  .extra-description {
+    font-style: oblique;
   }
 }
 
-// inline layout adjustments
-:host(.layout-inline) {
-  > nz-form-item {
-    > nz-form-label {
-    }
-  }
+.cvc-form-field-validation {
+  font-weight: 600;
 }
-
-// :host-context(form[nzlayout='vertical']) {
-//   nz-form-item:first-of-type {
-//     flex-wrap: nowrap;
-//     flex-direction: column;
-//   }
-// }
-
-// :host-context(form[nzlayout='horizontal']) {
-//   nz-form-item:first-of-type {
-//     flex-direction: inherit;
-//     nz-form-label {
-//       text-align: right;
-//       line-height: 28px;
-//       white-space: inherit;
-//       padding: inherit;
-//     }
-//   }
-// }
-
-// :host-context(form[nzlayout='inline']) {
-//   nz-form-item:first-of-type {
-//     flex-direction: inherit;
-//     nz-form-label {
-//       height: 28px;
-//       line-height: 28px;
-//       white-space: inherit;
-//       padding: inherit;
-//     }
-//   }
-// }
-
-// .cvc-field-label() {
-//   label {
-//     // embolden required labels
-//     &.item-required {
-//       font-weight: 500;
-
-//       &:before {
-//         border: 1px solid @required-color;
-//         height: 1em;
-//         content: '';
-//       }
-//     }
-//   }
-
-//   ::ng-deep span.label {
-//     padding-right: 4px;
-//   }
-
-//   &.disabled label ::ng-deep span.label {
-//     color: @text-color-secondary;
-//   }
-
-//   &.error label ::ng-deep span.label {
-//     color: @error-color;
-//   }
-
-//   &.valid label ::ng-deep span.label {
-//     color: @error-color;
-//   }
-// }
-
-// .cvc-form-field-card() {
-//   background-color: white;
-//   border: 1px solid #d9d9d9;
-//   padding: 4px 8px;
-//   border-radius: 6px;
-//   &.disabled {
-//     border: 1px solid #f5f5f5;
-//     background-color: #f5f5f5;
-//   }
-// }
-
-// .cvc-form-field-validation,
-// .form-field-description {
-//   // ensure consistent height of description, validation message line
-//   min-height: 16px;
-//   line-height: 1.2;
-//   // font-size: 96%;
-//   margin-top: 4px;
-//   .extra-prompt {
-//     font-weight: 400;
-//   }
-//   .extra-description {
-//     font-style: oblique;
-//   }
-// }
-
-// .cvc-form-field-validation {
-//   font-weight: 600;
-// }
-
-// nz-form-item.layout-horizontal {
-//   ::ng-deep nz-form-label:first-of-type {
-//     .cvc-field-label();
-//   }
-// }
-
-// nz-form-item.layout-vertical {
-//   .cvc-form-field-card();
-//   ::ng-deep nz-form-label:first-of-type {
-//     .cvc-field-label();
-//   }
-
-//   margin-bottom: @margin-lg;
-// }
-
-// nz-form-item.layout-inline {
-//   ::ng-deep nz-form-label:first-of-type {
-//     .cvc-field-label();
-//     text-align: right;
-//     margin-right: 6px;
-//   }
-// }

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
@@ -1,30 +1,35 @@
 @import 'themes/default.less';
 
-@helpIconSize: 14px;
-@helpIconColor: #cfcfdf;
+// nz-form-item.layout-vertical[_ngcontent-ng-c3802630593]     nz-form-label:first-of-type label.ant-form-item-required:before
 
-.layout-vertical ::ng-deep nz-form-item:first-of-type {
-  flex-wrap: nowrap;
-  flex-direction: column;
-}
-
-.layout-horizontal ::ng-deep nz-form-item:first-of-type {
-  flex-direction: inherit;
-  nz-form-label {
-    text-align: right;
-    line-height: 28px;
-    white-space: inherit;
-    padding: inherit;
+:host-context(form[nzlayout='vertical']) {
+  nz-form-item:first-of-type {
+    flex-wrap: nowrap;
+    flex-direction: column;
   }
 }
 
-.layout-inline ::ng-deep nz-form-item:first-of-type {
-  flex-direction: inherit;
-  nz-form-label {
-    height: 28px;
-    line-height: 28px;
-    white-space: inherit;
-    padding: inherit;
+:host-context(form[nzlayout='horizontal']) {
+  nz-form-item:first-of-type {
+    flex-direction: inherit;
+    nz-form-label {
+      text-align: right;
+      line-height: 28px;
+      white-space: inherit;
+      padding: inherit;
+    }
+  }
+}
+
+:host-context(form[nzlayout='inline']) {
+  nz-form-item:first-of-type {
+    flex-direction: inherit;
+    nz-form-label {
+      height: 28px;
+      line-height: 28px;
+      white-space: inherit;
+      padding: inherit;
+    }
   }
 }
 
@@ -35,11 +40,10 @@
       font-weight: 500;
 
       &:before {
-        border: 1px solid @error-color;
+        border: 1px solid @required-color;
         height: 1em;
         content: '';
       }
-
     }
   }
 

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
@@ -1,118 +1,190 @@
 @import 'themes/default.less';
 
-// nz-form-item.layout-vertical[_ngcontent-ng-c3802630593]     nz-form-label:first-of-type label.ant-form-item-required:before
+@default-border: 1px solid @blue-1;
+@default-bg-color: @blue-1;
+@default-label-color: @blue-10;
 
-:host-context(form[nzlayout='vertical']) {
-  nz-form-item:first-of-type {
-    flex-wrap: nowrap;
-    flex-direction: column;
-  }
-}
+@disabled-border: 1px solid @grey-4;
+@disabled-bg-color: @grey-2;
+@diabled-label-color: @text-color-secondary;
 
-:host-context(form[nzlayout='horizontal']) {
-  nz-form-item:first-of-type {
-    flex-direction: inherit;
-    nz-form-label {
-      text-align: right;
-      line-height: 28px;
-      white-space: inherit;
-      padding: inherit;
+@required-border: 1px solid @blue-4;
+@required-bg-color: @blue-2;
+@required-label-color: @blue-7;
+
+@item-border-radius: 4px;
+@item-padding: 4px 8px;
+@item-border: @default-border;
+@item-background-color: @default-bg-color;
+
+//
+// STATUS COLORS
+//
+//body > app-root > div.app-container > cvc-layout > nz-layout > nz-layout > nz-content > app-assertions > cvc-assertion-add > nz-page-header > nz-page-header-content > div > cvc-assertion-submit > cvc-assertion-submit-form > cvc-form-submission-status-display > nz-spin > div > form > formly-form > formly-field > formly-group > formly-field > cvc-form-layout-wrapper > nz-row > nz-col > formly-group > formly-field:nth-child(2) > cvc-form-card > nz-card > div.ant-card-body > nz-row > nz-col.ant-col.ant-col-16.ng-star-inserted > formly-field > cvc-form-field-wrapper > nz-form-item > nz-form-label > label
+:host {
+  > nz-form-item {
+    border-radius: @item-border-radius;
+    padding: @item-padding;
+    // defaults
+    > nz-form-label {
+      span.label {
+        color: @default-label-color;
+      }
     }
-  }
-}
-
-:host-context(form[nzlayout='inline']) {
-  nz-form-item:first-of-type {
-    flex-direction: inherit;
-    nz-form-label {
-      height: 28px;
-      line-height: 28px;
-      white-space: inherit;
-      padding: inherit;
-    }
-  }
-}
-
-.cvc-field-label() {
-  label {
-    // embolden required labels
-    &.ant-form-item-required {
-      font-weight: 500;
-
-      &:before {
-        border: 1px solid @required-color;
-        height: 1em;
-        content: '';
+    // required status
+    &.required {
+      > nz-form-label {
+        ::ng-deep label {
+          &:before {
+            border: 1px solid @required-label-color;
+            height: 1em;
+            content: '';
+          }
+          span.label {
+            color: @required-label-color;
+            font-weight: 600;
+          }
+        }
       }
     }
   }
+}
 
-  ::ng-deep span.label {
-    padding-right: 4px;
+// vertical layout adjustments
+:host(.layout-vertical) {
+  > nz-form-item {
+    background-color: @default-bg-color;
+    > nz-form-label {
+    }
   }
-
-  &.disabled label ::ng-deep span.label {
-    color: @text-color-secondary;
-  }
-
-  &.error label ::ng-deep span.label {
-    color: @error-color;
-  }
-
-  &.valid label ::ng-deep span.label {
-    color: @error-color;
+}
+// horizontal layout adjustments
+:host(.layout-horizontal) {
+  > nz-form-item {
+    > nz-form-label {
+    }
   }
 }
 
-.cvc-form-field-card() {
-  background-color: white;
-  border: 1px solid #d9d9d9;
-  padding: 4px 8px;
-  border-radius: 6px;
-  &.disabled {
-    border: 1px solid #f5f5f5;
-    background-color: #f5f5f5;
+// inline layout adjustments
+:host(.layout-inline) {
+  > nz-form-item {
+    > nz-form-label {
+    }
   }
 }
 
-.cvc-form-field-validation,
-.form-field-description {
-  // ensure consistent height of description, validation message line
-  min-height: 16px;
-  line-height: 1.2;
-  // font-size: 96%;
-  margin-top: 4px;
-  .extra-prompt {
-    font-weight: 400;
-  }
-  .extra-description {
-    font-style: oblique;
-  }
-}
+// :host-context(form[nzlayout='vertical']) {
+//   nz-form-item:first-of-type {
+//     flex-wrap: nowrap;
+//     flex-direction: column;
+//   }
+// }
 
-.cvc-form-field-validation {
-  font-weight: 600;
-}
+// :host-context(form[nzlayout='horizontal']) {
+//   nz-form-item:first-of-type {
+//     flex-direction: inherit;
+//     nz-form-label {
+//       text-align: right;
+//       line-height: 28px;
+//       white-space: inherit;
+//       padding: inherit;
+//     }
+//   }
+// }
 
-nz-form-item.layout-horizontal {
-  ::ng-deep nz-form-label:first-of-type {
-    .cvc-field-label();
-  }
-}
+// :host-context(form[nzlayout='inline']) {
+//   nz-form-item:first-of-type {
+//     flex-direction: inherit;
+//     nz-form-label {
+//       height: 28px;
+//       line-height: 28px;
+//       white-space: inherit;
+//       padding: inherit;
+//     }
+//   }
+// }
 
-nz-form-item.layout-vertical {
-  .cvc-form-field-card();
-  ::ng-deep nz-form-label:first-of-type {
-    .cvc-field-label();
-  }
+// .cvc-field-label() {
+//   label {
+//     // embolden required labels
+//     &.item-required {
+//       font-weight: 500;
 
-  margin-bottom: @margin-lg;
-}
+//       &:before {
+//         border: 1px solid @required-color;
+//         height: 1em;
+//         content: '';
+//       }
+//     }
+//   }
 
-nz-form-item.layout-inline {
-  ::ng-deep nz-form-label:first-of-type {
-    .cvc-field-label();
-    text-align: right;
-    margin-right: 6px;
-  }
-}
+//   ::ng-deep span.label {
+//     padding-right: 4px;
+//   }
+
+//   &.disabled label ::ng-deep span.label {
+//     color: @text-color-secondary;
+//   }
+
+//   &.error label ::ng-deep span.label {
+//     color: @error-color;
+//   }
+
+//   &.valid label ::ng-deep span.label {
+//     color: @error-color;
+//   }
+// }
+
+// .cvc-form-field-card() {
+//   background-color: white;
+//   border: 1px solid #d9d9d9;
+//   padding: 4px 8px;
+//   border-radius: 6px;
+//   &.disabled {
+//     border: 1px solid #f5f5f5;
+//     background-color: #f5f5f5;
+//   }
+// }
+
+// .cvc-form-field-validation,
+// .form-field-description {
+//   // ensure consistent height of description, validation message line
+//   min-height: 16px;
+//   line-height: 1.2;
+//   // font-size: 96%;
+//   margin-top: 4px;
+//   .extra-prompt {
+//     font-weight: 400;
+//   }
+//   .extra-description {
+//     font-style: oblique;
+//   }
+// }
+
+// .cvc-form-field-validation {
+//   font-weight: 600;
+// }
+
+// nz-form-item.layout-horizontal {
+//   ::ng-deep nz-form-label:first-of-type {
+//     .cvc-field-label();
+//   }
+// }
+
+// nz-form-item.layout-vertical {
+//   .cvc-form-field-card();
+//   ::ng-deep nz-form-label:first-of-type {
+//     .cvc-field-label();
+//   }
+
+//   margin-bottom: @margin-lg;
+// }
+
+// nz-form-item.layout-inline {
+//   ::ng-deep nz-form-label:first-of-type {
+//     .cvc-field-label();
+//     text-align: right;
+//     margin-right: 6px;
+//   }
+// }

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
@@ -9,8 +9,12 @@
 @diabled-label-color: @text-color-secondary;
 
 @required-border: 1px solid @blue-4;
-@required-bg-color: @blue-2;
+@required-bg-color: @blue-1;
 @required-label-color: @blue-7;
+
+@error-border: 1px solid @red-4;
+@error-bg-color: @red-1;
+@error-label-color: @red-7;
 
 @item-border-radius: 4px;
 @item-padding: 4px 8px;
@@ -31,7 +35,7 @@
         color: @default-label-color;
       }
     }
-    // required status
+    // required state
     &.required {
       > nz-form-label {
         ::ng-deep label {
@@ -47,14 +51,33 @@
         }
       }
     }
+    &.error {
+      > nz-form-label {
+        ::ng-deep label {
+          &:before {
+            border-color: @error-label-color;
+          }
+          span.label {
+            color: @error-label-color;
+          }
+        }
+      }
+    }
   }
 }
 
-// vertical layout adjustments
+// vertical layout applies a bg color & border
 :host(.layout-vertical) {
   > nz-form-item {
     background-color: @default-bg-color;
-    > nz-form-label {
+    border: @default-border;
+    &.required {
+      background-color: @required-bg-color;
+      border: @required-border;
+    }
+    &.error {
+      background-color: @error-bg-color;
+      border: @error-border;
     }
   }
 }

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.less
@@ -2,37 +2,42 @@
 
 @default-border: 1px solid @blue-1;
 @default-bg-color: @blue-1;
-@default-label-color: @blue-10;
+@default-label-color: @blue-7;
+@default-icon-color: @blue-4;
 
 @disabled-border: 1px solid @grey-4;
 @disabled-bg-color: @grey-2;
-@diabled-label-color: @text-color-secondary;
+@disabled-label-color: @text-color-secondary;
+@disabled-icon-color: @grey-5;
 
 @required-border: 1px solid @blue-4;
 @required-bg-color: @blue-1;
 @required-label-color: @blue-7;
+@required-icon-color: @blue-5;
 
 @error-border: 1px solid @red-4;
 @error-bg-color: @red-1;
 @error-label-color: @red-7;
+@error-icon-color: @red-5;
 
 @item-border-radius: 4px;
 @item-padding: 4px 8px;
 @item-border: @default-border;
 @item-background-color: @default-bg-color;
 
-//
-// STATUS COLORS
-//
-//body > app-root > div.app-container > cvc-layout > nz-layout > nz-layout > nz-content > app-assertions > cvc-assertion-add > nz-page-header > nz-page-header-content > div > cvc-assertion-submit > cvc-assertion-submit-form > cvc-form-submission-status-display > nz-spin > div > form > formly-form > formly-field > formly-group > formly-field > cvc-form-layout-wrapper > nz-row > nz-col > formly-group > formly-field:nth-child(2) > cvc-form-card > nz-card > div.ant-card-body > nz-row > nz-col.ant-col.ant-col-16.ng-star-inserted > formly-field > cvc-form-field-wrapper > nz-form-item > nz-form-label > label
 :host {
   > nz-form-item {
     border-radius: @item-border-radius;
-    padding: @item-padding;
     // defaults
     > nz-form-label {
       span.label {
         color: @default-label-color;
+      }
+      ::ng-deep span.anticon {
+        margin-left: 0.25em;
+        path {
+          color: @default-icon-color;
+        }
       }
     }
     // required state
@@ -48,9 +53,13 @@
             color: @required-label-color;
             font-weight: 600;
           }
+          ::ng-deep span.anticon path {
+            color: @required-icon-color;
+          }
         }
       }
     }
+    // error state
     &.error {
       > nz-form-label {
         ::ng-deep label {
@@ -60,17 +69,36 @@
           span.label {
             color: @error-label-color;
           }
+          ::ng-deep span.anticon path {
+            color: @error-icon-color;
+          }
+        }
+      }
+    }
+    &.disabled {
+      > nz-form-label {
+        ::ng-deep label {
+          &:before {
+            border-color: @disabled-label-color;
+          }
+          span.label {
+            color: @disabled-label-color;
+          }
+          ::ng-deep span.anticon path {
+            color: @disabled-icon-color;
+          }
         }
       }
     }
   }
 }
 
-// vertical layout applies a bg color & border
+// vertical layout fields displayed in a block w/ bg color & border styles
 :host(.layout-vertical) {
   > nz-form-item {
     background-color: @default-bg-color;
     border: @default-border;
+    padding: @item-padding;
     &.required {
       background-color: @required-bg-color;
       border: @required-border;
@@ -79,8 +107,13 @@
       background-color: @error-bg-color;
       border: @error-border;
     }
+    &.disabled {
+      background-color: @disabled-bg-color;
+      border: @disabled-border;
+    }
   }
 }
+
 // horizontal layout adjustments
 :host(.layout-horizontal) {
   > nz-form-item {

--- a/client/src/app/forms/wrappers/form-field/form-field.wrapper.ts
+++ b/client/src/app/forms/wrappers/form-field/form-field.wrapper.ts
@@ -13,24 +13,6 @@ import { NzAlign, NzJustify } from 'ng-zorro-antd/grid'
 export type CvcFormFieldExtraType = 'description' | 'prompt'
 
 export interface CvcFormFieldWrapperLayout {
-  layout: {
-    item: {
-      gutter:
-        | string
-        | number
-        | IndexableObject
-        | [number, number]
-        | [IndexableObject, IndexableObject]
-      justify?: NzJustify
-      align?: NzAlign
-    }
-    label: {
-      span: number
-    }
-    control: {
-      span: number
-    }
-  }
   showExtra: boolean
 }
 
@@ -39,6 +21,11 @@ export interface CvcFormFieldWrapperLayout {
   templateUrl: './form-field.wrapper.html',
   styleUrls: ['./form-field.wrapper.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class.layout-horizontal]': 'formLayout === "horizontal"',
+    '[class.layout-vertical]': 'formLayout === "vertical"',
+    '[class.layout-inline]': 'formLayout === "inline"',
+  },
 })
 export class CvcFormFieldWrapper
   extends FieldWrapper<FormlyFieldConfig>
@@ -59,23 +46,6 @@ export class CvcFormFieldWrapper
     // merge local wrapper config with field config specified properties
     try {
       this.wrapper = {
-        layout: {
-          // layout only relevant for horizontal nzLayout type
-          item: {
-            gutter: [6, 12],
-            ...(this.props.layout?.item ? this.props.layout.item : undefined),
-          },
-          label: {
-            span: 4,
-            ...(this.props.layout?.label ? this.props.layout.label : undefined),
-          },
-          control: {
-            span: 20,
-            ...(this.props.layout?.control
-              ? this.props.layout?.control
-              : undefined),
-          },
-        },
         showExtra:
           this.props.layout?.showExtra !== undefined
             ? this.props.layout.showExtra

--- a/client/src/app/layout/layout-routing.module.ts
+++ b/client/src/app/layout/layout-routing.module.ts
@@ -196,7 +196,7 @@ const routes: Routes = [
             (m) => m.TestPagesModule
           ),
         data: {
-          breadcrumb: 'Forms2',
+          breadcrumb: 'Forms Dev',
         },
       },
     ],

--- a/client/src/themes/default.less
+++ b/client/src/themes/default.less
@@ -10,7 +10,7 @@
  * override colors from the zorro's default.less:
  */
 
-@import "ng-zorro-antd/style/color/colors.less";
+@import 'ng-zorro-antd/style/color/colors.less';
 
 /*
  * PRIMARY COLOR PALETTE
@@ -29,6 +29,11 @@
 @normal-color: #d9d9d9;
 @white: #fff;
 @black: #000;
+
+// additional form field status colors
+@required-color: @blue-6;
+@required-border-color: @blue-3;
+@required-background-color: @blue-1;
 
 // Color used by default to control hover and active backgrounds and for
 // alert info backgrounds.
@@ -52,7 +57,7 @@
 @primary-10: color(~`colorPalette("@{primary-color}", 10) `); // unused
 
 // PUT CUSTOM GLOBALS IN global-variables.less
-@import "themes/global-variables.less";
+@import 'themes/global-variables.less';
 
 .typeahead-match {
   font-weight: bold;

--- a/client/src/themes/default.less
+++ b/client/src/themes/default.less
@@ -56,6 +56,21 @@
 @primary-9: color(~`colorPalette("@{primary-color}", 9) `); // unused
 @primary-10: color(~`colorPalette("@{primary-color}", 10) `); // unused
 
+// neutral color palette, not included w/ ant-design's defaults for some reason
+@grey-1: #ffffff;
+@grey-2: #fafafa;
+@grey-3: #f5f5f5;
+@grey-4: #f0f0f0;
+@grey-5: #d9d9d9;
+@grey-6: #bfbfbf;
+@grey-7: #8c8c8c;
+@grey-8: #595959;
+@grey-9: #434343;
+@grey-10: #262626;
+@grey-11: #1f1f1f;
+@grey-12: #141414;
+@greay-13: #000000;
+
 // PUT CUSTOM GLOBALS IN global-variables.less
 @import 'themes/global-variables.less';
 

--- a/client/src/themes/global-variables.less
+++ b/client/src/themes/global-variables.less
@@ -16,10 +16,6 @@
 @white: #fff;
 @black: #000;
 
-// Status Colors
-@suggested-color: #fadb14;
-@error-color: #ff4d4f; // (red-5)
-
 // Layout
 @layout-body-background: #f0f2f5;
 @layout-header-background: #001529;


### PR DESCRIPTION
Currently the status of a form field (required, disabled, error, valid) can be difficult to discern. This PR adjusts the styling on form fields in order to better visually differentiate their status for the user.

**Initially fields will either be default, required, and/or disabled**
<img width="666" alt="Screenshot 2023-10-30 at 1 32 12 PM" src="https://github.com/griffithlab/civic-v2/assets/132909/477ebebc-2fbd-4457-afda-9cbe29d6247b">

**As the form is populated, valid and error statuses will be displayed**
<img width="738" alt="Screenshot 2023-10-31 at 9 10 20 AM" src="https://github.com/griffithlab/civic-v2/assets/132909/8ec6cf93-c45e-4f8b-8b57-85e80a11ecfc">
