### PR TITLE
fix unknown icon error in event-feed

### DIFF
--- a/client/src/app/core/pipes/icon-name-for-event-action-pipe.ts
+++ b/client/src/app/core/pipes/icon-name-for-event-action-pipe.ts
@@ -50,7 +50,9 @@ export class IconNameForEventActionPipe implements PipeTransform {
         return 'civic-variant'
       case EventAction.DeprecatedMolecularProfile:
         return 'civic-molecularprofile'
-      case (EventAction.VariantCreated):
+      case EventAction.ComplexMolecularProfileCreated:
+        return 'civic-molecularprofile'
+      case EventAction.VariantCreated:
         return 'civic-variant'
       default:
         return a


### PR DESCRIPTION
Adds a case to `iconNameForEventFeed` pipe to handle new `ComplexMolecularProfileCreated` event type.