### PR TITLE
use csv library to ensure correct quoting, squish internal whitespace

### DIFF
--- a/server/app/jobs/generate_tsvs.rb
+++ b/server/app/jobs/generate_tsvs.rb
@@ -1,12 +1,14 @@
+require 'csv'
 class GenerateTsvs < ApplicationJob
   def perform
     ensure_downloads_directory_exists
     tsvs_to_generate.each do |e|
       begin
         tmp_file = tmp_file(e.file_name)
-        tmp_file.puts(e.headers.join("\t"))
+        tmp_file.puts CSV.generate_line(e.headers, col_sep: "\t")
         e.objects.find_each do |object|
-          tmp_file.puts(e.row_from_object(object).join("\t"))
+          row = e.row_from_object(object).map {|col| col.is_a?(String) ? col.squish : col }
+          tmp_file.puts CSV.generate_line(row, col_sep: "\t", quote_empty: false)
         end
         tmp_file.close
         public_path = public_file_path(e.file_name)


### PR DESCRIPTION
This will remove any internal tabs or line breaks for description fields and also should ensure correct escaping of quotes in tsv exports.

closes #1157