### PR TITLE
Show Organization settings now work properly in organization activity tab

### DIFF
--- a/client/src/app/components/activities/activity-feed/feed-item/feed-item.component.html
+++ b/client/src/app/components/activities/activity-feed/feed-item/feed-item.component.html
@@ -107,11 +107,7 @@
           ">
         </ng-container>
       }
-      @if (
-        showOrganization() &&
-        activity.organization &&
-        scope().mode !== 'ORGANIZATION'
-      ) {
+      @if (showOrganization() && activity.organization) {
         <div class="organization">
           <span
             class="verbiage"

--- a/client/src/app/forms/types/evidence-select/evidence-select.type.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-select.type.ts
@@ -261,7 +261,7 @@ export class CvcEvidenceSelectField
       )
     })
 
-    // combine all synchronized requireds updates, emit table filter changes array
+    // combine all synchronized required updates, emit table filter changes array
     this.onFieldsChange$ = combineLatest(this.synchronizedFields$).pipe(
       map((fields) => {
         const newFilters: CvcFilterChange[] = []

--- a/client/src/app/forms/types/evidence-select/evidence-select.type.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-select.type.ts
@@ -279,7 +279,7 @@ export class CvcEvidenceSelectField
       // tag('onFieldsChange$')
     )
 
-    // combine all synchronized requireds updates, emit table prefs array
+    // combine all synchronized required updates, emit table prefs array
     this.onRequiredChange$ = combineLatest(this.synchronizedRequired$).pipe(
       map((fields) => {
         const newPrefs: Partial<ColumnPrefsOption>[] = []

--- a/client/src/app/views/organizations/organizations-events/organizations-events.component.html
+++ b/client/src/app/views/organizations/organizations-events/organizations-events.component.html
@@ -1,3 +1,4 @@
 <cvc-activity-feed
   [cvcScope]="feedScope"
-  [cvcShowFilters]="true"></cvc-activity-feed>
+  [cvcShowFilters]="true"
+  [cvcSettings]="feedSettings"></cvc-activity-feed>

--- a/client/src/app/views/organizations/organizations-events/organizations-events.component.ts
+++ b/client/src/app/views/organizations/organizations-events/organizations-events.component.ts
@@ -1,7 +1,11 @@
 import { Component } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
 import { EventFeedMode } from '@app/generated/civic.apollo'
-import { ActivityFeedScope } from '@app/components/activities/activity-feed/activity-feed.types'
+import {
+  ActivityFeedScope,
+  ActivityFeedSettings,
+} from '@app/components/activities/activity-feed/activity-feed.types'
+import { feedDefaultSettings } from '@app/components/activities/activity-feed/activity-feed.config'
 
 @Component({
   selector: 'cvc-organizations-events',
@@ -10,8 +14,13 @@ import { ActivityFeedScope } from '@app/components/activities/activity-feed/acti
 })
 export class OrganizationsEventsComponent {
   feedScope: ActivityFeedScope
+  feedSettings: ActivityFeedSettings
 
   constructor(private route: ActivatedRoute) {
+    this.feedSettings = {
+      ...feedDefaultSettings,
+      showOrganization: false,
+    }
     this.feedScope = {
       mode: EventFeedMode.Organization,
       organizationId: +this.route.snapshot.params['organizationId'],


### PR DESCRIPTION
Updated activity feed configuration on the organizations-events page, and the show organization logic in feed-item component to synchronize the feed-settings 'Show Organization' option. Fixes #1192.

The Show Organization option wasn't working on the organization-events page due to a couple of issues. First, the activity-feed initializes with default feed settings which sets showOrganization to 'true'. These settings are only overridden by the cvcSettings input. Second, feed-item's logic overrode showOrganization with the activity-feed mode (organization, subject, user, unscoped), so the organization would never be shown if its mode was 'ORGANIZATION'. 

Adding cvcSettings configuration w/ showOrganization set to 'true', and removing the mode check from the feed item org display logic fixed the issue.