### PR TITLE
Include MPs in the TSV if they are linked to an assertion

### DIFF
--- a/server/app/tsv_formatters/molecular_profile_tsv_formatter.rb
+++ b/server/app/tsv_formatters/molecular_profile_tsv_formatter.rb
@@ -1,8 +1,8 @@
 class MolecularProfileTsvFormatter
   def self.objects
     MolecularProfile.eager_load(:variants, :evidence_items, :assertions, :molecular_profile_aliases)
-      .joins(:evidence_items)
-      .where("evidence_items.status = 'accepted'")
+      .left_joins(:evidence_items)
+      .where("evidence_items.status = 'accepted' OR assertions.id IS NOT NULL")
   end
 
   def self.headers


### PR DESCRIPTION
Previously, only MPs with accepted evidence were included, this omitted MPs used in an Assertion that do not themselves have any evidence.