### PR TITLE
Various browse table fixes

### DIFF
--- a/client/src/app/components/assertions/assertions-table/assertions-table.component.html
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.component.html
@@ -52,21 +52,14 @@
           [nzSortFn]="true">
           AID
         </th>
-        <th nzWidth="320px">
-          Molecular Profile
-        </th>
+        <th nzWidth="320px">Molecular Profile</th>
         <th
           nzWidth="250px"
           [nzColumnKey]="sortColumns.DiseaseName"
           [nzSortFn]="true">
           Disease
         </th>
-        <th
-          nzWidth="350px"
-          [nzColumnKey]="sortColumns.TherapyName"
-          [nzSortFn]="true">
-          Therapies
-        </th>
+        <th nzWidth="350px">Therapies</th>
         <th
           nzWidth="40px"
           nz-tooltip
@@ -144,7 +137,8 @@
             [onInputChanged]="textInputCallback"></cvc-clearable-input-filter>
         </th>
         <th>
-          <cvc-clearable-input-filter [(inputModel)]="molecularProfileNameInput"
+          <cvc-clearable-input-filter
+            [(inputModel)]="molecularProfileNameInput"
             [onInputChanged]="textInputCallback"></cvc-clearable-input-filter>
         </th>
         <th>
@@ -333,7 +327,9 @@
             <cvc-assertion-tag [assertion]="aid"></cvc-assertion-tag>
           </td>
           <td>
-            <cvc-molecular-profile-tag [molecularProfile]="aid.molecularProfile" [truncateLongName]="40"></cvc-molecular-profile-tag>
+            <cvc-molecular-profile-tag
+              [molecularProfile]="aid.molecularProfile"
+              [truncateLongName]="40"></cvc-molecular-profile-tag>
           </td>
           <td>
             <ng-container *ngIf="aid.disease.name; else diseaseElse">
@@ -379,7 +375,7 @@
                   style="color: #ac3996"
                   [nzType]="
                     aid.therapyInteractionType
-                      | therapyInteractionEnumDisplay : 'icon-name'
+                      | therapyInteractionEnumDisplay: 'icon-name'
                   "
                   class="attribute-icon"></i>
               </nz-tag>
@@ -407,31 +403,49 @@
           <td
             nzAlign="center"
             nzRight>
-            <nz-tag nz-tooltip
+            <nz-tag
+              nz-tooltip
               nzTooltipPlacement="top"
-              [nzTooltipTitle]="!isScrolling ? (aid.assertionType | evidenceEnumDisplay) : ''">
-              <i nz-icon
+              [nzTooltipTitle]="
+                !isScrolling ? (aid.assertionType | evidenceEnumDisplay) : ''
+              ">
+              <i
+                nz-icon
                 [nzType]="aid.assertionType | evidenceEnumDisplay: 'icon-name'"
                 class="attribute-icon"></i>
             </nz-tag>
           </td>
-          <td nzAlign="center"
+          <td
+            nzAlign="center"
             nzRight>
-            <nz-tag nz-tooltip
+            <nz-tag
+              nz-tooltip
               nzTooltipPlacement="top"
-              [nzTooltipTitle]="!isScrolling ? (aid.assertionDirection | evidenceEnumDisplay) : ''">
-              <i nz-icon
-                [nzType]="aid.assertionDirection | evidenceEnumDisplay: 'icon-name'"
+              [nzTooltipTitle]="
+                !isScrolling
+                  ? (aid.assertionDirection | evidenceEnumDisplay)
+                  : ''
+              ">
+              <i
+                nz-icon
+                [nzType]="
+                  aid.assertionDirection | evidenceEnumDisplay: 'icon-name'
+                "
                 class="attribute-icon"></i>
             </nz-tag>
           </td>
-          <td nzAlign="center"
+          <td
+            nzAlign="center"
             nzRight>
-            <nz-tag nz-tooltip
+            <nz-tag
+              nz-tooltip
               nzTooltipPlacement="top"
