### PR TITLE
entity-select fields now display proper status on init

### DIFF
--- a/client/src/app/forms/config/assertion-submit/assertion-submit.form.config.ts
+++ b/client/src/app/forms/config/assertion-submit/assertion-submit.form.config.ts
@@ -18,7 +18,7 @@ const formFieldConfig: FormlyFieldConfig[] = [
   {
     wrappers: ['form-layout'],
     props: <CvcFormLayoutWrapperProps>{
-      showDevPanel: true,
+      showDevPanel: false,
     },
     fieldGroup: [
       {

--- a/client/src/app/forms/mixins/entity-select-field.mixin.ts
+++ b/client/src/app/forms/mixins/entity-select-field.mixin.ts
@@ -318,7 +318,6 @@ export function EntitySelectField<
               newValue = options[0]!.id
             }
             this.formControl.setValue(newValue)
-            this.formControl.markAsTouched()
             // if onPopulate$ is called from a quick-add form in the select dropdown,
             // this will close it and cause nz-select to display the new tag
             this.selectOpen$.next(false)


### PR DESCRIPTION
This PR fixes entity-select's initial status, which was showing as invalid on Submit forms on initial display. Now it shows the default untouched status.