### PR TITLE
Fix variable name typo in therapy typeahead

### DIFF
--- a/server/app/graphql/types/queries/typeahead_queries.rb
+++ b/server/app/graphql/types/queries/typeahead_queries.rb
@@ -94,7 +94,7 @@ module Types::Queries
 
             return results + secondary_results + tertiary_results
           else
-            return results + secondar_results
+            return results + secondary_results
           end
         else
           return results

--- a/server/app/models/therapy.rb
+++ b/server/app/models/therapy.rb
@@ -8,7 +8,7 @@ class Therapy < ApplicationRecord
   has_and_belongs_to_many :assertions
   has_and_belongs_to_many :therapy_aliases
 
-  validates :ncit_id, uniqueness: true 
+  validates :ncit_id, uniqueness: true, allow_nil: true
 
   def self.url_for(ncit_id:)
     if ncit_id.nil?


### PR DESCRIPTION
Closes #943 