### PR TITLE
Submitting EIDs and Assertions should fail early if the entities would be invalid

### DIFF
--- a/server/app/models/activities/base.rb
+++ b/server/app/models/activities/base.rb
@@ -12,6 +12,7 @@ module Activities
     end
 
     def execute
+      setup
       create_activity
       call_actions
       after_actions
@@ -27,6 +28,10 @@ module Activities
 
     def call_actions
       raise NotImplementedError.new("Activity must implement call_actions")
+    end
+
+    def setup
+      # no op
     end
 
     def after_actions

--- a/server/app/models/activities/submit_assertion.rb
+++ b/server/app/models/activities/submit_assertion.rb
@@ -8,6 +8,13 @@ module Activities
     end
 
     private
+    def setup
+      if !assertion.valid?
+        msg = assertion.errors.map(&:full_message).join(", ")
+        raise StandardError.new(msg)
+      end
+    end
+
     def create_activity
       @activity = SubmitAssertionActivity.create!(
         subject: assertion,

--- a/server/app/models/activities/submit_evidence_item.rb
+++ b/server/app/models/activities/submit_evidence_item.rb
@@ -8,6 +8,13 @@ module Activities
     end
 
     private
+    def setup
+      if !evidence_item.valid?
+        msg = evidence_item.errors.map(&:full_message).join(", ")
+        raise StandardError.new(msg)
+      end
+    end
+
     def create_activity
       @activity = SubmitEvidenceItemActivity.create!(
         subject: evidence_item,


### PR DESCRIPTION
This adds an optional `setup` method to activities that will be called before any other processing has completed.

In this case, it is used to run validation on EIDs and Assertions prior to the creation of the activity entity, which will trigger a save on the EID automatically.

This results in the correct error coming back from the API:

![Screenshot 2025-03-06 at 10 38 18 AM](https://github.com/user-attachments/assets/81ff2c04-5f9d-481d-a4df-816cc4e31667)

Looking through the rest of the activities, I believe these are the only two places it makes sense to do this. The only other place is maybe creating Fusions because they have some fairly elaborate validation rules too, but much of that happens in a background task.

closes #1201 