### PR TITLE
Enqueue opencravat task after allele registry task

### DIFF
--- a/server/app/jobs/set_allele_registry_id_single_variant.rb
+++ b/server/app/jobs/set_allele_registry_id_single_variant.rb
@@ -21,5 +21,6 @@ class SetAlleleRegistryIdSingleVariant < AlleleRegistryIds
         delete_allele_registry_link(old_allele_registry_id)
       end
     end
+    GenerateOpenCravatLink.perform_later(self)
   end
 end

--- a/server/app/models/variant.rb
+++ b/server/app/models/variant.rb
@@ -100,7 +100,6 @@ class Variant < ApplicationRecord
 
   def on_revision_accepted
     SetAlleleRegistryIdSingleVariant.perform_later(self) if Rails.env.production?
-    GenerateOpenCravatLink.perform_later(self)
     update_single_variant_mp_aliases
   end
 


### PR DESCRIPTION
This avoids a race condition where the opencravat task could run before the allele registry id was set.