-              [nzTooltipTitle]="!isScrolling ? (aid.significance | evidenceEnumDisplay) : ''">
-              <i nz-icon
-                [nzType]="aid.significance| evidenceEnumDisplay: 'icon-name'"
+              [nzTooltipTitle]="
+                !isScrolling ? (aid.significance | evidenceEnumDisplay) : ''
+              ">
+              <i
+                nz-icon
+                [nzType]="aid.significance | evidenceEnumDisplay: 'icon-name'"
                 class="attribute-icon"></i>
             </nz-tag>
           </td>
@@ -443,9 +457,9 @@
               nz-tooltip
               nzTooltipPlacement="top"
               [nzTooltipTitle]="
-                !isScrolling ? (aid.ampLevel | formatAmp : 'verbose') : ''
+                !isScrolling ? (aid.ampLevel | formatAmp: 'verbose') : ''
               ">
-              {{ aid.ampLevel | formatAmp : 'compact' }}
+              {{ aid.ampLevel | formatAmp: 'compact' }}
             </nz-tag>
           </td>
           <td

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.html
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.html
@@ -68,12 +68,7 @@
           [nzSortFn]="true">
           Disease
         </th>
-        <th
-          nzWidth="400px"
-          [nzColumnKey]="sortColumns.TherapyName"
-          [nzSortFn]="true">
-          Therapies
-        </th>
+        <th nzWidth="400px">Therapies</th>
         <th
           nzWidth="40px"
           nz-tooltip
@@ -494,7 +489,7 @@
                   nz-icon
                   [nzType]="
                     eid.therapyInteractionType
-                      | therapyInteractionEnumDisplay : 'icon-name'
+                      | therapyInteractionEnumDisplay: 'icon-name'
                   "
                   class="attribute-icon"></i>
               </nz-tag>
@@ -546,7 +541,7 @@
               ">
               <i
                 nz-icon
-                [nzType]="eid.evidenceType | evidenceEnumDisplay : 'icon-name'"
+                [nzType]="eid.evidenceType | evidenceEnumDisplay: 'icon-name'"
                 class="attribute-icon"></i>
             </nz-tag>
           </td>
@@ -564,7 +559,7 @@
               <i
                 nz-icon
                 [nzType]="
-                  eid.evidenceDirection | evidenceEnumDisplay : 'icon-name'
+                  eid.evidenceDirection | evidenceEnumDisplay: 'icon-name'
                 "
                 class="attribute-icon"></i>
             </nz-tag>
@@ -580,7 +575,7 @@
               ">
               <i
                 nz-icon
-                [nzType]="eid.significance | evidenceEnumDisplay : 'icon-name'"
+                [nzType]="eid.significance | evidenceEnumDisplay: 'icon-name'"
                 class="attribute-icon"></i>
             </nz-tag>
           </td>
@@ -595,7 +590,7 @@
               ">
               <i
                 nz-icon
-                [nzType]="eid.variantOrigin | evidenceEnumDisplay : 'icon-name'"
+                [nzType]="eid.variantOrigin | evidenceEnumDisplay: 'icon-name'"
                 class="attribute-icon"></i>
             </nz-tag>
           </td>

--- a/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.component.html
+++ b/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.component.html
@@ -25,7 +25,7 @@
           <ng-container *ngIf="!col.hidden">
             <!-- SELECT HEADER -->
             <th
-              *ngIf="col | guardType : colGuards.isSelectCol as selectCol"
+              *ngIf="col | guardType: colGuards.isSelectCol as selectCol"
               [nzShowCheckbox]="selectCol.checkbox.th.showCheckbox || false"
               [nzWidth]="selectCol.width"
               [nzAlign]="selectCol.align ?? 'left'"
@@ -34,14 +34,16 @@
 
             <!-- ENTITY TAG HEADER -->
             <th
