### PR TITLE
Allow evidence and assertion tables to be filtered by status

### DIFF
--- a/client/src/app/components/assertions/assertions-table/assertions-table.component.html
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.component.html
@@ -498,4 +498,44 @@
     <span>Loading…</span>
   </nz-tag>
   <cvc-no-more-rows [cvcShowTag]="noMoreRows$ | ngrxPush"></cvc-no-more-rows>
+  <nz-filter-trigger
+    [(nzVisible)]="statusFilterVisible"
+    [nzDropdownMenu]="statusFilterMenu">
+    <span
+      nz-icon
+      nzType="filter"
+      nzTheme="fill"></span>
+  </nz-filter-trigger>
 </ng-template>
+
+<nz-dropdown-menu #statusFilterMenu>
+  <nz-radio-group
+    [(ngModel)]="statusInput"
+    (ngModelChange)="statusChanged()">
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.NonRejected"
+      >Non-Rejected</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.Accepted"
+      >Accepted</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.Submitted"
+      >Submitted</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.Rejected"
+      >Rejected</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.All"
+      >All</label
+    >
+  </nz-radio-group>
+</nz-dropdown-menu>

--- a/client/src/app/components/assertions/assertions-table/assertions-table.component.ts
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.component.ts
@@ -26,6 +26,7 @@ import {
   EvidenceType,
   Maybe,
   PageInfo,
+  EvidenceLevel,
 } from '@app/generated/civic.apollo'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { QueryRef } from 'apollo-angular'
@@ -118,6 +119,10 @@ export class CvcAssertionsTableComponent implements OnInit {
   SignificanceInput: Maybe<EvidenceSignificance>
   molecularProfileNameInput: Maybe<string>
   ampLevelInput: Maybe<AmpLevel>
+  statusInput: Maybe<EvidenceStatusFilter> = EvidenceStatusFilter.NonRejected
+
+  availableStatusFilters = EvidenceStatusFilter
+  statusFilterVisible = false
 
   sortColumns: typeof AssertionSortColumns = AssertionSortColumns
 
@@ -144,7 +149,7 @@ export class CvcAssertionsTableComponent implements OnInit {
       phenotypeId: this.phenotypeId,
       diseaseId: this.diseaseId,
       therapyId: this.therapyId,
-      status: this.status,
+      status: this.status || EvidenceStatusFilter.NonRejected,
     })
 
     this.result$ = this.queryRef.valueChanges
