### PR TITLE
Auto update clinical trial names and descriptions

### DIFF
--- a/server/app/jobs/populate_clinical_trial_record.rb
+++ b/server/app/jobs/populate_clinical_trial_record.rb
@@ -1,0 +1,5 @@
+class PopulateClinicalTrialRecord < ApplicationJob
+  def perform(clinical_trial)
+    Scrapers::ClinicalTrial.populate_fields(clinical_trial)
+  end
+end

--- a/server/app/lib/scrapers/clinical_trial.rb
+++ b/server/app/lib/scrapers/clinical_trial.rb
@@ -1,0 +1,27 @@
+module Scrapers
+  module ClinicalTrial
+    def self.populate_fields(clinical_trial)
+      resp = call_clinical_trials_api(clinical_trial.nct_id)
+      clinical_trial.description = resp.description
+      clinical_trial.name = resp.name
+      clinical_trial.save
+    end
+
+    def self.call_clinical_trials_api(nct_id)
+      http_resp = Util.make_get_request(url_for_nct_id(nct_id))
+      ClinicalTrialResponse.new(http_resp)
+    end
+
+    def self.url_for_nct_id(nct_id)
+      "https://clinicaltrials.gov/api/v2/studies/#{nct_id}?format=json&fields=#{fields}"
+    end
+
+    def self.fields
+      [
+        "protocolSection.identificationModule.nctId",
+        "protocolSection.identificationModule.briefTitle",
+        "protocolSection.descriptionModule.briefSummary"
+      ].join(",")
+    end
+  end
+end

--- a/server/app/lib/scrapers/clinical_trial_response.rb
+++ b/server/app/lib/scrapers/clinical_trial_response.rb
@@ -1,0 +1,24 @@
+module Scrapers
+  class ClinicalTrialResponse
+    attr_reader :json
+    def initialize(response_body)
+      @json = JSON.parse(response_body)
+    end
+
+    def nct_id
+      json.dig("protocolSection", "identificationModule", "nctId")
+    end
+
+    def name
+      json.dig("protocolSection", "identificationModule", "briefTitle")
+    end
+
+    def description
+      if desc = json.dig("protocolSection", "descriptionModule", "briefSummary")
+        desc.squish
+      else
+        nil
+      end
+    end
+  end
+end

--- a/server/app/models/clinical_trial.rb
+++ b/server/app/models/clinical_trial.rb
@@ -1,15 +1,25 @@
 class ClinicalTrial < ActiveRecord::Base
   has_and_belongs_to_many :sources
 
+  after_create :populate_additional_fields_if_needed
+
   def self.url_for(nct_id:)
     if nct_id.blank?
       nil
     else
-      "https://clinicaltrials.gov/ct2/show/#{nct_id}"
+      "https://clinicaltrials.gov/study/#{nct_id}"
     end
   end
 
   def link
     Rails.application.routes.url_helpers.url_for("/clinical-trials/#{self.id}")
+  end
+
+ 
+  private
+  def populate_additional_fields_if_needed
+    if self.name.blank? || self.description.blank?
+      PopulateClinicalTrialRecord.perform_later(self)
+    end
   end
 end


### PR DESCRIPTION
The API we were using in v1 no longer exists so this also updates the old jobs to use the new api.

We'll want to run a backfill in the console once deployed.