-              *ngIf="col | guardType : colGuards.isEntityTagCol as entityTagCol"
+              *ngIf="col | guardType: colGuards.isEntityTagCol as entityTagCol"
               [nzColumnKey]="entityTagCol.key"
               [nzAlign]="entityTagCol.align ?? 'left'"
               [nzWidth]="entityTagCol.width"
               [nzLeft]="entityTagCol.fixedLeft || false"
               [nzRight]="entityTagCol.fixedRight || false"
-              [nzShowSort]="entityTagCol.sort !== undefined"
-              [nzSortFn]="true"
+              [nzShowSort]="
+                entityTagCol.sort !== undefined && !entityTagCol.sort.disabled
+              "
+              [nzSortFn]="!entityTagCol.sort.disabled"
               [nzSortOrder]="
                 (entityTagCol.sort!.changes | ngrxPush)?.value || null
               "
@@ -61,7 +63,7 @@
 
             <!-- ENUM TAG HEADER -->
             <th
-              *ngIf="col | guardType : colGuards.isEnumTagCol as enumTagCol"
+              *ngIf="col | guardType: colGuards.isEnumTagCol as enumTagCol"
               [nzColumnKey]="enumTagCol.key"
               [nzAlign]="enumTagCol.align ?? 'left'"
               [nzWidth]="enumTagCol.width"
@@ -74,7 +76,7 @@
 
             <!-- TEXT TAG HEADER -->
             <th
-              *ngIf="col | guardType : colGuards.isTextTagCol as textTagCol"
+              *ngIf="col | guardType: colGuards.isTextTagCol as textTagCol"
               [nzColumnKey]="textTagCol.key"
               [nzAlign]="textTagCol.align ?? 'left'"
               [nzWidth]="textTagCol.width"
@@ -93,7 +95,7 @@
           <ng-container *ngIf="!col.hidden">
             <!-- SELECT FILTER -->
             <th
-              *ngIf="col | guardType : colGuards.isSelectCol as selectCol"
+              *ngIf="col | guardType: colGuards.isSelectCol as selectCol"
               [nzColumnKey]="selectCol.key"
               [nzAlign]="selectCol.align ?? 'left'"
               [nzWidth]="selectCol.width"
@@ -104,7 +106,7 @@
 
             <!-- ENTITY TAG FILTER -->
             <th
-              *ngIf="col | guardType : colGuards.isEntityTagCol as entityTagCol"
+              *ngIf="col | guardType: colGuards.isEntityTagCol as entityTagCol"
               [nzColumnKey]="entityTagCol.key"
               [nzWidth]="entityTagCol.width"
               [nzAlign]="entityTagCol.align ?? 'left'"
@@ -116,9 +118,15 @@
                 [cvcPlaceholder]="entityTagCol.filter.options[0].key"
                 [cvcModel]="entityTagCol.filter.options[0].value"
                 (cvcModelChange)="
-                  filter.transform ? 
-                  filter.changes!.next({ key: entityTagCol.key, value: filter.transform($event) }) :
-                  filter.changes!.next({ key: entityTagCol.key, value: $event })
+                  filter.transform
+                    ? filter.changes!.next({
+                        key: entityTagCol.key,
+                        value: filter.transform($event)
+                      })
+                    : filter.changes!.next({
+                        key: entityTagCol.key,
+                        value: $event
+                      })
                 ">
               </cvc-table-filter-input>
             </th>
@@ -126,15 +134,15 @@
             <!-- ENUM TAG FILTER -->
             <th
               #enumTableFilter
-              *ngIf="col | guardType : colGuards.isEnumTagCol as enumTagCol"
+              *ngIf="col | guardType: colGuards.isEnumTagCol as enumTagCol"
               [nzColumnKey]="enumTagCol.key"
               class="attribute-filter"
               [nzWidth]="enumTagCol.width"
               [nzAlign]="enumTagCol.align ?? 'left'"
               [nzLeft]="enumTagCol.fixedLeft || false"
               [nzRight]="enumTagCol.fixedRight || false"
