### PR TITLE
client apollo codegen service components have updates

### DIFF
--- a/client/src/app/generated/civic.apollo-helpers.ts
+++ b/client/src/app/generated/civic.apollo-helpers.ts
@@ -766,6 +766,16 @@ export type EvidenceItemsByStatusFieldPolicy = {
 	rejectedCount?: FieldPolicy<any> | FieldReadFunction<any>,
 	submittedCount?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type EvidenceItemsByTypeKeySpecifier = ('diagnosticCount' | 'functionalCount' | 'molecularProfileId' | 'oncogenicCount' | 'predictiveCount' | 'predisposingCount' | 'prognosticCount' | EvidenceItemsByTypeKeySpecifier)[];
+export type EvidenceItemsByTypeFieldPolicy = {
+	diagnosticCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	functionalCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	molecularProfileId?: FieldPolicy<any> | FieldReadFunction<any>,
+	oncogenicCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	predictiveCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	predisposingCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	prognosticCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type FdaCodeKeySpecifier = ('code' | 'description' | FdaCodeKeySpecifier)[];
 export type FdaCodeFieldPolicy = {
 	code?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1032,7 +1042,7 @@ export type ModeratedObjectFieldFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	link?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type MolecularProfileKeySpecifier = ('assertions' | 'comments' | 'complexMolecularProfileCreationActivity' | 'complexMolecularProfileDeprecationActivity' | 'deprecated' | 'deprecatedVariants' | 'deprecationReason' | 'description' | 'events' | 'evidenceCountsByStatus' | 'evidenceItems' | 'flagged' | 'flags' | 'id' | 'isComplex' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'molecularProfileAliases' | 'molecularProfileScore' | 'name' | 'parsedName' | 'rawName' | 'revisions' | 'sources' | 'variantCreationActivity' | 'variantDeprecationActivity' | 'variants' | MolecularProfileKeySpecifier)[];
+export type MolecularProfileKeySpecifier = ('assertions' | 'comments' | 'complexMolecularProfileCreationActivity' | 'complexMolecularProfileDeprecationActivity' | 'deprecated' | 'deprecatedVariants' | 'deprecationReason' | 'description' | 'events' | 'evidenceCountsByStatus' | 'evidenceCountsByType' | 'evidenceItems' | 'flagged' | 'flags' | 'id' | 'isComplex' | 'isMultiVariant' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'molecularProfileAliases' | 'molecularProfileScore' | 'name' | 'parsedName' | 'rawName' | 'revisions' | 'sources' | 'variantCreationActivity' | 'variantDeprecationActivity' | 'variants' | MolecularProfileKeySpecifier)[];
 export type MolecularProfileFieldPolicy = {
 	assertions?: FieldPolicy<any> | FieldReadFunction<any>,
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1044,11 +1054,13 @@ export type MolecularProfileFieldPolicy = {
 	description?: FieldPolicy<any> | FieldReadFunction<any>,
 	events?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceCountsByStatus?: FieldPolicy<any> | FieldReadFunction<any>,
+	evidenceCountsByType?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItems?: FieldPolicy<any> | FieldReadFunction<any>,
 	flagged?: FieldPolicy<any> | FieldReadFunction<any>,
 	flags?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	isComplex?: FieldPolicy<any> | FieldReadFunction<any>,
+	isMultiVariant?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastAcceptedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastCommentEvent?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastSubmittedRevisionEvent?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2325,6 +2337,10 @@ export type StrictTypedTypePolicies = {
 	EvidenceItemsByStatus?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | EvidenceItemsByStatusKeySpecifier | (() => undefined | EvidenceItemsByStatusKeySpecifier),
 		fields?: EvidenceItemsByStatusFieldPolicy,
+	},
+	EvidenceItemsByType?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | EvidenceItemsByTypeKeySpecifier | (() => undefined | EvidenceItemsByTypeKeySpecifier),
+		fields?: EvidenceItemsByTypeFieldPolicy,
 	},
 	FdaCode?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | FdaCodeKeySpecifier | (() => undefined | FdaCodeKeySpecifier),

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -1687,6 +1687,17 @@ export type EvidenceItemsByStatus = {
   submittedCount: Scalars['Int'];
 };
 
+export type EvidenceItemsByType = {
+  __typename: 'EvidenceItemsByType';
+  diagnosticCount: Scalars['Int'];
+  functionalCount: Scalars['Int'];
+  molecularProfileId: Scalars['Int'];
+  oncogenicCount: Scalars['Int'];
+  predictiveCount: Scalars['Int'];
+  predisposingCount: Scalars['Int'];
+  prognosticCount: Scalars['Int'];
+};
+
 export enum EvidenceLevel {
   A = 'A',
   B = 'B',
@@ -2431,6 +2442,7 @@ export type MolecularProfile = Commentable & EventOriginObject & EventSubject & 
   /** List and filter events for an object */
   events: EventConnection;
   evidenceCountsByStatus: EvidenceItemsByStatus;
+  evidenceCountsByType: EvidenceItemsByType;
   /** The collection of evidence items associated with this molecular profile. */
   evidenceItems: EvidenceItemConnection;
   flagged: Scalars['Boolean'];
@@ -2438,6 +2450,7 @@ export type MolecularProfile = Commentable & EventOriginObject & EventSubject & 
   flags: FlagConnection;
   id: Scalars['Int'];
   isComplex: Scalars['Boolean'];
+  isMultiVariant: Scalars['Boolean'];
   lastAcceptedRevisionEvent?: Maybe<Event>;
   lastCommentEvent?: Maybe<Event>;
   lastSubmittedRevisionEvent?: Maybe<Event>;
@@ -3771,6 +3784,8 @@ export type QueryGeneTypeaheadArgs = {
 export type QueryGenesArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  entrezIds?: InputMaybe<Array<Scalars['Int']>>;
+  entrezSymbols?: InputMaybe<Array<Scalars['String']>>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };


### PR DESCRIPTION
After updating to the latest main branch after big merge, when I export a current schema with `rake graphql:schema:dump`, it produces a schema that causes the client apollo services to have several differences with the staging deploy.

The client build was displaying forms w/o any errors before and currently appears to be working fine with these updates. It could be that a client-side rebuild got lost in the merges, or my db got out of sync somewhere.