### PR TITLE
Make MP and Variant TSV queries consistent with each other

### DIFF
--- a/server/app/tsv_formatters/molecular_profile_tsv_formatter.rb
+++ b/server/app/tsv_formatters/molecular_profile_tsv_formatter.rb
@@ -1,8 +1,7 @@
 class MolecularProfileTsvFormatter
   def self.objects
     MolecularProfile.eager_load(:variants, :evidence_items, :assertions, :molecular_profile_aliases)
-      .left_joins(:evidence_items)
-      .where("evidence_items.status = 'accepted' OR assertions.id IS NOT NULL")
+      .where("(evidence_items.id IS NOT NULL AND evidence_items.status = 'accepted') OR (assertions.id IS NOT NULL AND assertions.status = 'accepted')")
   end
 
   def self.headers

--- a/server/app/tsv_formatters/variant_tsv_formatter.rb
+++ b/server/app/tsv_formatters/variant_tsv_formatter.rb
@@ -1,6 +1,6 @@
 class VariantTsvFormatter
   def self.objects
-    Variant.left_joins(molecular_profiles: [ :evidence_items, :assertions ])
+    Variant.left_outer_joins(molecular_profiles: [ :evidence_items, :assertions ])
       .includes(:variant_groups, :variant_types, :hgvs_descriptions, :variant_aliases, :feature)
       .where("(evidence_items.id IS NOT NULL AND evidence_items.status = 'accepted') OR (assertions.id IS NOT NULL AND assertions.status = 'accepted')")
       .distinct

--- a/server/app/tsv_formatters/variant_tsv_formatter.rb
+++ b/server/app/tsv_formatters/variant_tsv_formatter.rb
@@ -1,8 +1,8 @@
 class VariantTsvFormatter
   def self.objects
-    Variant.joins(molecular_profiles: [ :evidence_items ])
+    Variant.left_joins(molecular_profiles: [ :evidence_items, :assertions ])
       .includes(:variant_groups, :variant_types, :hgvs_descriptions, :variant_aliases, :feature)
-      .where("evidence_items.status = 'accepted'")
+      .where("(evidence_items.id IS NOT NULL AND evidence_items.status = 'accepted') OR (assertions.id IS NOT NULL AND assertions.status = 'accepted')")
       .distinct
   end
 


### PR DESCRIPTION
In response to the civic-help email and in order to prevent confusion, only include variants and MPs in the TSVs if they have at least one accepted EID or AID.