### PR TITLE
Rename gene tsv to feature tsv on the downloads page

### DIFF
--- a/client/src/app/generated/civic.apollo-helpers.ts
+++ b/client/src/app/generated/civic.apollo-helpers.ts
@@ -735,13 +735,13 @@ export type CreateVariantPayloadFieldPolicy = {
 	new?: FieldPolicy<any> | FieldReadFunction<any>,
 	variant?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type DataReleaseKeySpecifier = ('acceptedAndSubmittedVariantsVcf' | 'acceptedVariantsVcf' | 'assertionTsv' | 'evidenceTsv' | 'geneTsv' | 'molecularProfileTsv' | 'name' | 'variantGroupTsv' | 'variantTsv' | DataReleaseKeySpecifier)[];
+export type DataReleaseKeySpecifier = ('acceptedAndSubmittedVariantsVcf' | 'acceptedVariantsVcf' | 'assertionTsv' | 'evidenceTsv' | 'featureTsv' | 'molecularProfileTsv' | 'name' | 'variantGroupTsv' | 'variantTsv' | DataReleaseKeySpecifier)[];
 export type DataReleaseFieldPolicy = {
 	acceptedAndSubmittedVariantsVcf?: FieldPolicy<any> | FieldReadFunction<any>,
 	acceptedVariantsVcf?: FieldPolicy<any> | FieldReadFunction<any>,
 	assertionTsv?: FieldPolicy<any> | FieldReadFunction<any>,
 	evidenceTsv?: FieldPolicy<any> | FieldReadFunction<any>,
-	geneTsv?: FieldPolicy<any> | FieldReadFunction<any>,
+	featureTsv?: FieldPolicy<any> | FieldReadFunction<any>,
 	molecularProfileTsv?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	variantGroupTsv?: FieldPolicy<any> | FieldReadFunction<any>,

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -1552,7 +1552,7 @@ export type DataRelease = {
   acceptedVariantsVcf?: Maybe<DownloadableFile>;
   assertionTsv?: Maybe<DownloadableFile>;
   evidenceTsv?: Maybe<DownloadableFile>;
-  geneTsv?: Maybe<DownloadableFile>;
+  featureTsv?: Maybe<DownloadableFile>;
   molecularProfileTsv?: Maybe<DownloadableFile>;
   name: Scalars['String']['output'];
   variantGroupTsv?: Maybe<DownloadableFile>;
@@ -9728,9 +9728,9 @@ export type PhenotypeDetailQuery = { __typename: 'Query', phenotype?: { __typena
 export type DataReleasesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type DataReleasesQuery = { __typename: 'Query', dataReleases: Array<{ __typename: 'DataRelease', name: string, geneTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantGroupTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, evidenceTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, molecularProfileTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, assertionTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedAndSubmittedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined }> };
+export type DataReleasesQuery = { __typename: 'Query', dataReleases: Array<{ __typename: 'DataRelease', name: string, featureTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantGroupTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, evidenceTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, molecularProfileTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, assertionTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedAndSubmittedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined }> };
 
-export type ReleaseFragment = { __typename: 'DataRelease', name: string, geneTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantGroupTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, evidenceTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, molecularProfileTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, assertionTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedAndSubmittedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined };
+export type ReleaseFragment = { __typename: 'DataRelease', name: string, featureTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, variantGroupTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, evidenceTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, molecularProfileTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, assertionTsv?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined, acceptedAndSubmittedVariantsVcf?: { __typename: 'DownloadableFile', filename: string, path: string } | undefined };
 
 export type SourceDetailQueryVariables = Exact<{
   sourceId: Scalars['Int']['input'];
@@ -13265,7 +13265,7 @@ export const OrganizationMembersFieldsFragmentDoc = gql`
 export const ReleaseFragmentDoc = gql`
     fragment Release on DataRelease {
   name
-  geneTsv {
+  featureTsv {
     filename
     path
   }

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -2436,7 +2436,7 @@ type DataRelease {
   acceptedVariantsVcf: DownloadableFile
   assertionTsv: DownloadableFile
   evidenceTsv: DownloadableFile
-  geneTsv: DownloadableFile
+  featureTsv: DownloadableFile
   molecularProfileTsv: DownloadableFile
   name: String!
   variantGroupTsv: DownloadableFile

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -12394,7 +12394,7 @@
               "deprecationReason": null
             },
             {
-              "name": "geneTsv",
+              "name": "featureTsv",
               "description": null,
               "args": [],
               "type": {

--- a/client/src/app/views/releases/releases-main/releases-list.query.gql
+++ b/client/src/app/views/releases/releases-main/releases-list.query.gql
@@ -6,7 +6,7 @@ query DataReleases {
 
 fragment Release on DataRelease {
   name
-  geneTsv {
+  featureTsv {
     filename
     path
   }

--- a/client/src/app/views/releases/releases-main/releases-main.component.html
+++ b/client/src/app/views/releases/releases-main/releases-main.component.html
@@ -65,7 +65,7 @@
       <nz-row *nzSpaceItem>
         <p nz-typography>
           The CIViC server produces nightly and monthly releases that include a
-          subset of all primary entity records (Genes, Variants, Molecular
+          subset of all primary entity records (Features, Variants, Molecular
           Profiles, Evidence, Variant Groups, and Assertions). Both TSV and VCF
           versions are provided below - just locate the specific entity type and
           data format you wish to obtain, then click on the relevant button to
@@ -128,7 +128,7 @@
                 <thead>
                   <tr>
                     <th>Date</th>
-                    <th>Genes</th>
+                    <th>Features</th>
                     <th>Variants</th>
                     <th>Molecular Profiles</th>
                     <th>Evidence</th>
@@ -141,11 +141,11 @@
                 <tbody>
                   <tr *ngFor="let release of releasesTable.data">
                     <td>{{ release.name }}</td>
-                    <td *ngIf="release.geneTsv; else noData">
+                    <td *ngIf="release.featureTsv; else noData">
                       <cvc-link-tag
-                        [href]="release.geneTsv.path"
+                        [href]="release.featureTsv.path"
                         iconName="download">
-                        Genes TSV
+                        Features TSV
                       </cvc-link-tag>
                     </td>
                     <td *ngIf="release.variantTsv; else noData">

--- a/server/app/graphql/types/data_release_type.rb
+++ b/server/app/graphql/types/data_release_type.rb
@@ -10,7 +10,7 @@ module Types
 
   class DataReleaseType < Types::BaseObject
     field :name, String, null: false 
-    field :gene_tsv, DownloadableFile, null: true
+    field :feature_tsv, DownloadableFile, null: true
     field :variant_tsv, DownloadableFile, null: true
     field :variant_group_tsv, DownloadableFile, null: true
     field :evidence_tsv, DownloadableFile, null: true

--- a/server/app/graphql/types/queries/data_release_query.rb
+++ b/server/app/graphql/types/queries/data_release_query.rb
@@ -13,7 +13,7 @@ module Types::Queries
             release_name = File.basename(release)
             {
               name: release_name,
-              gene_tsv: file_or_nil(release, release_name, 'GeneSummaries.tsv'),
+              feature_tsv: file_or_nil(release, release_name, 'FeatureSummaries.tsv'),
               variant_tsv: file_or_nil(release, release_name, 'VariantSummaries.tsv'),
               variant_group_tsv: file_or_nil(release, release_name, 'VariantGroupSummaries.tsv'),
               evidence_tsv: file_or_nil(release, release_name, 'ClinicalEvidenceSummaries.tsv'),
@@ -34,7 +34,7 @@ module Types::Queries
 
         end
       end
-      
+
       def file_or_nil(path, release, filename)
         full_path = File.join(path, "#{release}-#{filename}")
         if File.exist?(full_path)


### PR DESCRIPTION
The previous PR renames it on the backend and sets up an alias/link for backwards compatibility, this PR changes the naming on the downloads page.