### PR TITLE
add default placeholder text to country select on profile page

### DIFF
--- a/client/src/app/forms/components/user-profile/user-profile.form.html
+++ b/client/src/app/forms/components/user-profile/user-profile.form.html
@@ -46,6 +46,8 @@
       <nz-select
         [(ngModel)]="this.countryId"
         nzAllowClear
+        [nzDropdownMatchSelectWidth]="false"
+        nzPlaceHolder="Select a Country"
         nzShowSearch>
         <nz-option
           *ngFor="let country of countries$ | ngrxPush"


### PR DESCRIPTION
closes #1158 

This now behaves as expected. If no country is set, it will display `Select a Country` and if they save their profile without doing so, it will default to null.