### PR TITLE
When revising a fusion variant, allow for optional exon coordinates

### DIFF
--- a/client/src/app/forms/config/fusion-variant-revise/fusion-variant-revise.form.config.ts
+++ b/client/src/app/forms/config/fusion-variant-revise/fusion-variant-revise.form.config.ts
@@ -88,8 +88,10 @@ function formFieldConfig(
                         {
                           key: 'referenceBuild',
                           type: 'reference-build-select',
-                          props: {
-                            required: true,
+                          expressions: {
+                            'props.required': (field) =>
+                              Boolean(field.model.fivePrimeTranscript) ||
+                              Boolean(field.model.threePrimeTranscript),
                           },
                         },
                         {
@@ -107,7 +109,11 @@ function formFieldConfig(
                             label: 'Ensembl Version',
                             description:
                               'Enter a valid Ensembl database version (e.g. 75)',
-                            required: true,
+                          },
+                          expressions: {
+                            'props.required': (field) =>
+                              Boolean(field.model.fivePrimeTranscript) ||
+                              Boolean(field.model.threePrimeTranscript),
                           },
                         },
                       ],
@@ -125,10 +131,13 @@ function formFieldConfig(
                           type: 'base-input',
                           props: {
                             label: "5' Transcript",
-                            required: !fivePrimeDisabled,
                             disabled: fivePrimeDisabled,
                             tooltip:
                               "Specify a transcript ID, including version number (e.g. ENST00000348159.4) for the 5' exon you have selected",
+                          },
+                          expressions: {
+                            'props.required': (field) =>
+                              Boolean(field.model.fivePrimeExonEnd),
                           },
                           validators: {
                             isTranscriptId: {
@@ -149,10 +158,13 @@ function formFieldConfig(
                           },
                           props: {
                             label: "5' End Exon",
-                            required: !fivePrimeDisabled,
                             disabled: fivePrimeDisabled,
                             tooltip:
                               'The exon number counted from the 5’ end of the transcript.',
+                          },
+                          expressions: {
+                            'props.required': (field) =>
+                              Boolean(field.model.fivePrimeTranscript),
                           },
                         },
                         {
@@ -205,7 +217,6 @@ function formFieldConfig(
                           key: 'threePrimeTranscript',
                           type: 'base-input',
                           props: {
-                            required: !threePrimeDisabled,
                             disabled: threePrimeDisabled,
                             label: "3' Transcript",
                             tooltip:
@@ -217,6 +228,10 @@ function formFieldConfig(
                               message:
                                 "3' Transcript must be a valid, human, versioned, Ensembl transcript ID",
                             },
+                          },
+                          expressions: {
+                            'props.required': (field) =>
+                              Boolean(field.model.threePrimeExonStart),
                           },
                         },
                         {
@@ -232,8 +247,11 @@ function formFieldConfig(
                             label: "3' Start Exon",
                             tooltip:
                               'The exon number counted from the 3’ end of the transcript.',
-                            required: !threePrimeDisabled,
                             disabled: threePrimeDisabled,
+                          },
+                          expressions: {
+                            'props.required': (field) =>
+                              Boolean(field.model.threePrimeTranscript),
                           },
                         },
                         {

--- a/server/app/graphql/mutations/suggest_fusion_variant_revision.rb
+++ b/server/app/graphql/mutations/suggest_fusion_variant_revision.rb
@@ -86,7 +86,11 @@ class Mutations::SuggestFusionVariantRevision < Mutations::MutationWithOrg
     updated_variant.single_variant_molecular_profile_id = variant.single_variant_molecular_profile_id
     updated_variant.feature = variant.feature
     updated_variant.fusion = variant.feature.feature_instance
-    updated_variant.name = updated_variant.generate_name
+    if variant.name == 'Fusion'
+      updated_variant.name = 'Fusion'
+    else
+      updated_variant.name = updated_variant.generate_name
+    end
     updated_variant.vicc_compliant_name = updated_variant.generate_vicc_name
 
     variant_revisions_obj = Activities::RevisedObjectPair.new(existing_obj: variant, updated_obj: updated_variant)


### PR DESCRIPTION
Previously, the revise fusion variant form shared the same validation rules as the "create fusion variant" form. This meant requiring 5' or 3' coordinates to be entered (depending on the properties of the Feature).

However, when revising a representative Fusion variant that may not have coordinates specified, this would render a user unable to provide an alias or additional SO terms.

This changes the rules so that:

* Exons are required if the corresponding transcript is filled in
* Transcripts are required if the corresponding exon is filled in
* Ensembl version and Reference build are required if either transcript is filled in
* Offset and Offset direction continue to work as before