### PR TITLE
Update short links to allow doid, ncit_id, and hpo_id

### DIFF
--- a/server/app/lib/link_adaptors/phenotype.rb
+++ b/server/app/lib/link_adaptors/phenotype.rb
@@ -1,0 +1,11 @@
+module LinkAdaptors
+  class Phenotype < Base
+    def display_name
+      obj.name
+    end
+
+    def base_path
+      "/phenotypes/#{obj.id}"
+    end
+  end
+end

--- a/server/app/models/frontend_router.rb
+++ b/server/app/models/frontend_router.rb
@@ -24,8 +24,16 @@ class FrontendRouter
   def query_info
     case id_type
     when /genes?/
-      [ 
-        Feature.where(feature_instance_type: "Features::Gene"), :feature_instance_id, 
+      [
+        Feature.where(feature_instance_type: "Features::Gene"), :id,
+      ]
+    when /fusions?/
+      [
+        Feature.where(feature_instance_type: "Features::Fusion"), :id,
+      ]
+    when /factors?/
+      [
+        Feature.where(feature_instance_type: "Features::Factor"), :id,
       ]
     when /features?/
       [ Feature, :id, ]
@@ -38,7 +46,7 @@ class FrontendRouter
     when /entrez_id/
       [ Features::Gene, :entrez_id ]
     when /entrez_name/
-      [ 
+      [
         Feature.where(feature_instance_type: "Features::Gene"), :name, -> { _1.upcase }
       ]
     when /variant_groups?/
@@ -47,10 +55,18 @@ class FrontendRouter
       [ Revision, :id ]
     when /diseases?/
       [ Disease, :id ]
+    when /doid/
+      [ Disease.where(deprecated: false), :doid, ]
     when /drugs?/
       [ Therapy, :id ]
     when /therapies?/
       [ Therapy, :id ]
+    when /ncit_id/
+      [ Therapy.where(deprecated: false), :ncit_id, ]
+    when /phenotypes?/
+      [ Phenotype, :id ]
+    when /hpo_id/
+      [ Phenotype, :hpo_id ]
     when /assertions?/
       [ Assertion, :id ]
     when /sources?/
@@ -62,8 +78,8 @@ class FrontendRouter
       when "AID"
         [ Assertion, :id ]
       when "GID"
-        [ 
-          Feature.where(feature_instance_type: "Features::Gene"), :feature_instance_id, 
+        [
+          Feature.where(feature_instance_type: "Features::Gene"), :id,
         ]
       when "FID"
         [ Feature, :id ]


### PR DESCRIPTION
In addition to adding logic for resolving diseases, therapies, and phenotypes by doid, ncit_id, and hpo_id, respectively, this PR  also adds link resolvers for phenotypes by ID, factors and fusions by feature ID and updates some logic that was incorrectly using the feature_instance_id instead of the feature ID.

TODO:
- [ ] Update documentation