### PR TITLE
Enhancements to demo queries

### DIFF
--- a/client/src/app/generated/civic.apollo-helpers.ts
+++ b/client/src/app/generated/civic.apollo-helpers.ts
@@ -848,6 +848,19 @@ export type FactorFieldPolicy = {
 	sources?: FieldPolicy<any> | FieldReadFunction<any>,
 	variants?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type FactorConnectionKeySpecifier = ('edges' | 'nodes' | 'pageCount' | 'pageInfo' | 'totalCount' | FactorConnectionKeySpecifier)[];
+export type FactorConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	nodes?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type FactorEdgeKeySpecifier = ('cursor' | 'node' | FactorEdgeKeySpecifier)[];
+export type FactorEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type FactorVariantKeySpecifier = ('comments' | 'creationActivity' | 'deprecated' | 'deprecationActivity' | 'deprecationReason' | 'events' | 'feature' | 'flagged' | 'flags' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'molecularProfiles' | 'name' | 'ncitDetails' | 'ncitId' | 'revisions' | 'singleVariantMolecularProfile' | 'singleVariantMolecularProfileId' | 'variantAliases' | 'variantTypes' | FactorVariantKeySpecifier)[];
 export type FactorVariantFieldPolicy = {
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -873,6 +886,19 @@ export type FactorVariantFieldPolicy = {
 	singleVariantMolecularProfileId?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantAliases?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantTypes?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type FactorVariantConnectionKeySpecifier = ('edges' | 'nodes' | 'pageCount' | 'pageInfo' | 'totalCount' | FactorVariantConnectionKeySpecifier)[];
+export type FactorVariantConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	nodes?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type FactorVariantEdgeKeySpecifier = ('cursor' | 'node' | FactorVariantEdgeKeySpecifier)[];
+export type FactorVariantEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type FdaCodeKeySpecifier = ('code' | 'description' | FdaCodeKeySpecifier)[];
 export type FdaCodeFieldPolicy = {
@@ -1045,6 +1071,19 @@ export type GeneVariantFieldPolicy = {
 	variantAliases?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantBases?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantTypes?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GeneVariantConnectionKeySpecifier = ('edges' | 'nodes' | 'pageCount' | 'pageInfo' | 'totalCount' | GeneVariantConnectionKeySpecifier)[];
+export type GeneVariantConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	nodes?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type GeneVariantEdgeKeySpecifier = ('cursor' | 'node' | GeneVariantEdgeKeySpecifier)[];
+export type GeneVariantEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
 };
 export type LeaderboardOrganizationKeySpecifier = ('actionCount' | 'description' | 'eventCount' | 'events' | 'id' | 'memberCount' | 'members' | 'mostRecentActivityTimestamp' | 'name' | 'orgAndSuborgsStatsHash' | 'orgStatsHash' | 'profileImagePath' | 'rank' | 'ranks' | 'subGroups' | 'url' | LeaderboardOrganizationKeySpecifier)[];
 export type LeaderboardOrganizationFieldPolicy = {
@@ -1536,7 +1575,7 @@ export type PhenotypePopoverFieldPolicy = {
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type QueryKeySpecifier = ('acmgCode' | 'acmgCodesTypeahead' | 'activities' | 'activity' | 'assertion' | 'assertions' | 'browseDiseases' | 'browseFeatures' | 'browseMolecularProfiles' | 'browseSources' | 'browseVariantGroups' | 'browseVariants' | 'clingenCode' | 'clingenCodesTypeahead' | 'clinicalTrial' | 'clinicalTrials' | 'comment' | 'comments' | 'contributors' | 'countries' | 'dataReleases' | 'disease' | 'diseasePopover' | 'diseaseTypeahead' | 'entityTypeahead' | 'events' | 'evidenceItem' | 'evidenceItems' | 'feature' | 'featureTypeahead' | 'flag' | 'flags' | 'gene' | 'genes' | 'molecularProfile' | 'molecularProfiles' | 'nccnGuideline' | 'nccnGuidelinesTypeahead' | 'notifications' | 'organization' | 'organizationLeaderboards' | 'organizations' | 'phenotype' | 'phenotypePopover' | 'phenotypeTypeahead' | 'phenotypes' | 'previewCommentText' | 'previewMolecularProfileName' | 'remoteCitation' | 'revision' | 'revisions' | 'search' | 'searchByPermalink' | 'searchGenes' | 'source' | 'sourcePopover' | 'sourceSuggestionValues' | 'sourceSuggestions' | 'sourceTypeahead' | 'subscriptionForEntity' | 'therapies' | 'therapy' | 'therapyPopover' | 'therapyTypeahead' | 'timepointStats' | 'user' | 'userLeaderboards' | 'userTypeahead' | 'users' | 'validateRevisionsForAcceptance' | 'variant' | 'variantGroup' | 'variantGroups' | 'variantType' | 'variantTypePopover' | 'variantTypeTypeahead' | 'variantTypes' | 'variants' | 'variantsTypeahead' | 'viewer' | QueryKeySpecifier)[];
+export type QueryKeySpecifier = ('acmgCode' | 'acmgCodesTypeahead' | 'activities' | 'activity' | 'assertion' | 'assertions' | 'browseDiseases' | 'browseFeatures' | 'browseMolecularProfiles' | 'browseSources' | 'browseVariantGroups' | 'browseVariants' | 'clingenCode' | 'clingenCodesTypeahead' | 'clinicalTrial' | 'clinicalTrials' | 'comment' | 'comments' | 'contributors' | 'countries' | 'dataReleases' | 'disease' | 'diseasePopover' | 'diseaseTypeahead' | 'entityTypeahead' | 'events' | 'evidenceItem' | 'evidenceItems' | 'factors' | 'feature' | 'featureTypeahead' | 'flag' | 'flags' | 'gene' | 'genes' | 'molecularProfile' | 'molecularProfiles' | 'nccnGuideline' | 'nccnGuidelinesTypeahead' | 'notifications' | 'organization' | 'organizationLeaderboards' | 'organizations' | 'phenotype' | 'phenotypePopover' | 'phenotypeTypeahead' | 'phenotypes' | 'previewCommentText' | 'previewMolecularProfileName' | 'remoteCitation' | 'revision' | 'revisions' | 'search' | 'searchByPermalink' | 'searchGenes' | 'source' | 'sourcePopover' | 'sourceSuggestionValues' | 'sourceSuggestions' | 'sourceTypeahead' | 'subscriptionForEntity' | 'therapies' | 'therapy' | 'therapyPopover' | 'therapyTypeahead' | 'timepointStats' | 'user' | 'userLeaderboards' | 'userTypeahead' | 'users' | 'validateRevisionsForAcceptance' | 'variant' | 'variantGroup' | 'variantGroups' | 'variantType' | 'variantTypePopover' | 'variantTypeTypeahead' | 'variantTypes' | 'variants' | 'variantsTypeahead' | 'viewer' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {
 	acmgCode?: FieldPolicy<any> | FieldReadFunction<any>,
 	acmgCodesTypeahead?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1566,6 +1605,7 @@ export type QueryFieldPolicy = {
 	events?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItem?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceItems?: FieldPolicy<any> | FieldReadFunction<any>,
+	factors?: FieldPolicy<any> | FieldReadFunction<any>,
 	feature?: FieldPolicy<any> | FieldReadFunction<any>,
 	featureTypeahead?: FieldPolicy<any> | FieldReadFunction<any>,
 	flag?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2126,19 +2166,6 @@ export type VariantAliasKeySpecifier = ('name' | VariantAliasKeySpecifier)[];
 export type VariantAliasFieldPolicy = {
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type VariantConnectionKeySpecifier = ('edges' | 'nodes' | 'pageCount' | 'pageInfo' | 'totalCount' | VariantConnectionKeySpecifier)[];
-export type VariantConnectionFieldPolicy = {
-	edges?: FieldPolicy<any> | FieldReadFunction<any>,
-	nodes?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageCount?: FieldPolicy<any> | FieldReadFunction<any>,
-	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
-	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
-};
-export type VariantEdgeKeySpecifier = ('cursor' | 'node' | VariantEdgeKeySpecifier)[];
-export type VariantEdgeFieldPolicy = {
-	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
-	node?: FieldPolicy<any> | FieldReadFunction<any>
-};
 export type VariantGroupKeySpecifier = ('comments' | 'description' | 'events' | 'flagged' | 'flags' | 'id' | 'lastAcceptedRevisionEvent' | 'lastCommentEvent' | 'lastSubmittedRevisionEvent' | 'link' | 'name' | 'revisions' | 'sources' | 'variants' | VariantGroupKeySpecifier)[];
 export type VariantGroupFieldPolicy = {
 	comments?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -2588,9 +2615,25 @@ export type StrictTypedTypePolicies = {
 		keyFields?: false | FactorKeySpecifier | (() => undefined | FactorKeySpecifier),
 		fields?: FactorFieldPolicy,
 	},
+	FactorConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | FactorConnectionKeySpecifier | (() => undefined | FactorConnectionKeySpecifier),
+		fields?: FactorConnectionFieldPolicy,
+	},
+	FactorEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | FactorEdgeKeySpecifier | (() => undefined | FactorEdgeKeySpecifier),
+		fields?: FactorEdgeFieldPolicy,
+	},
 	FactorVariant?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | FactorVariantKeySpecifier | (() => undefined | FactorVariantKeySpecifier),
 		fields?: FactorVariantFieldPolicy,
+	},
+	FactorVariantConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | FactorVariantConnectionKeySpecifier | (() => undefined | FactorVariantConnectionKeySpecifier),
+		fields?: FactorVariantConnectionFieldPolicy,
+	},
+	FactorVariantEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | FactorVariantEdgeKeySpecifier | (() => undefined | FactorVariantEdgeKeySpecifier),
+		fields?: FactorVariantEdgeFieldPolicy,
 	},
 	FdaCode?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | FdaCodeKeySpecifier | (() => undefined | FdaCodeKeySpecifier),
@@ -2647,6 +2690,14 @@ export type StrictTypedTypePolicies = {
 	GeneVariant?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | GeneVariantKeySpecifier | (() => undefined | GeneVariantKeySpecifier),
 		fields?: GeneVariantFieldPolicy,
+	},
+	GeneVariantConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GeneVariantConnectionKeySpecifier | (() => undefined | GeneVariantConnectionKeySpecifier),
+		fields?: GeneVariantConnectionFieldPolicy,
+	},
+	GeneVariantEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | GeneVariantEdgeKeySpecifier | (() => undefined | GeneVariantEdgeKeySpecifier),
+		fields?: GeneVariantEdgeFieldPolicy,
 	},
 	LeaderboardOrganization?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | LeaderboardOrganizationKeySpecifier | (() => undefined | LeaderboardOrganizationKeySpecifier),
@@ -3051,14 +3102,6 @@ export type StrictTypedTypePolicies = {
 	VariantAlias?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | VariantAliasKeySpecifier | (() => undefined | VariantAliasKeySpecifier),
 		fields?: VariantAliasFieldPolicy,
-	},
-	VariantConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | VariantConnectionKeySpecifier | (() => undefined | VariantConnectionKeySpecifier),
-		fields?: VariantConnectionFieldPolicy,
-	},
-	VariantEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
-		keyFields?: false | VariantEdgeKeySpecifier | (() => undefined | VariantEdgeKeySpecifier),
-		fields?: VariantEdgeFieldPolicy,
 	},
 	VariantGroup?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | VariantGroupKeySpecifier | (() => undefined | VariantGroupKeySpecifier),

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -1951,8 +1951,8 @@ export type Factor = Commentable & EventOriginObject & EventSubject & Flaggable 
   /** List and filter revisions. */
   revisions: RevisionConnection;
   sources: Array<Source>;
-  /** List and filter variants. */
-  variants: VariantConnection;
+  /** List and filter Gene variants. */
+  variants: FactorVariantConnection;
 };
 
 
@@ -2013,10 +2013,42 @@ export type FactorRevisionsArgs = {
 /** The Feature that a Variant can belong to */
 export type FactorVariantsArgs = {
   after?: InputMaybe<Scalars['String']>;
+  alleleRegistryId?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  category?: InputMaybe<VariantCategories>;
+  factorId?: InputMaybe<Scalars['Int']>;
+  featureId?: InputMaybe<Scalars['Int']>;
   first?: InputMaybe<Scalars['Int']>;
+  geneId?: InputMaybe<Scalars['Int']>;
+  hasNoVariantType?: InputMaybe<Scalars['Boolean']>;
   last?: InputMaybe<Scalars['Int']>;
   name?: InputMaybe<Scalars['String']>;
+  sortBy?: InputMaybe<VariantMenuSort>;
+  variantTypeIds?: InputMaybe<Array<Scalars['Int']>>;
+};
+
+/** The connection type for Factor. */
+export type FactorConnection = {
+  __typename: 'FactorConnection';
+  /** A list of edges. */
+  edges: Array<FactorEdge>;
+  /** A list of nodes. */
+  nodes: Array<Factor>;
+  /** Total number of pages, based on filtered count and pagesize. */
+  pageCount: Scalars['Int'];
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The total number of records in this filtered collection. */
+  totalCount: Scalars['Int'];
+};
+
+/** An edge in a connection. */
+export type FactorEdge = {
+  __typename: 'FactorEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge. */
+  node?: Maybe<Factor>;
 };
 
 /** Fields on a Factor that curators may propose revisions to. */
@@ -2124,6 +2156,30 @@ export type FactorVariantRevisionsArgs = {
   status?: InputMaybe<RevisionStatus>;
 };
 
+/** The connection type for FactorVariant. */
+export type FactorVariantConnection = {
+  __typename: 'FactorVariantConnection';
+  /** A list of edges. */
+  edges: Array<FactorVariantEdge>;
+  /** A list of nodes. */
+  nodes: Array<FactorVariant>;
+  /** Total number of pages, based on filtered count and pagesize. */
+  pageCount: Scalars['Int'];
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The total number of records in this filtered collection. */
+  totalCount: Scalars['Int'];
+};
+
+/** An edge in a connection. */
+export type FactorVariantEdge = {
+  __typename: 'FactorVariantEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge. */
+  node?: Maybe<FactorVariant>;
+};
+
 /** Fields on a FactorVariant that curators may propose revisions to. */
 export type FactorVariantFields = {
   /** List of aliases or alternate names for the Variant. */
@@ -2171,8 +2227,8 @@ export type Feature = Commentable & EventOriginObject & EventSubject & Flaggable
   /** List and filter revisions. */
   revisions: RevisionConnection;
   sources: Array<Source>;
-  /** List and filter variants. */
-  variants: VariantConnection;
+  /** List and filter Gene variants. */
+  variants: VariantInterfaceConnection;
 };
 
 
@@ -2233,10 +2289,18 @@ export type FeatureRevisionsArgs = {
 /** The Feature that a Variant can belong to */
 export type FeatureVariantsArgs = {
   after?: InputMaybe<Scalars['String']>;
+  alleleRegistryId?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  category?: InputMaybe<VariantCategories>;
+  factorId?: InputMaybe<Scalars['Int']>;
+  featureId?: InputMaybe<Scalars['Int']>;
   first?: InputMaybe<Scalars['Int']>;
+  geneId?: InputMaybe<Scalars['Int']>;
+  hasNoVariantType?: InputMaybe<Scalars['Boolean']>;
   last?: InputMaybe<Scalars['Int']>;
   name?: InputMaybe<Scalars['String']>;
+  sortBy?: InputMaybe<VariantMenuSort>;
+  variantTypeIds?: InputMaybe<Array<Scalars['Int']>>;
 };
 
 export enum FeatureDeprecationReason {
@@ -2477,8 +2541,8 @@ export type Gene = Commentable & EventOriginObject & EventSubject & Flaggable & 
   /** List and filter revisions. */
   revisions: RevisionConnection;
   sources: Array<Source>;
-  /** List and filter variants. */
-  variants: VariantConnection;
+  /** List and filter Gene variants. */
+  variants: GeneVariantConnection;
 };
 
 
@@ -2539,10 +2603,18 @@ export type GeneRevisionsArgs = {
 /** The Feature that a Variant can belong to */
 export type GeneVariantsArgs = {
   after?: InputMaybe<Scalars['String']>;
+  alleleRegistryId?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  category?: InputMaybe<VariantCategories>;
+  factorId?: InputMaybe<Scalars['Int']>;
+  featureId?: InputMaybe<Scalars['Int']>;
   first?: InputMaybe<Scalars['Int']>;
+  geneId?: InputMaybe<Scalars['Int']>;
+  hasNoVariantType?: InputMaybe<Scalars['Boolean']>;
   last?: InputMaybe<Scalars['Int']>;
   name?: InputMaybe<Scalars['String']>;
+  sortBy?: InputMaybe<VariantMenuSort>;
+  variantTypeIds?: InputMaybe<Array<Scalars['Int']>>;
 };
 
 /** The connection type for Gene. */
@@ -2686,6 +2758,30 @@ export type GeneVariantRevisionsArgs = {
   revisionSetId?: InputMaybe<Scalars['Int']>;
   sortBy?: InputMaybe<DateSort>;
   status?: InputMaybe<RevisionStatus>;
+};
+
+/** The connection type for GeneVariant. */
+export type GeneVariantConnection = {
+  __typename: 'GeneVariantConnection';
+  /** A list of edges. */
+  edges: Array<GeneVariantEdge>;
+  /** A list of nodes. */
+  nodes: Array<GeneVariant>;
+  /** Total number of pages, based on filtered count and pagesize. */
+  pageCount: Scalars['Int'];
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The total number of records in this filtered collection. */
+  totalCount: Scalars['Int'];
+};
+
+/** An edge in a connection. */
+export type GeneVariantEdge = {
+  __typename: 'GeneVariantEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge. */
+  node?: Maybe<GeneVariant>;
 };
 
 /** Fields on a GeneVariant that curators may propose revisions to. */
@@ -4056,6 +4152,8 @@ export type Query = {
   evidenceItem?: Maybe<EvidenceItem>;
   /** List and filter evidence items. */
   evidenceItems: EvidenceItemConnection;
+  /** List and filter factors. */
+  factors: FactorConnection;
   /** Find a single feature by CIViC ID */
   feature?: Maybe<Feature>;
   /** Retrieve Features of a specific instance type for a search term. */
@@ -4424,6 +4522,16 @@ export type QueryEvidenceItemsArgs = {
   userId?: InputMaybe<Scalars['Int']>;
   variantId?: InputMaybe<Scalars['Int']>;
   variantOrigin?: InputMaybe<VariantOrigin>;
+};
+
+
+export type QueryFactorsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  name?: InputMaybe<Array<Scalars['String']>>;
+  ncitIt?: InputMaybe<Array<Scalars['String']>>;
 };
 
 
@@ -6290,36 +6398,12 @@ export type VariantComponent = {
   variantId: Scalars['Int'];
 };
 
-/** The connection type for Variant. */
-export type VariantConnection = {
-  __typename: 'VariantConnection';
-  /** A list of edges. */
-  edges: Array<VariantEdge>;
-  /** A list of nodes. */
-  nodes: Array<Variant>;
-  /** Total number of pages, based on filtered count and pagesize. */
-  pageCount: Scalars['Int'];
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The total number of records in this filtered collection. */
-  totalCount: Scalars['Int'];
-};
-
 export enum VariantDeprecationReason {
   Duplicate = 'DUPLICATE',
   FeatureDeprecated = 'FEATURE_DEPRECATED',
   Invalid = 'INVALID',
   Other = 'OTHER'
 }
-
-/** An edge in a connection. */
-export type VariantEdge = {
-  __typename: 'VariantEdge';
-  /** A cursor for use in pagination. */
-  cursor: Scalars['String'];
-  /** The item at the end of the edge. */
-  node?: Maybe<Variant>;
-};
 
 export type VariantGroup = Commentable & EventSubject & Flaggable & WithRevisions & {
   __typename: 'VariantGroup';
@@ -6340,8 +6424,8 @@ export type VariantGroup = Commentable & EventSubject & Flaggable & WithRevision
   /** List and filter revisions. */
   revisions: RevisionConnection;
   sources: Array<Source>;
-  /** List and filter variants. */
-  variants: VariantConnection;
+  /** List and filter Gene variants. */
+  variants: VariantInterfaceConnection;
 };
 
 
@@ -6397,10 +6481,18 @@ export type VariantGroupRevisionsArgs = {
 
 export type VariantGroupVariantsArgs = {
   after?: InputMaybe<Scalars['String']>;
+  alleleRegistryId?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  category?: InputMaybe<VariantCategories>;
+  factorId?: InputMaybe<Scalars['Int']>;
+  featureId?: InputMaybe<Scalars['Int']>;
   first?: InputMaybe<Scalars['Int']>;
+  geneId?: InputMaybe<Scalars['Int']>;
+  hasNoVariantType?: InputMaybe<Scalars['Boolean']>;
   last?: InputMaybe<Scalars['Int']>;
   name?: InputMaybe<Scalars['String']>;
+  sortBy?: InputMaybe<VariantMenuSort>;
+  variantTypeIds?: InputMaybe<Array<Scalars['Int']>>;
 };
 
 /** The connection type for VariantGroup. */
@@ -6966,9 +7058,9 @@ export type FeaturePopoverQueryVariables = Exact<{
 }>;
 
 
-export type FeaturePopoverQuery = { __typename: 'Query', feature?: { __typename: 'Feature', id: number, name: string, fullName?: string | undefined, featureAliases: Array<string>, featureInstance: { __typename: 'Factor' } | { __typename: 'Gene' }, variants: { __typename: 'VariantConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number } } | undefined };
+export type FeaturePopoverQuery = { __typename: 'Query', feature?: { __typename: 'Feature', id: number, name: string, fullName?: string | undefined, featureAliases: Array<string>, featureInstance: { __typename: 'Factor' } | { __typename: 'Gene' }, variants: { __typename: 'VariantInterfaceConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number } } | undefined };
 
-export type FeaturePopoverFragment = { __typename: 'Feature', id: number, name: string, fullName?: string | undefined, featureAliases: Array<string>, featureInstance: { __typename: 'Factor' } | { __typename: 'Gene' }, variants: { __typename: 'VariantConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number } };
+export type FeaturePopoverFragment = { __typename: 'Feature', id: number, name: string, fullName?: string | undefined, featureAliases: Array<string>, featureInstance: { __typename: 'Factor' } | { __typename: 'Gene' }, variants: { __typename: 'VariantInterfaceConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number } };
 
 export type BrowseFeaturesQueryVariables = Exact<{
   featureName?: InputMaybe<Scalars['String']>;
@@ -7411,9 +7503,9 @@ export type VariantGroupPopoverQueryVariables = Exact<{
 }>;
 
 
-export type VariantGroupPopoverQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', edges: Array<{ __typename: 'VariantEdge', node?: { __typename: 'Variant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | undefined }> }, sources: Array<{ __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource, link: string }> } | undefined };
+export type VariantGroupPopoverQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantInterfaceConnection', edges: Array<{ __typename: 'VariantInterfaceEdge', node?: { __typename: 'FactorVariant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'GeneVariant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'Variant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | undefined }> }, sources: Array<{ __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource, link: string }> } | undefined };
 
-export type VariantGroupPopoverFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', edges: Array<{ __typename: 'VariantEdge', node?: { __typename: 'Variant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | undefined }> }, sources: Array<{ __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource, link: string }> };
+export type VariantGroupPopoverFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantInterfaceConnection', edges: Array<{ __typename: 'VariantInterfaceEdge', node?: { __typename: 'FactorVariant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'GeneVariant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'Variant', id: number, name: string, link: string, deprecated: boolean, feature: { __typename: 'Feature', id: number, name: string, link: string } } | undefined }> }, sources: Array<{ __typename: 'Source', id: number, citation?: string | undefined, sourceType: SourceSource, link: string }> };
 
 export type BrowseVariantGroupsQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']>;
@@ -7860,9 +7952,9 @@ export type VariantGroupRevisableFieldsQueryVariables = Exact<{
 }>;
 
 
-export type VariantGroupRevisableFieldsQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', totalCount: number, edges: Array<{ __typename: 'VariantEdge', cursor: string, node?: { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> } | undefined };
+export type VariantGroupRevisableFieldsQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantInterfaceConnection', totalCount: number, edges: Array<{ __typename: 'VariantInterfaceEdge', cursor: string, node?: { __typename: 'FactorVariant', id: number, name: string, link: string } | { __typename: 'GeneVariant', id: number, name: string, link: string } | { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'FactorVariant', id: number, name: string, link: string } | { __typename: 'GeneVariant', id: number, name: string, link: string } | { __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> } | undefined };
 
-export type VariantGroupRevisableFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', totalCount: number, edges: Array<{ __typename: 'VariantEdge', cursor: string, node?: { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> };
+export type VariantGroupRevisableFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantInterfaceConnection', totalCount: number, edges: Array<{ __typename: 'VariantInterfaceEdge', cursor: string, node?: { __typename: 'FactorVariant', id: number, name: string, link: string } | { __typename: 'GeneVariant', id: number, name: string, link: string } | { __typename: 'Variant', id: number, name: string, link: string } | undefined }>, nodes: Array<{ __typename: 'FactorVariant', id: number, name: string, link: string } | { __typename: 'GeneVariant', id: number, name: string, link: string } | { __typename: 'Variant', id: number, name: string, link: string }> }, sources: Array<{ __typename: 'Source', id: number, name: string, link: string }> };
 
 export type SuggestVariantGroupRevisionMutationVariables = Exact<{
   input: SuggestVariantGroupRevisionInput;
@@ -7876,9 +7968,9 @@ export type VariantGroupSubmittableFieldsQueryVariables = Exact<{
 }>;
 
 
-export type VariantGroupSubmittableFieldsQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> } | undefined };
+export type VariantGroupSubmittableFieldsQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantInterfaceConnection', nodes: Array<{ __typename: 'FactorVariant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } | { __typename: 'GeneVariant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } | { __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> } | undefined };
 
-export type SubmittableVariantGroupFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantConnection', nodes: Array<{ __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> };
+export type SubmittableVariantGroupFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, description: string, variants: { __typename: 'VariantInterfaceConnection', nodes: Array<{ __typename: 'FactorVariant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } | { __typename: 'GeneVariant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } } | { __typename: 'Variant', id: number, name: string, link: string, singleVariantMolecularProfile: { __typename: 'MolecularProfile', id: number, name: string, link: string } }> }, sources: Array<{ __typename: 'Source', id: number, link: string, citation?: string | undefined, sourceType: SourceSource }> };
 
 export type SubmitVariantGroupMutationVariables = Exact<{
   input: SubmitVariantGroupInput;
@@ -8516,9 +8608,9 @@ export type VariantGroupDetailQueryVariables = Exact<{
 }>;
 
 
-export type VariantGroupDetailQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, variants: { __typename: 'VariantConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number }, revisions: { __typename: 'RevisionConnection', totalCount: number }, comments: { __typename: 'CommentConnection', totalCount: number } } | undefined };
+export type VariantGroupDetailQuery = { __typename: 'Query', variantGroup?: { __typename: 'VariantGroup', id: number, name: string, variants: { __typename: 'VariantInterfaceConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number }, revisions: { __typename: 'RevisionConnection', totalCount: number }, comments: { __typename: 'CommentConnection', totalCount: number } } | undefined };
 
-export type VariantGroupDetailFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, variants: { __typename: 'VariantConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number }, revisions: { __typename: 'RevisionConnection', totalCount: number }, comments: { __typename: 'CommentConnection', totalCount: number } };
+export type VariantGroupDetailFieldsFragment = { __typename: 'VariantGroup', id: number, name: string, variants: { __typename: 'VariantInterfaceConnection', totalCount: number }, flags: { __typename: 'FlagConnection', totalCount: number }, revisions: { __typename: 'RevisionConnection', totalCount: number }, comments: { __typename: 'CommentConnection', totalCount: number } };
 
 export type VariantGroupsSummaryQueryVariables = Exact<{
   variantGroupId: Scalars['Int'];

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -3193,7 +3193,7 @@ type Factor implements Commentable & EventOriginObject & EventSubject & Flaggabl
   sources: [Source!]!
 
   """
-  List and filter variants.
+  List and filter Gene variants.
   """
   variants(
     """
@@ -3202,14 +3202,40 @@ type Factor implements Commentable & EventOriginObject & EventSubject & Flaggabl
     after: String
 
     """
+    Find a CIViC Variant based on its ClinGen Allele Registry ID
+    """
+    alleleRegistryId: String
+
+    """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    category: VariantCategories
+
+    """
+    Feature that the variants are associated with, limited to only Factor type features.
+    """
+    factorId: Int
+
+    """
+    Feature that the variants are associated with.
+    """
+    featureId: Int
 
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+
+    """
+    Feature that the variants are associated with, limited to only Gene type features.
+    """
+    geneId: Int
+
+    """
+    Return Variants lacking an assigned VariantType
+    """
+    hasNoVariantType: Boolean
 
     """
     Returns the last _n_ elements from the list.
@@ -3220,7 +3246,58 @@ type Factor implements Commentable & EventOriginObject & EventSubject & Flaggabl
     Left anchored filtering for variant name and aliases.
     """
     name: String
-  ): VariantConnection!
+    sortBy: VariantMenuSort
+
+    """
+    A list of CIViC identifiers for variant types
+    """
+    variantTypeIds: [Int!]
+  ): FactorVariantConnection!
+}
+
+"""
+The connection type for Factor.
+"""
+type FactorConnection {
+  """
+  A list of edges.
+  """
+  edges: [FactorEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Factor!]!
+
+  """
+  Total number of pages, based on filtered count and pagesize.
+  """
+  pageCount: Int!
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  The total number of records in this filtered collection.
+  """
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type FactorEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Factor
 }
 
 """
@@ -3478,6 +3555,51 @@ type FactorVariant implements Commentable & EventOriginObject & EventSubject & F
 }
 
 """
+The connection type for FactorVariant.
+"""
+type FactorVariantConnection {
+  """
+  A list of edges.
+  """
+  edges: [FactorVariantEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [FactorVariant!]!
+
+  """
+  Total number of pages, based on filtered count and pagesize.
+  """
+  pageCount: Int!
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  The total number of records in this filtered collection.
+  """
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type FactorVariantEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: FactorVariant
+}
+
+"""
 Fields on a FactorVariant that curators may propose revisions to.
 """
 input FactorVariantFields {
@@ -3711,7 +3833,7 @@ type Feature implements Commentable & EventOriginObject & EventSubject & Flaggab
   sources: [Source!]!
 
   """
-  List and filter variants.
+  List and filter Gene variants.
   """
   variants(
     """
@@ -3720,14 +3842,40 @@ type Feature implements Commentable & EventOriginObject & EventSubject & Flaggab
     after: String
 
     """
+    Find a CIViC Variant based on its ClinGen Allele Registry ID
+    """
+    alleleRegistryId: String
+
+    """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    category: VariantCategories
+
+    """
+    Feature that the variants are associated with, limited to only Factor type features.
+    """
+    factorId: Int
+
+    """
+    Feature that the variants are associated with.
+    """
+    featureId: Int
 
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+
+    """
+    Feature that the variants are associated with, limited to only Gene type features.
+    """
+    geneId: Int
+
+    """
+    Return Variants lacking an assigned VariantType
+    """
+    hasNoVariantType: Boolean
 
     """
     Returns the last _n_ elements from the list.
@@ -3738,7 +3886,13 @@ type Feature implements Commentable & EventOriginObject & EventSubject & Flaggab
     Left anchored filtering for variant name and aliases.
     """
     name: String
-  ): VariantConnection!
+    sortBy: VariantMenuSort
+
+    """
+    A list of CIViC identifiers for variant types
+    """
+    variantTypeIds: [Int!]
+  ): VariantInterfaceConnection!
 }
 
 enum FeatureDeprecationReason {
@@ -4298,7 +4452,7 @@ type Gene implements Commentable & EventOriginObject & EventSubject & Flaggable 
   sources: [Source!]!
 
   """
-  List and filter variants.
+  List and filter Gene variants.
   """
   variants(
     """
@@ -4307,14 +4461,40 @@ type Gene implements Commentable & EventOriginObject & EventSubject & Flaggable 
     after: String
 
     """
+    Find a CIViC Variant based on its ClinGen Allele Registry ID
+    """
+    alleleRegistryId: String
+
+    """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    category: VariantCategories
+
+    """
+    Feature that the variants are associated with, limited to only Factor type features.
+    """
+    factorId: Int
+
+    """
+    Feature that the variants are associated with.
+    """
+    featureId: Int
 
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+
+    """
+    Feature that the variants are associated with, limited to only Gene type features.
+    """
+    geneId: Int
+
+    """
+    Return Variants lacking an assigned VariantType
+    """
+    hasNoVariantType: Boolean
 
     """
     Returns the last _n_ elements from the list.
@@ -4325,7 +4505,13 @@ type Gene implements Commentable & EventOriginObject & EventSubject & Flaggable 
     Left anchored filtering for variant name and aliases.
     """
     name: String
-  ): VariantConnection!
+    sortBy: VariantMenuSort
+
+    """
+    A list of CIViC identifiers for variant types
+    """
+    variantTypeIds: [Int!]
+  ): GeneVariantConnection!
 }
 
 """
@@ -4628,6 +4814,51 @@ type GeneVariant implements Commentable & EventOriginObject & EventSubject & Fla
   variantAliases: [String!]!
   variantBases: String
   variantTypes: [VariantType!]!
+}
+
+"""
+The connection type for GeneVariant.
+"""
+type GeneVariantConnection {
+  """
+  A list of edges.
+  """
+  edges: [GeneVariantEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [GeneVariant!]!
+
+  """
+  Total number of pages, based on filtered count and pagesize.
+  """
+  pageCount: Int!
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  The total number of records in this filtered collection.
+  """
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type GeneVariantEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: GeneVariant
 }
 
 """
@@ -7306,6 +7537,41 @@ type Query {
     """
     variantOrigin: VariantOrigin
   ): EvidenceItemConnection!
+
+  """
+  List and filter factors.
+  """
+  factors(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    List of Factor names to return
+    """
+    name: [String!]
+
+    """
+    List of NCIt Codes to return Factors for
+    """
+    ncitIt: [String!]
+  ): FactorConnection!
 
   """
   Find a single feature by CIViC ID
@@ -10435,56 +10701,11 @@ input VariantComponent {
   variantId: Int!
 }
 
-"""
-The connection type for Variant.
-"""
-type VariantConnection {
-  """
-  A list of edges.
-  """
-  edges: [VariantEdge!]!
-
-  """
-  A list of nodes.
-  """
-  nodes: [Variant!]!
-
-  """
-  Total number of pages, based on filtered count and pagesize.
-  """
-  pageCount: Int!
-
-  """
-  Information to aid in pagination.
-  """
-  pageInfo: PageInfo!
-
-  """
-  The total number of records in this filtered collection.
-  """
-  totalCount: Int!
-}
-
 enum VariantDeprecationReason {
   DUPLICATE
   FEATURE_DEPRECATED
   INVALID
   OTHER
-}
-
-"""
-An edge in a connection.
-"""
-type VariantEdge {
-  """
-  A cursor for use in pagination.
-  """
-  cursor: String!
-
-  """
-  The item at the end of the edge.
-  """
-  node: Variant
 }
 
 type VariantGroup implements Commentable & EventSubject & Flaggable & WithRevisions {
@@ -10676,7 +10897,7 @@ type VariantGroup implements Commentable & EventSubject & Flaggable & WithRevisi
   sources: [Source!]!
 
   """
-  List and filter variants.
+  List and filter Gene variants.
   """
   variants(
     """
@@ -10685,14 +10906,40 @@ type VariantGroup implements Commentable & EventSubject & Flaggable & WithRevisi
     after: String
 
     """
+    Find a CIViC Variant based on its ClinGen Allele Registry ID
+    """
+    alleleRegistryId: String
+
+    """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    category: VariantCategories
+
+    """
+    Feature that the variants are associated with, limited to only Factor type features.
+    """
+    factorId: Int
+
+    """
+    Feature that the variants are associated with.
+    """
+    featureId: Int
 
     """
     Returns the first _n_ elements from the list.
     """
     first: Int
+
+    """
+    Feature that the variants are associated with, limited to only Gene type features.
+    """
+    geneId: Int
+
+    """
+    Return Variants lacking an assigned VariantType
+    """
+    hasNoVariantType: Boolean
 
     """
     Returns the last _n_ elements from the list.
@@ -10703,7 +10950,13 @@ type VariantGroup implements Commentable & EventSubject & Flaggable & WithRevisi
     Left anchored filtering for variant name and aliases.
     """
     name: String
-  ): VariantConnection!
+    sortBy: VariantMenuSort
+
+    """
+    A list of CIViC identifiers for variant types
+    """
+    variantTypeIds: [Int!]
+  ): VariantInterfaceConnection!
 }
 
 """

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -15906,7 +15906,7 @@
             },
             {
               "name": "variants",
-              "description": "List and filter variants.",
+              "description": "List and filter Gene variants.",
               "args": [
                 {
                   "name": "name",
@@ -15914,6 +15914,110 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "featureId",
+                  "description": "Feature that the variants are associated with.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "geneId",
+                  "description": "Feature that the variants are associated with, limited to only Gene type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "factorId",
+                  "description": "Feature that the variants are associated with, limited to only Factor type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "variantTypeIds",
+                  "description": "A list of CIViC identifiers for variant types",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Int",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "alleleRegistryId",
+                  "description": "Find a CIViC Variant based on its ClinGen Allele Registry ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "hasNoVariantType",
+                  "description": "Return Variants lacking an assigned VariantType",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sortBy",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "VariantMenuSort",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "category",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "VariantCategories",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -15974,7 +16078,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "VariantConnection",
+                  "name": "FactorVariantConnection",
                   "ofType": null
                 }
               },
@@ -16015,6 +16119,152 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FactorConnection",
+          "description": "The connection type for Factor.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "FactorEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Factor",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageCount",
+              "description": "Total number of pages, based on filtered count and pagesize.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The total number of records in this filtered collection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FactorEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Factor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -17002,6 +17252,152 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "FactorVariantConnection",
+          "description": "The connection type for FactorVariant.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "FactorVariantEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "FactorVariant",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageCount",
+              "description": "Total number of pages, based on filtered count and pagesize.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The total number of records in this filtered collection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FactorVariantEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FactorVariant",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "FactorVariantFields",
           "description": "Fields on a FactorVariant that curators may propose revisions to.",
@@ -17874,7 +18270,7 @@
             },
             {
               "name": "variants",
-              "description": "List and filter variants.",
+              "description": "List and filter Gene variants.",
               "args": [
                 {
                   "name": "name",
@@ -17882,6 +18278,110 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "featureId",
+                  "description": "Feature that the variants are associated with.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "geneId",
+                  "description": "Feature that the variants are associated with, limited to only Gene type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "factorId",
+                  "description": "Feature that the variants are associated with, limited to only Factor type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "variantTypeIds",
+                  "description": "A list of CIViC identifiers for variant types",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Int",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "alleleRegistryId",
+                  "description": "Find a CIViC Variant based on its ClinGen Allele Registry ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "hasNoVariantType",
+                  "description": "Return Variants lacking an assigned VariantType",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sortBy",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "VariantMenuSort",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "category",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "VariantCategories",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -17942,7 +18442,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "VariantConnection",
+                  "name": "VariantInterfaceConnection",
                   "ofType": null
                 }
               },
@@ -20298,7 +20798,7 @@
             },
             {
               "name": "variants",
-              "description": "List and filter variants.",
+              "description": "List and filter Gene variants.",
               "args": [
                 {
                   "name": "name",
@@ -20306,6 +20806,110 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "featureId",
+                  "description": "Feature that the variants are associated with.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "geneId",
+                  "description": "Feature that the variants are associated with, limited to only Gene type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "factorId",
+                  "description": "Feature that the variants are associated with, limited to only Factor type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "variantTypeIds",
+                  "description": "A list of CIViC identifiers for variant types",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Int",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "alleleRegistryId",
+                  "description": "Find a CIViC Variant based on its ClinGen Allele Registry ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "hasNoVariantType",
+                  "description": "Return Variants lacking an assigned VariantType",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sortBy",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "VariantMenuSort",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "category",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "VariantCategories",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -20366,7 +20970,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "VariantConnection",
+                  "name": "GeneVariantConnection",
                   "ofType": null
                 }
               },
@@ -21735,6 +22339,152 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GeneVariantConnection",
+          "description": "The connection type for GeneVariant.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "GeneVariantEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "GeneVariant",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageCount",
+              "description": "Total number of pages, based on filtered count and pagesize.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The total number of records in this filtered collection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GeneVariantEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "GeneVariant",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -33873,6 +34623,111 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "EvidenceItemConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factors",
+              "description": "List and filter factors.",
+              "args": [
+                {
+                  "name": "ncitIt",
+                  "description": "List of NCIt Codes to return Factors for",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "name",
+                  "description": "List of Factor names to return",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FactorConnection",
                   "ofType": null
                 }
               },
@@ -47322,113 +48177,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "VariantConnection",
-          "description": "The connection type for Variant.",
-          "fields": [
-            {
-              "name": "edges",
-              "description": "A list of edges.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "VariantEdge",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "nodes",
-              "description": "A list of nodes.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Variant",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageCount",
-              "description": "Total number of pages, based on filtered count and pagesize.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": "Information to aid in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PageInfo",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "totalCount",
-              "description": "The total number of records in this filtered collection.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "ENUM",
           "name": "VariantDeprecationReason",
           "description": null,
@@ -47461,45 +48209,6 @@
               "deprecationReason": null
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "VariantEdge",
-          "description": "An edge in a connection.",
-          "fields": [
-            {
-              "name": "cursor",
-              "description": "A cursor for use in pagination.",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": "The item at the end of the edge.",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Variant",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -48125,7 +48834,7 @@
             },
             {
               "name": "variants",
-              "description": "List and filter variants.",
+              "description": "List and filter Gene variants.",
               "args": [
                 {
                   "name": "name",
@@ -48133,6 +48842,110 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "featureId",
+                  "description": "Feature that the variants are associated with.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "geneId",
+                  "description": "Feature that the variants are associated with, limited to only Gene type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "factorId",
+                  "description": "Feature that the variants are associated with, limited to only Factor type features.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "variantTypeIds",
+                  "description": "A list of CIViC identifiers for variant types",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Int",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "alleleRegistryId",
+                  "description": "Find a CIViC Variant based on its ClinGen Allele Registry ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "hasNoVariantType",
+                  "description": "Return Variants lacking an assigned VariantType",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sortBy",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "VariantMenuSort",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "category",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "VariantCategories",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -48193,7 +49006,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "VariantConnection",
+                  "name": "VariantInterfaceConnection",
                   "ofType": null
                 }
               },

--- a/server/app/graphql/resolvers/factor_variants.rb
+++ b/server/app/graphql/resolvers/factor_variants.rb
@@ -1,6 +1,6 @@
-class Resolvers::Variants < Resolvers::Shared::Variants
+class Resolvers::FactorVariants < Resolvers::Shared::Variants
 
-  type Types::Interfaces::VariantInterface.connection_type, null: false
+  type Types::Variants::FactorVariantType.connection_type, null: false
 
   description 'List and filter Gene variants.'
 

--- a/server/app/graphql/resolvers/gene_variants.rb
+++ b/server/app/graphql/resolvers/gene_variants.rb
@@ -1,6 +1,6 @@
-class Resolvers::Variants < Resolvers::Shared::Variants
+class Resolvers::GeneVariants < Resolvers::Shared::Variants
 
-  type Types::Interfaces::VariantInterface.connection_type, null: false
+  type Types::Variants::GeneVariantType.connection_type, null: false
 
   description 'List and filter Gene variants.'
 

--- a/server/app/graphql/resolvers/shared/variants.rb
+++ b/server/app/graphql/resolvers/shared/variants.rb
@@ -1,0 +1,61 @@
+require 'search_object/plugin/graphql'
+
+class Resolvers::Shared::Variants < GraphQL::Schema::Resolver
+  include SearchObject.module(:graphql)
+
+  option(:name, type: GraphQL::Types::String, description: 'Left anchored filtering for variant name and aliases.') do |scope, value|
+    scope.left_joins(:variant_aliases)
+      .where('variants.name ILIKE :query OR variant_aliases.name ILIKE :query', { query: "%#{value}%" })
+  end
+
+  option(:feature_id, type: GraphQL::Types::Int, description: 'Feature that the variants are associated with.') do |scope, value|
+    scope.where(feature_id: value)
+  end
+
+  option(:gene_id, type: GraphQL::Types::Int, description: 'Feature that the variants are associated with, limited to only Gene type features.') do |scope, value|
+    scope.joins(:feature).where(feature_id: value, feature: { feature_instance_type: 'Features::Gene' })
+  end
+
+  option(:factor_id, type: GraphQL::Types::Int, description: 'Feature that the variants are associated with, limited to only Factor type features.') do |scope, value|
+    scope.joins(:feature).where(feature_id: value, feature: { feature_instance_type: 'Features::Factor' })
+  end
+
+  option(:variant_type_ids, type: [GraphQL::Types::Int], description: 'A list of CIViC identifiers for variant types') do  |scope, value|
+    if value.size > 0
+      scope.joins(:variant_types).where(variant_types: { id: value })
+    else
+      scope
+    end
+  end
+
+  option(:allele_registry_id, type: GraphQL::Types::String, description: 'Find a CIViC Variant based on its ClinGen Allele Registry ID') do |scope, value|
+    scope.where(allele_registry_id: value)
+  end
+
+  option(:has_no_variant_type, type: GraphQL::Types::Boolean, description: "Return Variants lacking an assigned VariantType") do |scope, value|
+    if(value)
+      scope.left_joins(:variant_types).where(variant_types: { id: nil })
+    else
+      scope
+    end
+  end
+
+  option :sort_by, type: Types::VariantMenuSortType do |scope, value|
+    case value.column
+    when 'NAME'
+      scope.reorder("variants.name #{value.direction}")
+    when 'COORDINATE_START'
+      scope.reorder("variants.start #{value.direction} NULLS LAST")
+    when 'COORDINATE_END'
+      scope.reorder("variants.stop #{value.direction} NULLS LAST")
+    end
+  end
+
+  option(:category, type: Types::VariantCategories) do |scope, value|
+    if value
+      scope.where(category: value)
+    else
+      scope
+    end
+  end
+end

--- a/server/app/graphql/resolvers/top_level_variants.rb
+++ b/server/app/graphql/resolvers/top_level_variants.rb
@@ -1,67 +1,7 @@
-require 'search_object/plugin/graphql'
-
-class Resolvers::TopLevelVariants < GraphQL::Schema::Resolver
-  include SearchObject.module(:graphql)
-
+class Resolvers::TopLevelVariants < Resolvers::Shared::Variants
   type Types::Interfaces::VariantInterface.connection_type, null: false
 
   description 'List and filter variants.'
 
   scope { Variant.where(deprecated: false).order('variants.name ASC').distinct }
-
-  option(:name, type: GraphQL::Types::String, description: 'Left anchored filtering for variant name and aliases.') do |scope, value|
-    scope.left_joins(:variant_aliases)
-      .where('variants.name ILIKE :query OR variant_aliases.name ILIKE :query', { query: "%#{value}%" })
-  end
-
-  option(:feature_id, type: GraphQL::Types::Int, description: 'Feature that the variants are associated with.') do |scope, value|
-    scope.where(feature_id: value)
-  end
-
-  option(:gene_id, type: GraphQL::Types::Int, description: 'Feature that the variants are associated with, limited to only Gene type features.') do |scope, value|
-    scope.joins(:feature).where(feature_id: value, feature: { feature_instance_type: 'Features::Gene' })
-  end
-
-  option(:factor_id, type: GraphQL::Types::Int, description: 'Feature that the variants are associated with, limited to only Factor type features.') do |scope, value|
-    scope.joins(:feature).where(feature_id: value, feature: { feature_instance_type: 'Features::Factor' })
-  end
-
-  option(:variant_type_ids, type: [GraphQL::Types::Int], description: 'A list of CIViC identifiers for variant types') do  |scope, value|
-    if value.size > 0
-      scope.joins(:variant_types).where(variant_types: { id: value })
-    else
-      scope
-    end
-  end
-
-  option(:allele_registry_id, type: GraphQL::Types::String, description: 'Find a CIViC Variant based on its ClinGen Allele Registry ID') do |scope, value|
-    scope.where(allele_registry_id: value)
-  end
-
-  option(:has_no_variant_type, type: GraphQL::Types::Boolean, description: "Return Variants lacking an assigned VariantType") do |scope, value|
-    if(value)
-      scope.left_joins(:variant_types).where(variant_types: { id: nil })
-    else
-      scope
-    end
-  end
-
-  option :sort_by, type: Types::VariantMenuSortType do |scope, value|
-    case value.column
-    when 'NAME'
-      scope.reorder("variants.name #{value.direction}")
-    when 'COORDINATE_START'
-      scope.reorder("variants.start #{value.direction} NULLS LAST")
-    when 'COORDINATE_END'
-      scope.reorder("variants.stop #{value.direction} NULLS LAST")
-    end
-  end
-
-  option(:category, type: Types::VariantCategories) do |scope, value|
-    if value
-      scope.where(category: value)
-    else
-      scope
-    end
-  end
 end

--- a/server/app/graphql/types/entities/factor_type.rb
+++ b/server/app/graphql/types/entities/factor_type.rb
@@ -3,6 +3,7 @@ module Types::Entities
 
     field :ncit_id, String, null: true
     field :ncit_details, Types::Entities::NcitDetailsType, null: true
+    field :variants, resolver: Resolvers::FactorVariants
 
     def ncit_details
       NcitDetails.new(object).response

--- a/server/app/graphql/types/entities/gene_type.rb
+++ b/server/app/graphql/types/entities/gene_type.rb
@@ -3,6 +3,7 @@ module Types::Entities
 
     field :entrez_id, Int, null: false
     field :my_gene_info_details, GraphQL::Types::JSON, null: true
+    field :variants, resolver: Resolvers::GeneVariants
 
     def my_gene_info_details
       MyGeneInfo.get_by_gene_id(object.id)

--- a/server/config/query_examples/factor_mp_variants.yml
+++ b/server/config/query_examples/factor_mp_variants.yml
@@ -1,0 +1,38 @@
+name: Get Variants for MP
+description: Query for Molecular Profiles by name, pulling back their variants. Retrieve different fields based on underlying Variant type
+order: 4
+query: |
+  {
+    molecularProfiles(name: "MSI") {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        name
+        evidenceCountsByStatus {
+          acceptedCount
+          submittedCount
+        }
+        molecularProfileAliases
+        variants {
+          id
+          name
+          link
+          ... on FactorVariant {
+            ncitId
+          }
+          ... on GeneVariant {
+            alleleRegistryId
+          }
+          feature {
+            id
+            name
+            link
+          }
+        }
+      }
+    }
+  }
+


### PR DESCRIPTION
This does two things:

1. Pulls the variant resolver into a shared class, and then subclasses it with resolvers having specific return types (GeneVariant, FactorVariant, or VariantInterface) based on how much context we have available.

Now, when you query

```
variants {
}
```
You will get `VariantInterface` back and be able to disambiguate with 

```
... on GeneVariant {}
... on FactorVariant {}
```
etc.

But if you query

```
genes {
  variants {
  }
}
```

You will get explicitly `GeneVariant`s back with no ambiguity. (Likewise for factors).

Realized this was possible while fixing one of the existing demo queries that the features rollout broke.

2) Adds an additional example query that shows how to pull back different fields based on what variant subtype you have
