### PR TITLE
Linking org -> user -> event associated events by affiliation not by acting org

### DIFF
--- a/server/app/models/leaderboard.rb
+++ b/server/app/models/leaderboard.rb
@@ -1,8 +1,8 @@
 class Leaderboard
   def self.organization_base_query(*actions)
-    Organization.joins(users: [ :events ])
+    Organization.joins(:events)
         .where("events.action" => actions)
-        .where.not("users.id" => Constants::CIVICBOT_USER_ID)
+        .where.not("events.originating_user_id" => Constants::CIVICBOT_USER_ID)
         .group("organizations.id")
         .select('
                 organizations.*,


### PR DESCRIPTION
The previous query would join the organization to the events via the user table which would include in the count all of the users that are members of the organization, even if they were acting under a different organization when executing the event. Joining the organization to the events directly (via `events.organization_id`) sidesteps this problem.

Side note: this will drop ClinGen dramatically in all the rankings because the ranks don't include child orgs and they have barely any activity under ClinGen directly.