### PR TITLE
always use the base class in search, not the inherited type

### DIFF
--- a/server/app/graphql/resolvers/quicksearch.rb
+++ b/server/app/graphql/resolvers/quicksearch.rb
@@ -40,7 +40,7 @@ class Resolvers::Quicksearch < GraphQL::Schema::Resolver
       {
         id: res.id,
         name: format_name(res.name, highlights),
-        result_type: res.class,
+        result_type: res.class.base_class,
         matching_text: format_highlights(highlights)
       }
     end


### PR DESCRIPTION
The GraphQL enum will not resolve for `Variants::FactorVariant` so use `Variant` instead. `.base_class` will get the uppermost class in the inheritance hierarchy that isn't ApplicationRecord/Activerecord::Base