### PR TITLE
Improve Submission Comment display when no comment exists

### DIFF
--- a/client/src/app/components/activities/activity-feed/activity-feed.component.html
+++ b/client/src/app/components/activities/activity-feed/activity-feed.component.html
@@ -29,8 +29,7 @@
             {{ activity.verbiage }}
             @switch (activity.subject.__typename) {
               @case ('Feature') {
-                <cvc-feature-tag
-                  [feature]="activity.subject"></cvc-feature-tag>
+                <cvc-feature-tag [feature]="activity.subject"></cvc-feature-tag>
               }
               @case ('Assertion') {
                 <cvc-assertion-tag

--- a/client/src/app/components/comments/comment-display/comment-display.component.html
+++ b/client/src/app/components/comments/comment-display/comment-display.component.html
@@ -11,7 +11,15 @@
       nzIcon="civic:curator"></nz-avatar>
   </ng-template>
   <nz-comment-content>
-    <cvc-comment-body
-      [commentBodySegments]="comment.parsedComment"></cvc-comment-body>
+    @if (comment.parsedComment.length == 0) {
+      <span
+        nz-typography
+        nzType="secondary">
+        <i>No Comment Provided</i>
+      </span>
+    } @else {
+      <cvc-comment-body
+        [commentBodySegments]="comment.parsedComment"></cvc-comment-body>
+    }
   </nz-comment-content>
 </nz-comment>

--- a/client/src/app/components/comments/comment-display/comment-display.component.ts
+++ b/client/src/app/components/comments/comment-display/comment-display.component.ts
@@ -1,14 +1,14 @@
 import { Component, Input, OnInit } from '@angular/core'
-import { Comment, CommentBodySegment, Maybe, Scalars } from '@app/generated/civic.apollo'
+import { CommentBodySegment, Maybe } from '@app/generated/civic.apollo'
 
 export interface CommenterInterface {
-  displayName: string,
+  displayName: string
   profileImagePath: Maybe<string>
 }
 
-export interface CommentInterface  {
-  createdAt: string | number,
-  parsedComment: CommentBodySegment[],
+export interface CommentInterface {
+  createdAt: string | number
+  parsedComment: CommentBodySegment[]
   commenter: CommenterInterface
 }
 

--- a/client/src/app/components/comments/comment-display/comment-display.module.ts
+++ b/client/src/app/components/comments/comment-display/comment-display.module.ts
@@ -5,6 +5,7 @@ import { NzCommentModule } from 'ng-zorro-antd/comment'
 import { NzAvatarModule } from 'ng-zorro-antd/avatar'
 import { CvcCommentBodyModule } from '../comment-body/comment-body.module'
 import { CvcPipesModule } from '@app/core/pipes/pipes.module'
+import { NzTypographyModule } from 'ng-zorro-antd/typography'
 
 @NgModule({
   declarations: [CvcCommentDisplayComponent],
@@ -12,8 +13,9 @@ import { CvcPipesModule } from '@app/core/pipes/pipes.module'
     CommonModule,
     NzCommentModule,
     NzAvatarModule,
+    NzTypographyModule,
     CvcCommentBodyModule,
-    CvcPipesModule
+    CvcPipesModule,
   ],
   exports: [CvcCommentDisplayComponent],
 })


### PR DESCRIPTION
Instead of a comment box with no comment, this will display secondary text indicating that a submission comment was not provided.