### PR TITLE
Fix ProteinPaint url

### DIFF
--- a/client/src/app/components/genes/gene-base-summary/gene-base-summary.page.html
+++ b/client/src/app/components/genes/gene-base-summary/gene-base-summary.page.html
@@ -80,8 +80,9 @@
             </cvc-link-tag>
             <cvc-link-tag
               [href]="
-                'https://pecan.stjude.cloud/variants/protein-paint/?gene=' +
-                gene.name
+                'https://proteinpaint.stjude.org/?genome=hg19&gene=' +
+                gene.name +
+                '&dataset=CIViC'
               "
               [tooltip]="'View ' + gene.name + ' on ProteinPaint'">
               ProteinPaint


### PR DESCRIPTION
The URL format changed again so the links were broken (again). This new format also allows us to pre-select the CIViC annotation track so this actually closes #836 