### PR TITLE
hotfix for tag-overflow's matchingText embolden feature regression

### DIFF
--- a/client/src/app/components/shared/plain-tag-overflow/plain-tag-overflow.component.html
+++ b/client/src/app/components/shared/plain-tag-overflow/plain-tag-overflow.component.html
@@ -2,7 +2,8 @@
   <span
     *ngFor="let tag of displayedTags"
     [ngClass]="{
-      'matched-tag': matchingText && tag.toLowerCase().includes(matchingText)
+      'matched-tag':
+        matchingText && tag.toLowerCase().includes(matchingText.toLowerCase())
     }">
     <nz-tag>{{ tag }}</nz-tag>
   </span>

--- a/client/src/app/components/shared/tag-overflow/tag-overflow.component.html
+++ b/client/src/app/components/shared/tag-overflow/tag-overflow.component.html
@@ -3,7 +3,8 @@
     *ngFor="let tag of displayedTags"
     [ngClass]="{
       'matched-tag':
-        matchingText && tag.name.toLowerCase().includes(matchingText)
+        matchingText &&
+        tag.name.toLowerCase().includes(matchingText.toLowerCase())
     }">
     <ng-container
       [ngTemplateOutlet]="tagTemplate"


### PR DESCRIPTION
The tag-overflow components' filter text embolden feature is working for me now, however I'm not quite sure why. I'm checking this in so y'all can see if this fixes the issue for you. I traced the filter text and logic, adding variable debug output in child templates, and at some point the proper tags were showing up emboldened again. After I reverted the templates to remove the debug output, and reverted any other updates I made to components to figure out which modification fixed the issue, tags matching col filter text were still being emboldened. 

I did keep an update that makes the 'matching-tag' ngClass expression case-insensitive, which could cause confusing results if users are expecting 'C' to match all 'c' in tag labels. That's the entirety of the PR. If I revert this change locally, the filter embolden feature still works... so, not sure what's going on.

Fixes #971 