### PR TITLE
Add hasLinkedEvidence filter to therapies endpoint

### DIFF
--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -5587,6 +5587,7 @@ export type QueryTherapiesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
+  hasLinkedEvidence?: InputMaybe<Scalars['Boolean']['input']>;
   id?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -9575,6 +9575,11 @@ type Query {
     first: Int
 
     """
+    Limit to therapies that are linked to at least one non-rejected Evidence Item or Assertion
+    """
+    hasLinkedEvidence: Boolean
+
+    """
     Filter on a therapy's internal CIViC id
     """
     id: Int

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -43589,6 +43589,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "hasLinkedEvidence",
+                  "description": "Limit to therapies that are linked to at least one non-rejected Evidence Item or Assertion",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "therapyAlias",
                   "description": null,
                   "type": {

--- a/server/app/graphql/resolvers/top_level_therapies.rb
+++ b/server/app/graphql/resolvers/top_level_therapies.rb
@@ -23,6 +23,16 @@ class Resolvers::TopLevelTherapies < GraphQL::Schema::Resolver
     end
   end
 
+  option(:has_linked_evidence, type: Boolean, description: "Limit to therapies that are linked to at least one non-rejected Evidence Item or Assertion") do |scope, value|
+    if value
+      scope.left_outer_joins(:assertions, :evidence_items)
+        .where("(assertions.id IS NOT NULL AND assertions.status != 'rejected') OR (evidence_items.id IS NOT NULL AND evidence_items.status != 'rejected')")
+        .distinct
+    else
+      scope
+    end
+  end
+
   option(:therapy_alias, type: String) do |scope, value|
     scope.where(array_query_for_column("alias_names"), "%#{value}%")
   end


### PR DESCRIPTION
We import a large chunk of the NCIt to power the typeahead, but it can also be useful to only iterate through therapies that have associated CIViC evidence. This filter will allow for that.

Its also a prerequisite for dgidb/dgidb-v5#576