### PR TITLE
rank typeahead results by length of matched name

### DIFF
--- a/server/app/graphql/types/queries/typeahead_queries.rb
+++ b/server/app/graphql/types/queries/typeahead_queries.rb
@@ -81,13 +81,13 @@ module Types::Queries
         base_query = Disease.where(deprecated: false)
         results = base_query.where("diseases.name ILIKE ?", "%#{query_term}%")
           .or(base_query.where("diseases.doid ILIKE ?", "#{query_term}%"))
-          #.order("LENGTH(diseases.name) ASC")
+          .order("LENGTH(diseases.name) ASC")
           .limit(10)
         if results.size < 10
           secondary_results = base_query.eager_load(:disease_aliases)
             .where("disease_aliases.name ILIKE ?", "%#{query_term}%")
             .where.not(id: results.select('id'))
-            #.order("LENGTH(diseases.name) ASC")
+            .order("LENGTH(diseases.name) ASC")
             .distinct
             .limit(10-results.size)
           return results + secondary_results
@@ -100,7 +100,7 @@ module Types::Queries
         base_query = Therapy.where(deprecated: false)
         results = base_query.where("therapies.name ILIKE ?", "#{query_term}%")
           .or(base_query.where("therapies.ncit_id ILIKE ?", "%#{query_term}%"))
-          #.order("LENGTH(therapies.name) ASC")
+          .order("LENGTH(therapies.name) ASC")
           .limit(10)
         if results.size < 10
           secondary_results = base_query.where('therapies.name ILIKE ?', "%#{query_term}%")
@@ -110,7 +110,7 @@ module Types::Queries
             tertiary_results = base_query.eager_load(:therapy_aliases)
               .where("therapy_aliases.name ILIKE ?", "%#{query_term}%")
               .where.not(id: results.select('id') + secondary_results.select('id'))
-              #.order("LENGTH(therapies.name) ASC")
+              .order("LENGTH(therapies.name) ASC")
               .distinct
               .limit(10-results.size)
 
@@ -131,14 +131,14 @@ module Types::Queries
                      end
 
         results = base_query.where('features.name ILIKE ?', "#{query_term}%")
-          #.order("LENGTH(features.name) ASC")
+          .order("LENGTH(features.name) ASC")
           .limit(10)
 
         if results.size < 10
           secondary_results = base_query.eager_load(:feature_aliases)
             .where("feature_aliases.name ILIKE ?", "#{query_term}%")
             .where.not(id: results.select('id'))
-            #.order("LENGTH(features.name) ASC")
+            .order("LENGTH(features.name) ASC")
             .distinct
             .limit(10 - results.size)
           return (results + secondary_results).uniq


### PR DESCRIPTION
This behavior did not work on the version of Postgres we were using previously. I've verified it works on the current prod instance so we can bring it back.