-              [nzShowSort]="true"
-              [nzSortFn]="true"
+              [nzShowSort]="!enumTagCol.sort.disabled"
+              [nzSortFn]="!enumTagCol.sort.disabled"
               [nzSortOrder]="
                 (enumTagCol.sort!.changes | ngrxPush)?.value || null
               "
@@ -174,7 +182,7 @@
             <!-- TEXT TAG FILTER -->
             <th
               #enumTableFilter
-              *ngIf="col | guardType : colGuards.isTextTagCol as textTagCol"
+              *ngIf="col | guardType: colGuards.isTextTagCol as textTagCol"
               [nzColumnKey]="textTagCol.key"
               class="attribute-filter"
               [nzWidth]="textTagCol.width"
@@ -223,7 +231,7 @@
             <ng-container *ngIf="!col.hidden">
               <!-- SELECT CELL -->
               <td
-                *ngIf="col | guardType : colGuards.isSelectCol as selectCol"
+                *ngIf="col | guardType: colGuards.isSelectCol as selectCol"
                 [nzChecked]="row.selected"
                 (nzCheckedChange)="
                   onRowSelected$.next({ id: row.id, selected: $event })
@@ -235,7 +243,7 @@
               <!-- ENTITY TAG CELL -->
               <td
                 *ngIf="
-                  col | guardType : colGuards.isEntityTagCol as entityTagCol
+                  col | guardType: colGuards.isEntityTagCol as entityTagCol
                 "
                 [nzAlign]="entityTagCol.align ?? 'left'"
                 [nzLeft]="entityTagCol.fixedLeft || false"
@@ -267,7 +275,6 @@
                   let-emphasize="emphasize">
                   <ng-container
                     *ngIf="data.length > 0; else emptyEntityTagCell">
-
                     <!-- display full size tags up to maxTags length -->
                     <cvc-entity-tag-list
                       [cvcTagTemplate]="entityTag"
@@ -332,7 +339,7 @@
 
               <!-- ENUM TAG CELL -->
               <td
-                *ngIf="col | guardType : colGuards.isEnumTagCol as enumTagCol"
+                *ngIf="col | guardType: colGuards.isEnumTagCol as enumTagCol"
                 [nzAlign]="enumTagCol.align ?? 'left'"
                 [nzLeft]="enumTagCol.fixedLeft || false"
                 [nzRight]="enumTagCol.fixedRight || false">
@@ -356,7 +363,7 @@
 
               <!-- TEXT TAG CELL -->
               <td
-                *ngIf="col | guardType : colGuards.isTextTagCol as textTagCol"
+                *ngIf="col | guardType: colGuards.isTextTagCol as textTagCol"
                 [nzAlign]="textTagCol.align ?? 'left'"
                 [nzLeft]="textTagCol.fixedLeft || false"
                 [nzRight]="textTagCol.fixedRight || false">

--- a/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.config.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.config.ts
@@ -32,7 +32,6 @@ export const columnKeyToSortColumnMap: EvidenceManagerColSortMap = {
   id: EvidenceSortColumns.Id,
   significance: EvidenceSortColumns.Significance,
   status: EvidenceSortColumns.Status,
-  therapies: EvidenceSortColumns.TherapyName,
   variantOrigin: EvidenceSortColumns.VariantOrigin,
 }
 
@@ -115,7 +114,7 @@ export class EvidenceManagerConfig {
             } else {
               return null
             }
