### PR TITLE
Various fusion bugfixes

### DIFF
--- a/server/app/graphql/types/queries/typeahead_queries.rb
+++ b/server/app/graphql/types/queries/typeahead_queries.rb
@@ -81,13 +81,13 @@ module Types::Queries
         base_query = Disease.where(deprecated: false)
         results = base_query.where("diseases.name ILIKE ?", "%#{query_term}%")
           .or(base_query.where("diseases.doid ILIKE ?", "#{query_term}%"))
-          .order("LENGTH(diseases.name) ASC")
+          #.order("LENGTH(diseases.name) ASC")
           .limit(10)
         if results.size < 10
           secondary_results = base_query.eager_load(:disease_aliases)
             .where("disease_aliases.name ILIKE ?", "%#{query_term}%")
             .where.not(id: results.select('id'))
-            .order("LENGTH(diseases.name) ASC")
+            #.order("LENGTH(diseases.name) ASC")
             .distinct
             .limit(10-results.size)
           return results + secondary_results
@@ -100,7 +100,7 @@ module Types::Queries
         base_query = Therapy.where(deprecated: false)
         results = base_query.where("therapies.name ILIKE ?", "#{query_term}%")
           .or(base_query.where("therapies.ncit_id ILIKE ?", "%#{query_term}%"))
-          .order("LENGTH(therapies.name) ASC")
+          #.order("LENGTH(therapies.name) ASC")
           .limit(10)
         if results.size < 10
           secondary_results = base_query.where('therapies.name ILIKE ?', "%#{query_term}%")
@@ -110,7 +110,7 @@ module Types::Queries
             tertiary_results = base_query.eager_load(:therapy_aliases)
               .where("therapy_aliases.name ILIKE ?", "%#{query_term}%")
               .where.not(id: results.select('id') + secondary_results.select('id'))
-              .order("LENGTH(therapies.name) ASC")
+              #.order("LENGTH(therapies.name) ASC")
               .distinct
               .limit(10-results.size)
 
@@ -131,14 +131,14 @@ module Types::Queries
                      end
 
         results = base_query.where('features.name ILIKE ?', "#{query_term}%")
-          .order("LENGTH(features.name) ASC")
+          #.order("LENGTH(features.name) ASC")
           .limit(10)
 
         if results.size < 10
           secondary_results = base_query.eager_load(:feature_aliases)
             .where("feature_aliases.name ILIKE ?", "#{query_term}%")
             .where.not(id: results.select('id'))
-            .order("LENGTH(features.name) ASC")
+            #.order("LENGTH(features.name) ASC")
             .distinct
             .limit(10 - results.size)
           return (results + secondary_results).uniq

--- a/server/app/graphql/types/variants/gene_variant_type.rb
+++ b/server/app/graphql/types/variants/gene_variant_type.rb
@@ -42,7 +42,7 @@ module Types::Variants
     def open_revision_count
       Loaders::AssociationCountLoader.for(object.class, association: :open_revisions).load(object.id).then do |count|
         Loaders::AssociationLoader.for(Variants::GeneVariant, :coordinates).load(object).then do |coord|
-          Loaders::AssociationCountLoader.for(VariantCoordinate, association: :open_revisions).load(coord.id) do |coord_count|
+          Loaders::AssociationCountLoader.for(VariantCoordinate, association: :open_revisions).load(coord.id).then do |coord_count|
             count + coord_count
           end
         end

--- a/server/app/models/activities/create_variant.rb
+++ b/server/app/models/activities/create_variant.rb
@@ -32,7 +32,17 @@ module Activities
 
       @variant = cmd.variant
       @molecular_profile = cmd.molecular_profile
+
+      stub_coordinates
+      variant.save!
+
       events << cmd.events
+    end
+
+    def stub_coordinates
+      if variant.type == 'Variants::GeneVariant'
+        variant.coordinates = VariantCoordinate.generate_stub(variant, 'Gene Variant Coordinate')
+      end
     end
 
     def linked_entities


### PR DESCRIPTION
This PR addresses the following bugs:
- Closes #1118 by commenting out any order by LENGTH statements since they cause unexplained errors on production
- Coordinate stub wasn't being added when a new gene variant was created
- Closes #1120 by fixing the promise resolution for counts