### PR TITLE
Remove invalid order clause

### DIFF
--- a/server/app/graphql/types/queries/typeahead_queries.rb
+++ b/server/app/graphql/types/queries/typeahead_queries.rb
@@ -136,7 +136,6 @@ module Types::Queries
           secondary_results = base_query.eager_load(:feature_aliases)
             .where("feature_aliases.name ILIKE ?", "#{query_term}%")
             .where.not(id: results.select("id"))
-            .order("LENGTH(features.name) ASC")
             .distinct
             .limit(10 - results.size)
           return (results + secondary_results).uniq


### PR DESCRIPTION
I thought we had removed all of these previously, but looks like we missed one. The `.order` clause generates invalid SQL when we're matching on aliases.