-          }
+          },
         },
       },
       {
@@ -163,7 +162,9 @@ export class EvidenceManagerConfig {
         label: 'Therapies',
         type: 'entity-tag',
         width: '275px',
-        sort: {},
+        sort: {
+          disabled: true,
+        },
         tag: {
           maxTags: 2,
           truncateLabel: '150px',

--- a/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.types.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.types.ts
@@ -90,9 +90,9 @@ export type EvidenceManagerColSortMap = {
   [key in EvidenceManagerColKey]?: EvidenceSortColumns
 }
 
-export type EvidenceManagerColQueryMap =  {
-    [key in EvidenceManagerColKey]?: ConvertedQueryVar
-  }
+export type EvidenceManagerColQueryMap = {
+  [key in EvidenceManagerColKey]?: ConvertedQueryVar
+}
 
 // array of column configs, will be rendered left-to-right in array order
 export type EvidenceManagerTableConfig = ColumnConfig[]
@@ -130,7 +130,7 @@ interface InputFilterConfig {
     inputType: 'default' | 'numeric'
     typename?: string
     options: [{ key: string; value: string | number | null }]
-    changes?: Subject<CvcFilterChange>,
+    changes?: Subject<CvcFilterChange>
     transform?: (v: string | number | null) => string | number | null
   }
 }
@@ -140,6 +140,7 @@ export interface SortConfig {
   sort: {
     default?: NzTableSortOrder
     changes?: Subject<CvcSortChange>
+    disabled?: boolean
   }
 }
 
@@ -276,33 +277,25 @@ export type RequestError = {
 
 // Type guard fns for TypeGuard pipe. Required to simplify the construction of
 // generic template logic, a kludge to prevent *ngFor from getting clobbered
-export const isDefaultColumn: TypeGuard<
-  ColumnConfig,
-  DefaultColumnType
-> = (option: ColumnConfig): option is DefaultColumnType =>
-  option.type === 'default'
+export const isDefaultColumn: TypeGuard<ColumnConfig, DefaultColumnType> = (
+  option: ColumnConfig
+): option is DefaultColumnType => option.type === 'default'
 
 export const isSelectColumn: TypeGuard<ColumnConfig, SelectColumnType> = (
   option: ColumnConfig
 ): option is SelectColumnType => option.type === 'select'
 
-export const isEntityTagOptions: TypeGuard<
-  ColumnConfig,
-  EntityTagType
-> = (option: ColumnConfig): option is EntityTagType =>
-  option.type === 'entity-tag'
+export const isEntityTagOptions: TypeGuard<ColumnConfig, EntityTagType> = (
+  option: ColumnConfig
+): option is EntityTagType => option.type === 'entity-tag'
 
-export const isEnumTagOptions: TypeGuard<
-  ColumnConfig,
-  EnumTagType
-> = (option: ColumnConfig): option is EnumTagType =>
-  option.type === 'enum-tag'
+export const isEnumTagOptions: TypeGuard<ColumnConfig, EnumTagType> = (
+  option: ColumnConfig
+): option is EnumTagType => option.type === 'enum-tag'
 
-export const isTextTagOptions: TypeGuard<
-  ColumnConfig,
-  TextTagType
-> = (option: ColumnConfig): option is TextTagType =>
-  option.type === 'text-tag'
+export const isTextTagOptions: TypeGuard<ColumnConfig, TextTagType> = (
+  option: ColumnConfig
+): option is TextTagType => option.type === 'text-tag'
 
 export const colTypeGuards = {
   isSelectCol: isSelectColumn,

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -472,8 +472,7 @@ export enum AssertionSortColumns {
   Id = 'ID',
   Significance = 'SIGNIFICANCE',
   Status = 'STATUS',
-  Summary = 'SUMMARY',
-  TherapyName = 'THERAPY_NAME'
+  Summary = 'SUMMARY'
 }
 
 export enum AssertionType {
@@ -1941,7 +1940,6 @@ export enum EvidenceSortColumns {
   Id = 'ID',
   Significance = 'SIGNIFICANCE',
   Status = 'STATUS',
-  TherapyName = 'THERAPY_NAME',
   VariantOrigin = 'VARIANT_ORIGIN'
 }
 

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -781,7 +781,6 @@ enum AssertionSortColumns {
   SIGNIFICANCE
   STATUS
   SUMMARY
-  THERAPY_NAME
 }
 
 enum AssertionType {
@@ -3008,7 +3007,6 @@ enum EvidenceSortColumns {
   ID
   SIGNIFICANCE
   STATUS
-  THERAPY_NAME
   VARIANT_ORIGIN
 }
 

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -3482,12 +3482,6 @@
               "deprecationReason": null
             },
             {
-              "name": "THERAPY_NAME",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "STATUS",
               "description": null,
               "isDeprecated": false,
@@ -15543,12 +15537,6 @@
             },
             {
               "name": "DISEASE_NAME",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "THERAPY_NAME",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/server/app/graphql/resolvers/top_level_assertions.rb
+++ b/server/app/graphql/resolvers/top_level_assertions.rb
@@ -1,6 +1,8 @@
 require 'search_object/plugin/graphql'
 
 class Resolvers::TopLevelAssertions < GraphQL::Schema::Resolver
+  @@base_select_fields = ['evidence_items_count', 'id']
+
   include SearchObject.module(:graphql)
 
   type Types::Entities::AssertionType.connection_type, null: false
@@ -11,7 +13,13 @@ class Resolvers::TopLevelAssertions < GraphQL::Schema::Resolver
     Assertion
       .order("evidence_items_count DESC")
       .where.not(status: 'rejected')
+      .select(generate_select)
   }
+
+  def generate_select(field = nil)
+    query_fields = @@base_select_fields.dup.prepend(field).compact
+    "DISTINCT ON (#{query_fields.join(",")}) assertions.*"
+  end
 
   option(:id, type: GraphQL::Types::Int, description: 'Exact match filtering on the ID of the assertion.') do |scope, value|
     scope.where("assertions.id = ?", value)
@@ -85,26 +93,12 @@ class Resolvers::TopLevelAssertions < GraphQL::Schema::Resolver
 
   option :sort_by, type: Types::BrowseTables::AssertionSortType, description: 'Columm and direction to sort evidence on.' do |scope, value|
     case value.column
-    when 'ID'
-      scope.reorder("assertions.id #{value.direction}")
     when 'DISEASE_NAME'
       scope.joins(:disease).reorder("diseases.name #{value.direction}")
-    when 'THERAPY_NAME'
-      scope.joins(:therapies).reorder("therapies.name #{value.direction}")
-    when 'SUMMARY'
-      scope.reorder("assertions.summary #{value.direction}")
-    when 'ASSERTION_TYPE'
-      scope.reorder("assertion_type #{value.direction}")
-    when 'STATUS'
-      scope.reorder("status #{value.direction}")
-    when 'ASSERTION_DIRECTION'
-      scope.reorder("assertion_direction #{value.direction}")
-    when 'SIGNIFICANCE'
-      scope.reorder("significance #{value.direction}")
-    when 'AMP_LEVEL'
-      scope.reorder("amp_level #{value.direction}")
-    when 'EVIDENCE_ITEMS_COUNT'
-      scope.reorder("evidence_items_count #{value.direction}")
+        .reselect(generate_select("diseases.name"))
+    else
+      scope.reorder("#{value.column.downcase} #{value.direction}")
+        .reselect(generate_select(value.column.downcase))
     end
   end
 end

--- a/server/app/graphql/resolvers/top_level_evidence_items.rb
+++ b/server/app/graphql/resolvers/top_level_evidence_items.rb
@@ -1,6 +1,8 @@
 require 'search_object/plugin/graphql'
 
 class Resolvers::TopLevelEvidenceItems < GraphQL::Schema::Resolver
+  @@base_select_fields = ['evidence_level', 'rating', 'id']
+
   include SearchObject.module(:graphql)
 
   type Types::Entities::EvidenceItemType.connection_type, null: false
@@ -12,8 +14,13 @@ class Resolvers::TopLevelEvidenceItems < GraphQL::Schema::Resolver
       .all
       .order("evidence_level ASC, rating DESC, id ASC")
       .where.not(status: 'rejected')
-      .distinct
+      .select(generate_select)
   }
+
+  def generate_select(field = nil)
+    query_fields = @@base_select_fields.dup.prepend(field).compact
+    "DISTINCT ON (#{query_fields.join(",")}) evidence_items.*"
+  end
 
   option(:id, type: GraphQL::Types::Int, description: 'Exact match filtering on the ID of the evidence item.') do |scope, value|
     scope.where("evidence_items.id = ?", value)
@@ -97,28 +104,14 @@ class Resolvers::TopLevelEvidenceItems < GraphQL::Schema::Resolver
 
   option :sort_by, type: Types::BrowseTables::EvidenceSortType, description: 'Columm and direction to sort evidence on.' do |scope, value|
     case value.column
-    when 'ID'
-      scope.reorder("id #{value.direction}")
     when 'DISEASE_NAME'
-      scope.joins(:disease).reorder("diseases.name #{value.direction}")
-    when 'THERAPY_NAME'
-      scope.joins(:therapies).reorder("therapies.name #{value.direction}")
-    when 'DESCRIPTION'
-      scope.reorder("description #{value.direction}")
-    when 'EVIDENCE_LEVEL'
-      scope.reorder("evidence_level #{value.direction}")
+      scope.left_joins(:disease).reorder("diseases.name #{value.direction} NULLS LAST")
+        .reselect(generate_select("diseases.name"))
     when 'EVIDENCE_RATING'
-      scope.reorder("rating #{value.direction}")
-    when 'STATUS'
-      scope.reorder("status #{value.direction}")
-    when 'EVIDENCE_TYPE'
-      scope.reorder("evidence_type #{value.direction}")
-    when 'EVIDENCE_DIRECTION'
-      scope.reorder("evidence_direction #{value.direction}")
-    when 'SIGNIFICANCE'
-      scope.reorder("significance #{value.direction}")
-    when 'VARIANT_ORIGIN'
-      scope.reorder("variant_origin #{value.direction}")
+      scope.reorder("rating #{value.direction} NULLS LAST")
+    else
+      scope.reorder("#{value.column.downcase} #{value.direction}")
+        .reselect(generate_select(value.column.downcase))
     end
   end
 end

--- a/server/app/graphql/types/base_connection.rb
+++ b/server/app/graphql/types/base_connection.rb
@@ -13,7 +13,11 @@ module Types
     node_nullable(false)
 
     def total_count
-      object.items&.count
+      if object.items&.is_a?(ActiveRecord::Relation)
+        object.items.reselect("#{object.items.table_name}.id").count
+      else
+        object.items&.count
+      end
     end
 
     def page_count

--- a/server/app/graphql/types/browse_tables/assertion_sort_columns.rb
+++ b/server/app/graphql/types/browse_tables/assertion_sort_columns.rb
@@ -3,7 +3,6 @@ module Types::BrowseTables
     value 'ID'
     value 'DISEASE_NAME'
     value 'SUMMARY'
-    value 'THERAPY_NAME'
     value 'STATUS'
     value 'ASSERTION_TYPE'
     value 'ASSERTION_DIRECTION'

--- a/server/app/graphql/types/browse_tables/evidence_sort_columns.rb
+++ b/server/app/graphql/types/browse_tables/evidence_sort_columns.rb
@@ -2,7 +2,6 @@ module Types::BrowseTables
   class EvidenceSortColumns < Types::BaseEnum
     value 'ID'
     value 'DISEASE_NAME'
-    value 'THERAPY_NAME'
     value 'DESCRIPTION'
     value 'EVIDENCE_LEVEL'
     value 'EVIDENCE_RATING'


### PR DESCRIPTION
closes #1051 


This PR ensures duplicate results do not appear on browse tables as a result of joining across tables. It also disables sorting where it doesn't make sense to support it (ie: when there are multiple items)