### PR TITLE
add explicit primary key to source browse model

### DIFF
--- a/server/app/models/materialized_views/source_browse_table_row.rb
+++ b/server/app/models/materialized_views/source_browse_table_row.rb
@@ -1,4 +1,5 @@
 class MaterializedViews::SourceBrowseTableRow < MaterializedViews::MaterializedView
+  self.primary_key = :id
   has_and_belongs_to_many :clinical_trials, join_table: :clinical_trials_sources, foreign_key: :source_id
 
   enum source_type: ['PubMed', 'ASCO', 'ASH']


### PR DESCRIPTION
This is required for the join across to clinical trials via the `has_and_belongs_to_many` relation.