### PR TITLE
Filter out sources without citations from browse view

### DIFF
--- a/server/app/graphql/resolvers/browse_sources.rb
+++ b/server/app/graphql/resolvers/browse_sources.rb
@@ -9,6 +9,7 @@ class Resolvers::BrowseSources < GraphQL::Schema::Resolver
 
   scope do
     MaterializedViews::SourceBrowseTableRow.order('source_suggestion_count desc')
+      .where.not(citation: nil)
       .order('evidence_item_count desc')
       .all
   end


### PR DESCRIPTION
The ongoing issues with the ASCO API means ASCO sources are being left in stubbed state. This causes issues when they're returned in the browse views with non-nullable fields as null.

Until we can get a longer term ASCO fix in place, just filter them out of the browse view results.



fixes (the filtering bug in) #1022 