### PR TITLE
Add banner indicating when we are in a non-production environment

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -2,6 +2,9 @@
      main app.component delegates all app layout and routing
      to layout.component and layout-routing.module
 -->
+<div>
+  <cvc-environment-banner></cvc-environment-banner>
+</div>
 <div class="alert-container">
   <cvc-network-error-alert></cvc-network-error-alert>
 </div>

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { Observable } from 'rxjs'
 import { AppErrorHandler } from './core/utilities/app-error-handler'
 import { CvcForms2Module } from '@app/forms/forms.module'
 import { graphqlProvider } from './graphql/graphql.module'
+import { CvcEnvironmentBannerComponent } from './components/app/environment-banner/environment-banner.component'
 
 registerLocaleData(en)
 
@@ -44,6 +45,7 @@ function initializeApiFactory(httpClient: HttpClient): () => Observable<any> {
     LetDirective,
     PushPipe,
     CvcNetworkErrorAlertModule,
+    CvcEnvironmentBannerComponent,
   ],
   providers: [
     graphqlProvider,

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,5 +1,10 @@
 import { BrowserModule } from '@angular/platform-browser'
-import { APP_INITIALIZER, ErrorHandler, NgModule } from '@angular/core'
+import {
+  ErrorHandler,
+  inject,
+  NgModule,
+  provideAppInitializer,
+} from '@angular/core'
 import { registerLocaleData } from '@angular/common'
 import en from '@angular/common/locales/en'
 import {
@@ -20,17 +25,32 @@ import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
 import { NzIconModule } from 'ng-zorro-antd/icon'
 import { CvcNetworkErrorAlertModule } from './components/app/network-error-alert/network-error-alert.module'
-import { Observable } from 'rxjs'
+import { firstValueFrom, Observable, tap } from 'rxjs'
 import { AppErrorHandler } from './core/utilities/app-error-handler'
 import { CvcForms2Module } from '@app/forms/forms.module'
 import { graphqlProvider } from './graphql/graphql.module'
 import { CvcEnvironmentBannerComponent } from './components/app/environment-banner/environment-banner.component'
+import { environment } from 'environments/environment'
 
 registerLocaleData(en)
 
-function initializeApiFactory(httpClient: HttpClient): () => Observable<any> {
-  return () => httpClient.get('/api/status')
+interface ServerConfig {
+  displayEnvBanner: boolean
+  env: string
+  status: string
 }
+
+const initlializerProvider = provideAppInitializer(() => {
+  const http = inject(HttpClient)
+  return firstValueFrom(
+    http.get<ServerConfig>('/api/status').pipe(
+      tap((config) => {
+        environment.displayEnvBanner = config.displayEnvBanner
+        environment.backendEnv = config.env
+      })
+    )
+  )
+})
 
 @NgModule({
   declarations: [AppComponent],
@@ -48,18 +68,13 @@ function initializeApiFactory(httpClient: HttpClient): () => Observable<any> {
     CvcEnvironmentBannerComponent,
   ],
   providers: [
+    initlializerProvider,
     graphqlProvider,
     {
       provide: ErrorHandler,
       useClass: AppErrorHandler,
     },
     { provide: NZ_I18N, useValue: en_US },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: initializeApiFactory,
-      deps: [HttpClient],
-      multi: true,
-    },
     provideHttpClient(
       withInterceptorsFromDi(),
       withJsonpSupport(),

--- a/client/src/app/components/app/environment-banner/environment-banner.component.html
+++ b/client/src/app/components/app/environment-banner/environment-banner.component.html
@@ -1,8 +1,8 @@
-@if (!isProduction) {
+@if (displayBanner) {
   <div class="alert-container">
     <nz-alert
       nzType="info"
-      nzMessage="You are in a development environment.">
+      [nzMessage]="displayMsg">
     </nz-alert>
   </div>
 }

--- a/client/src/app/components/app/environment-banner/environment-banner.component.html
+++ b/client/src/app/components/app/environment-banner/environment-banner.component.html
@@ -1,0 +1,8 @@
+@if (!isProduction) {
+  <div class="alert-container">
+    <nz-alert
+      nzType="info"
+      nzMessage="You are in a development environment.">
+    </nz-alert>
+  </div>
+}

--- a/client/src/app/components/app/environment-banner/environment-banner.component.less
+++ b/client/src/app/components/app/environment-banner/environment-banner.component.less
@@ -1,0 +1,7 @@
+@import "themes/global-variables.less";
+
+.alert-container {
+  display: block;
+  width: 100%;
+  padding: @default-padding-sm @default-padding-lg;
+}

--- a/client/src/app/components/app/environment-banner/environment-banner.component.ts
+++ b/client/src/app/components/app/environment-banner/environment-banner.component.ts
@@ -11,5 +11,6 @@ import { NzAlertModule } from 'ng-zorro-antd/alert'
   imports: [NzAlertModule],
 })
 export class CvcEnvironmentBannerComponent {
-  isProduction = environment.production
+  displayBanner: boolean = environment.displayEnvBanner
+  displayMsg: string = `You are in the ${environment.backendEnv} environment`
 }

--- a/client/src/app/components/app/environment-banner/environment-banner.component.ts
+++ b/client/src/app/components/app/environment-banner/environment-banner.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { environment } from 'environments/environment'
+import { NzAlertModule } from 'ng-zorro-antd/alert'
+
+@Component({
+  selector: 'cvc-environment-banner',
+  templateUrl: './environment-banner.component.html',
+  styleUrls: ['./environment-banner.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [NzAlertModule],
+})
+export class CvcEnvironmentBannerComponent {
+  isProduction = environment.production
+}

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
 export const environment = {
   production: true,
+  backendEnv: 'production',
+  displayEnvBanner: false,
 }

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -4,6 +4,8 @@
 
 export const environment = {
   production: false,
+  backendEnv: 'development',
+  displayEnvBanner: false,
 }
 
 /*

--- a/server/app/controllers/static_controller.rb
+++ b/server/app/controllers/static_controller.rb
@@ -1,5 +1,9 @@
 class StaticController < ApplicationController
   def status
-    render json: { status: :ok }
+    render json: {
+      status: :ok,
+      env: Rails.env,
+      displayEnvBanner: DISPLAY_ENVIRONMENT_BANNER,
+    }
   end
 end

--- a/server/config/initializers/environment_banner.rb
+++ b/server/config/initializers/environment_banner.rb
@@ -1,0 +1,2 @@
+val = (ENV["CIVIC_DISPLAY_ENV_BANNER"] || "false").downcase
+DISPLAY_ENVIRONMENT_BANNER = ActiveModel::Type::Boolean.new.cast(val)


### PR DESCRIPTION
When developing features, we often find ourselves having to double check the URL to make sure we're not going to perform actions on the real site. This should help that by adding a fixed banner to the top of the site when we're in dev mode.

It would be nice potentially to differentiate between staging and dev as well, but the `production` flag on the frontend doesn't handle that case at the moment, it just indicates that the frontend build is a "production" build of the angular app which is indeed what gets deployed to staging.

![Screenshot 2025-03-24 at 11 54 05 AM](https://github.com/user-attachments/assets/24687ed0-843e-4e96-afaa-320a823a1dc2)
