### PR TITLE
Support case insensitive gene symbols for entrez links

### DIFF
--- a/server/app/models/frontend_router.rb
+++ b/server/app/models/frontend_router.rb
@@ -8,11 +8,13 @@ class FrontendRouter
   end
 
   def url
-    (entity, query_field) = query_info
+    (entity, query_field, transform) = query_info
     if [entity, query_field, id].any? { |i| i.blank? }
       nil
     else
-      obj = entity.find_by!(query_field => id)
+      #identity function if none defined
+      transform ||= -> {_1}
+      obj = entity.find_by!(query_field => transform.call(id))
       adaptor = "LinkAdaptors::#{obj.class}".constantize.new(obj)
       "#{domain}#{adaptor.base_path}"
     end
@@ -32,7 +34,7 @@ class FrontendRouter
     when /entrez_id/
       [ Gene, :entrez_id, ]
     when /entrez_name/
-      [ Gene, :name , ]
+      [ Gene, :name , -> { _1.upcase }]
     when /variant_groups?/
       [ VariantGroup, :id, ]
     when /revisions?/


### PR DESCRIPTION
Allow the `FrontendRouter` to pass along a lambda that will be used to transform the incoming identifier. Default to no-op if not provided.

Always upcase incoming gene symbols.

closes #993 