### PR TITLE
add alias matching to MP name filtering

### DIFF
--- a/server/app/graphql/resolvers/top_level_molecular_profiles.rb
+++ b/server/app/graphql/resolvers/top_level_molecular_profiles.rb
@@ -35,7 +35,9 @@ class Resolvers::TopLevelMolecularProfiles < GraphQL::Schema::Resolver
     )
     ids = results.hits.map { |x| x["_id"] }
 
-    scope.where(molecular_profiles: { id: ids })
+    scope.left_joins(:molecular_profile_aliases).where(molecular_profiles: { id: ids })
+      .or(scope.where('molecular_profile_aliases.name ILIKE :query', {query: "%#{value}%"}))
+      .distinct
   end
 
   option(:gene_id, type: Int, description: "Filter molecular profiles to the CIViC id of the gene(s) involved.") do |scope, value|


### PR DESCRIPTION
This brings the filtering behavior into alignment between the Variant menu and MP menu on feature pages and also makes the behavior match what the documentation claims it does anyways.