@@ -255,6 +260,7 @@ export class CvcAssertionsTableComponent implements OnInit {
       molecularProfileName: this.molecularProfileNameInput,
       therapyName: this.therapyNameInput,
       summary: this.summaryInput,
+      status: this.statusInput,
       assertionType: this.assertionTypeInput
         ? this.assertionTypeInput
         : undefined,
@@ -276,8 +282,16 @@ export class CvcAssertionsTableComponent implements OnInit {
     this.loadedPages += 1
   }
 
+  statusChanged() {
+    this.debouncedQuery.next()
+    this.statusFilterVisible = false
+  }
+
   // virtual scroll helpers
-  trackByIndex(_: number, data: Maybe<AssertionBrowseFieldsFragment>): Maybe<number> {
+  trackByIndex(
+    _: number,
+    data: Maybe<AssertionBrowseFieldsFragment>
+  ): Maybe<number> {
     return data?.id
   }
 

--- a/client/src/app/components/assertions/assertions-table/assertions-table.module.ts
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.module.ts
@@ -27,6 +27,8 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
 import { NzTypographyModule } from 'ng-zorro-antd/typography'
 import { CvcAssertionsTagModule } from '../assertions-tag/assertions-tag.module'
 import { CvcAssertionsTableComponent } from './assertions-table.component'
+import { NzDropDownModule } from 'ng-zorro-antd/dropdown'
+import { NzRadioModule } from 'ng-zorro-antd/radio'
 
 @NgModule({
   declarations: [CvcAssertionsTableComponent],
@@ -46,6 +48,8 @@ import { CvcAssertionsTableComponent } from './assertions-table.component'
     NzTagModule,
     NzToolTipModule,
     NzTypographyModule,
+    NzDropDownModule,
+    NzRadioModule,
 
     CvcAssertionsTagModule,
     CvcAutoHeightCardModule,

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.html
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.html
@@ -644,4 +644,44 @@
     <span>Loading…</span>
   </nz-tag>
   <cvc-no-more-rows [cvcShowTag]="noMoreRows$ | ngrxPush"></cvc-no-more-rows>
+  <nz-filter-trigger
+    [(nzVisible)]="statusFilterVisible"
+    [nzDropdownMenu]="statusFilterMenu">
+    <span
+      nz-icon
+      nzType="filter"
+      nzTheme="fill"></span>
+  </nz-filter-trigger>
 </ng-template>
+
+<nz-dropdown-menu #statusFilterMenu>
+  <nz-radio-group
+    [(ngModel)]="statusInput"
+    (ngModelChange)="statusChanged()">
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.NonRejected"
+      >Non-Rejected</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.Accepted"
+      >Accepted</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.Submitted"
+      >Submitted</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.Rejected"
+      >Rejected</label
+    >
+    <label
+      nz-radio-button
+      [nzValue]="availableStatusFilters.All"
+      >All</label
+    >
+  </nz-radio-group>
+</nz-dropdown-menu>

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.ts
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.ts
@@ -58,6 +58,7 @@ export interface EvidenceTableUserFilters {
   evidenceRatingInput?: Maybe<number>
   molecularProfileNameInput?: Maybe<string>
   geneSymbolInput?: Maybe<string>
+  statusInput?: Maybe<EvidenceStatusFilter>
 }
 
 @UntilDestroy()
@@ -126,11 +127,18 @@ export class CvcEvidenceTableComponent implements OnInit {
   evidenceTypeInput: Maybe<EvidenceType>
   molecularProfileNameInput: Maybe<string>
   variantOriginInput: Maybe<VariantOrigin>
+  statusInput: Maybe<EvidenceStatusFilter> = EvidenceStatusFilter.NonRejected
+
+  availableStatusFilters = EvidenceStatusFilter
+  statusFilterVisible = false
 
   sortColumns = EvidenceSortColumns
   evidenceLevels = EvidenceLevel
 
-  constructor(private gql: EvidenceBrowseGQL, private cdr: ChangeDetectorRef) {
+  constructor(
+    private gql: EvidenceBrowseGQL,
+    private cdr: ChangeDetectorRef
+  ) {
     this.noMoreRows$ = new BehaviorSubject<boolean>(false)
     this.scrollEvent$ = new BehaviorSubject<ScrollEvent>('stop')
     this.sortChange$ = new Subject<SortDirectionEvent>()
@@ -160,7 +168,7 @@ export class CvcEvidenceTableComponent implements OnInit {
       phenotypeId: this.phenotypeId,
       rating: this.evidenceRatingInput ? this.evidenceRatingInput : undefined,
       sourceId: this.sourceId,
-      status: this.status,
+      status: this.status || EvidenceStatusFilter.NonRejected,
       userId: this.userId,
       variantId: this.variantId,
       molecularProfileId: this.molecularProfileId,
@@ -278,6 +286,7 @@ export class CvcEvidenceTableComponent implements OnInit {
         diseaseName: this.diseaseNameInput,
         therapyName: this.therapyNameInput,
         description: this.descriptionInput,
+        status: this.statusInput,
         evidenceLevel: this.evidenceLevelInput
           ? this.evidenceLevelInput
           : undefined,
@@ -303,7 +312,15 @@ export class CvcEvidenceTableComponent implements OnInit {
     this.cdr.detectChanges()
   }
 
-  trackByIndex(_: number, data: Maybe<EvidenceGridFieldsFragment>): Maybe<number> {
+  statusChanged() {
+    this.filterChange$.next()
+    this.statusFilterVisible = false
+  }
+
+  trackByIndex(
+    _: number,
+    data: Maybe<EvidenceGridFieldsFragment>
+  ): Maybe<number> {
     return data?.id
   }
 }

--- a/client/src/app/components/evidence/evidence-table/evidence-table.module.ts
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.module.ts
@@ -28,6 +28,8 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
 import { NzTypographyModule } from 'ng-zorro-antd/typography'
 import { CvcEvidenceTagModule } from '../evidence-tag/evidence-tag.module'
 import { CvcEvidenceTableComponent } from './evidence-table.component'
+import { NzDropDownModule } from 'ng-zorro-antd/dropdown'
+import { NzRadioModule } from 'ng-zorro-antd/radio'
 
 @NgModule({
   declarations: [CvcEvidenceTableComponent],
@@ -49,6 +51,8 @@ import { CvcEvidenceTableComponent } from './evidence-table.component'
     NzTagModule,
     NzToolTipModule,
     NzTypographyModule,
+    NzDropDownModule,
+    NzRadioModule,
 
     CvcAutoHeightCardModule,
     CvcAutoHeightTableModule,

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -2084,6 +2084,7 @@ export enum EvidenceStatus {
 export enum EvidenceStatusFilter {
   Accepted = 'ACCEPTED',
   All = 'ALL',
+  NonRejected = 'NON_REJECTED',
   Rejected = 'REJECTED',
   Submitted = 'SUBMITTED'
 }

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -3239,6 +3239,7 @@ enum EvidenceStatus {
 enum EvidenceStatusFilter {
   ACCEPTED
   ALL
+  NON_REJECTED
   REJECTED
   SUBMITTED
 }

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -16765,6 +16765,12 @@
               "deprecationReason": null
             },
             {
+              "name": "NON_REJECTED",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "ALL",
               "description": null,
               "isDeprecated": false,

--- a/server/app/graphql/resolvers/top_level_assertions.rb
+++ b/server/app/graphql/resolvers/top_level_assertions.rb
@@ -86,13 +86,14 @@ class Resolvers::TopLevelAssertions < GraphQL::Schema::Resolver
     scope.joins(:therapies).where('therapies.id = ?', value)
   end
   option(:status, type: Types::EvidenceStatusFilterType, description: "Filtering on the status of the assertion.") do |scope, value|
-    if value != 'ALL'
-      scope.unscope(where: :status).where(status: value)
-    else
+    if value == 'ALL'
       scope.unscope(where: :status)
+    elsif value == 'NON_REJECTED'
+      scope.unscope(where: :status).where.not(status: 'rejected')
+    else
+      scope.unscope(where: :status).where(status: value)
     end
   end
-
 
   option :sort_by, type: Types::BrowseTables::AssertionSortType, description: 'Columm and direction to sort evidence on.' do |scope, value|
     case value.column

--- a/server/app/graphql/resolvers/top_level_evidence_items.rb
+++ b/server/app/graphql/resolvers/top_level_evidence_items.rb
@@ -71,10 +71,12 @@ class Resolvers::TopLevelEvidenceItems < GraphQL::Schema::Resolver
     scope.where(rating: value)
   end
   option(:status, type: Types::EvidenceStatusFilterType, description: 'Filtering on the evidence status.') do |scope, value|
-    if value != 'ALL'
-      scope.unscope(where: :status).where(status: value)
-    else
+    if value == 'ALL'
       scope.unscope(where: :status)
+    elsif value == 'NON_REJECTED'
+      scope.unscope(where: :status).where.not(status: 'rejected')
+    else
+      scope.unscope(where: :status).where(status: value)
     end
   end
   option(:phenotype_id, type: GraphQL::Types::Int, description: 'Exact match filtering of the evidence items based on the internal CIViC phenotype id') do |scope, value|

--- a/server/app/graphql/types/evidence_status_filter_type.rb
+++ b/server/app/graphql/types/evidence_status_filter_type.rb
@@ -3,6 +3,7 @@ module Types
     value 'ACCEPTED', value: 'accepted'
     value 'SUBMITTED', value: 'submitted'
     value 'REJECTED', value: 'rejected'
+    value 'NON_REJECTED'
     value 'ALL'
   end
 end


### PR DESCRIPTION
Default to showing all non-rejected, but allow users to pick any status or "show all"

![Screenshot 2024-08-22 at 3 04 48 PM](https://github.com/user-attachments/assets/8168d348-9fc0-43eb-b0e5-8d878a41df7c)



closes #1088