### PR TITLE
Improve handling of duplicate revisions

### DIFF
--- a/server/app/models/actions/suggest_revision_set.rb
+++ b/server/app/models/actions/suggest_revision_set.rb
@@ -75,5 +75,9 @@ class Actions::SuggestRevisionSet
     unless any_changes
       raise StandardError.new("You must change at least one field in order to suggest a revision.")
     end
+
+    if revision_results.none? { |r| r[:newly_created] }
+      raise StandardError.new("All proposed revisions already exist. Please review them or suggest unique changes.")
+    end
   end
 end

--- a/server/app/models/activities/suggest_revision_set.rb
+++ b/server/app/models/activities/suggest_revision_set.rb
@@ -37,7 +37,13 @@ module Activities
     end
 
     def linked_entities
-      [ revision_set, revisions ].flatten
+      new_revision_ids = revision_results
+        .select { |r| r[:newly_created] }
+        .map { |r| r[:id] }
+
+      new_revisions = revisions.select { |r| new_revision_ids.include?(r.id) }
+
+      [ revision_set, new_revisions ].flatten
     end
   end
 end


### PR DESCRIPTION
* If only duplicate revisions are proposed, raise an exception and fail
* Only add newly created revisions as linked entities, not any preexisting revisions

closes #1240 