### PR TITLE
fixes form clone regression where direction & significance aren't set on form init

### DIFF
--- a/client/src/app/forms/config/assertion-revise/assertion-revise.form.config.ts
+++ b/client/src/app/forms/config/assertion-revise/assertion-revise.form.config.ts
@@ -76,7 +76,6 @@ const formFieldConfig: FormlyFieldConfig[] = [
                 type: 'direction-select',
                 props: {
                   required: true,
-                  formMode: 'revise',
                 },
               },
               {
@@ -84,7 +83,6 @@ const formFieldConfig: FormlyFieldConfig[] = [
                 type: 'significance-select',
                 props: {
                   required: true,
-                  formMode: 'revise',
                 },
               },
               {

--- a/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
+++ b/client/src/app/forms/config/evidence-revise/evidence-revise.form.config.ts
@@ -3,16 +3,12 @@ import { CvcDirectionSelectFieldOptions } from '@app/forms/types/direction-selec
 import { CvcDiseaseSelectFieldOptions } from '@app/forms/types/disease-select/disease-select.type'
 import { CvcInteractionSelectFieldOptions } from '@app/forms/types/interaction-select/interaction-select.type'
 import { CvcLevelSelectFieldOptions } from '@app/forms/types/level-select/level-select.type'
-import { CvcMolecularProfileSelectFieldConfig } from '@app/forms/types/molecular-profile-select/molecular-profile-select.type'
 import { CvcOrgSubmitButtonFieldConfig } from '@app/forms/types/org-submit-button/org-submit-button.type'
 import { CvcOriginSelectFieldOptions } from '@app/forms/types/origin-select/origin-select.type'
 import { CvcPhenotypeSelectFieldOptions } from '@app/forms/types/phenotype-select/phenotype-select.type'
 import { CvcRatingFieldOptions } from '@app/forms/types/rating/rating.type'
 import { CvcSignificanceSelectFieldOptions } from '@app/forms/types/significance-select/significance-select.type'
-import {
-  CvcSourceSelectFieldConfig,
-  CvcSourceSelectFieldOptions,
-} from '@app/forms/types/source-select/source-select.type'
+import { CvcSourceSelectFieldConfig } from '@app/forms/types/source-select/source-select.type'
 import { CvcTherapySelectFieldOptions } from '@app/forms/types/therapy-select/therapy-select.type'
 import { CvcEntityTypeSelectFieldConfig } from '@app/forms/types/type-select/type-select.type'
 import assignFieldConfigDefaultValues from '@app/forms/utilities/assign-field-default-values'
@@ -22,7 +18,6 @@ import { CvcFormRowWrapperProps } from '@app/forms/wrappers/form-row/form-row.wr
 import { FormlyFieldConfig } from '@ngx-formly/core'
 
 const formFieldConfig: FormlyFieldConfig[] = [
-  // form-layout wrapper embeds the form in an nz-grid row, allowing the form to be placed adjacent to other controls or page elements. Currently, it provides a toggleable dev panel. Could be used to add a preview of the entity being added/edited, or more extensive feedback like lists of similar entities, etc.
   {
     wrappers: ['form-layout'],
     props: <CvcFormLayoutWrapperProps>{
@@ -87,7 +82,6 @@ const formFieldConfig: FormlyFieldConfig[] = [
                 type: 'direction-select',
                 props: {
                   required: true,
-                  formMode: 'revise',
                 },
               },
               <CvcSignificanceSelectFieldOptions>{
@@ -95,7 +89,6 @@ const formFieldConfig: FormlyFieldConfig[] = [
                 type: 'significance-select',
                 props: {
                   required: true,
-                  formMode: 'revise',
                 },
               },
               <CvcDiseaseSelectFieldOptions>{

--- a/client/src/app/forms/config/evidence-submit/evidence-submit.form.ts
+++ b/client/src/app/forms/config/evidence-submit/evidence-submit.form.ts
@@ -65,8 +65,14 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
   selectedSourceId?: number
   selectedMpId?: number
 
-  countQueryRef?: QueryRef<ExistingEvidenceCountQuery, ExistingEvidenceCountQueryVariables>
-  curatedQueryRef?: QueryRef<FullyCuratedSourceQuery, FullyCuratedSourceQueryVariables>
+  countQueryRef?: QueryRef<
+    ExistingEvidenceCountQuery,
+    ExistingEvidenceCountQueryVariables
+  >
+  curatedQueryRef?: QueryRef<
+    FullyCuratedSourceQuery,
+    FullyCuratedSourceQueryVariables
+  >
   existingEvidenceId?: number
   routeSub: Subscription
 
@@ -90,30 +96,19 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
     this.routeSub = this.route.queryParams.subscribe((params) => {
       if (params.existingEvidenceId) {
         this.existingEvidenceId = +params.existingEvidenceId
-
-        let direction = this.getFieldConfig('direction-select')
-        if (direction) {
-          direction.props!.formMode = 'clone'
-        }
-        let significance = this.getFieldConfig('significance-select')
-        if (significance) {
-          significance.props!.formMode = 'clone'
-        }
+        this.state.formMode = 'clone'
       } else {
         this.model = { fields: {} }
       }
     })
   }
 
-  getFieldConfig(fieldKey: string) {
-    return this.fields?.[0].fieldGroup
-      ?.find((f) => f.key === 'fields')
-      ?.fieldGroup?.find((f) => f.type === fieldKey)
-  }
-
   ngOnInit(): void {
-    this.countQueryRef = this.existingEvidenceGQL.watch({molecularProfileId: 0, sourceId: 0})
-    this.curatedQueryRef = this.fullyCuratedSourceGQL.watch({sourceId: 0})
+    this.countQueryRef = this.existingEvidenceGQL.watch({
+      molecularProfileId: 0,
+      sourceId: 0,
+    })
+    this.curatedQueryRef = this.fullyCuratedSourceGQL.watch({ sourceId: 0 })
 
     this.existingEvidenceCount$ = this.countQueryRef?.valueChanges.pipe(
       map((c) => c.data?.evidenceItems?.totalCount),
@@ -121,8 +116,8 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
       untilDestroyed(this)
     )
     this.fullyCuratedSource$ = this.curatedQueryRef?.valueChanges.pipe(
-        map(c => c.data?.source?.fullyCurated),
-        untilDestroyed(this)
+      map((c) => c.data?.source?.fullyCurated),
+      untilDestroyed(this)
     )
   }
 
@@ -188,7 +183,7 @@ export class CvcEvidenceSubmitForm implements OnDestroy, AfterViewInit, OnInit {
     }
 
     if (newModel.fields.sourceId) {
-      if(newModel.fields.sourceId != this.selectedSourceId) {
+      if (newModel.fields.sourceId != this.selectedSourceId) {
         this.selectedSourceId = newModel.fields.sourceId
         this.curatedQueryRef?.refetch({ sourceId: this.selectedSourceId })
       }

--- a/client/src/app/forms/states/base.state.ts
+++ b/client/src/app/forms/states/base.state.ts
@@ -1,6 +1,4 @@
-import {
-  formatEvidenceEnum,
-} from '@app/core/utilities/enum-formatters/format-evidence-enum'
+import { formatEvidenceEnum } from '@app/core/utilities/enum-formatters/format-evidence-enum'
 import {
   AssertionSignificance,
   AssertionDirection,
@@ -21,6 +19,8 @@ export type EntityType = EvidenceType | AssertionType
 export type EntitySignificance = EvidenceSignificance | AssertionSignificance
 
 export type EntityDirection = EvidenceDirection | AssertionDirection
+
+export type CvcFormMode = 'revise' | 'add' | 'clone'
 
 export type ValidEntity = {
   entityType: EntityType
@@ -52,6 +52,7 @@ export type NoStateFormOptions = { formState: { formLayout: NzFormLayoutType } }
 export interface IEntityState {
   formReady$: Subject<boolean>
   formLayout: NzFormLayoutType
+  formMode: CvcFormMode
   validStates: Map<EntityType, ValidEntity>
   getTypeOptions: () => EntityType[]
   getSignificanceOptions: (et: EntityType) => EntitySignificance[]
@@ -77,6 +78,7 @@ export interface IEntityState {
 class BaseState implements IEntityState {
   formReady$ = new Subject<boolean>()
   formLayout: NzFormLayoutType = 'vertical'
+  formMode: CvcFormMode = 'add'
   fields: EntityFieldSubjectMap
   enums: EntityFieldSubjectMap
   options: EntityFieldSubjectMap

--- a/client/src/app/forms/types/direction-select/direction-select.type.ts
+++ b/client/src/app/forms/types/direction-select/direction-select.type.ts
@@ -116,7 +116,6 @@ export interface CvcDirectionSelectFieldProps extends FormlyFieldProps {
   requireTypePromptFn: (entityName: string) => string
   tooltip?: string
   extraType?: CvcFormFieldExtraType
-  formMode: 'revise' | 'add' | 'clone'
 }
 
 export interface CvcDirectionSelectFieldConfig
@@ -164,7 +163,6 @@ export class CvcDirectionSelectField
         `Select ${entityType ? entityType + ' ' : ''}${entityName} Direction`,
       requireTypePromptFn: (entityName: string) =>
         `Select ${entityName} Type to select its Direction`,
-      formMode: 'add',
     },
   }
 
@@ -246,7 +244,10 @@ export class CvcDirectionSelectField
     this.onEntityType$ = this.state.fields[etName]
     // if new entityType received, reset field, then based on entityType value, toggle disabled state, update placeholder
     this.onEntityType$
-      .pipe(skip(this.props.formMode === 'add' ? 0 : 1), untilDestroyed(this))
+      .pipe(
+        skip(this.options.formState.formMode === 'add' ? 0 : 1),
+        untilDestroyed(this)
+      )
       .subscribe((et: Maybe<CvcInputEnum>) => {
         if (!et) {
           this.props.disabled = true

--- a/client/src/app/forms/types/significance-select/significance-select.type.ts
+++ b/client/src/app/forms/types/significance-select/significance-select.type.ts
@@ -122,7 +122,6 @@ interface CvcSignificanceSelectFieldProps extends FormlyFieldProps {
   tooltip?: string
   description?: string
   extraType?: CvcFormFieldExtraType
-  formMode: 'revise' | 'add' | 'clone'
 }
 
 export interface CvcSignificanceSelectFieldConfig
@@ -170,7 +169,6 @@ export class CvcSignificanceSelectField
       requireTypePromptFn: (entityName: string) =>
         `Select ${entityName} Type to select its Significance`,
       tooltip: 'Clinical impact of the variant',
-      formMode: 'add',
     },
   }
 
@@ -247,7 +245,10 @@ export class CvcSignificanceSelectField
     this.onTypeSelect$ = this.state.fields[etName]
     // if new entityType received, reset field, then based on entityType value, toggle disabled state, update placeholder
     this.onTypeSelect$
-      .pipe(skip(this.props.formMode === 'add' ? 0 : 1), untilDestroyed(this))
+      .pipe(
+        skip(this.options.formState.formMode === 'add' ? 0 : 1),
+        untilDestroyed(this)
+      )
       .subscribe((et: Maybe<CvcInputEnum>) => {
         if (!et) {
           this.props.disabled = true


### PR DESCRIPTION
Recent updates to the forms broke the method that clone-mode forms were using to set the mode in direction and significance fields. The `form.fields` array isn't initialized in the constructor when the form control attempts to set `props.formMode` on direction & significance. Therefore those fields are set to the default 'add' mode by the time they are instantiated.

To fix this, I moved the formMode attribute to `base.state`, a base class shared by the submit/revise form states, and is available to all fields in `options.formState`. Instead of getting the formMode for control logic from their field props, now they get it from the formState.