### PR TITLE
Adjust OpenCravat predictor tab heading

### DIFF
--- a/client/src/app/components/variants/variant-info/variant-info.component.html
+++ b/client/src/app/components/variants/variant-info/variant-info.component.html
@@ -47,7 +47,7 @@
               style="fill: #fff" />
           </svg>
         </i>
-        OpenCravat Annotations
+        OpenCRAVAT ACMG/AMP Classifications
       </ng-template>
     </nz-tabset>
   </nz-card-tab>


### PR DESCRIPTION
This is a wording change that Rachel requested. The panel would look like this:
<img width="745" alt="Screenshot 2025-06-16 at 9 37 59 AM" src="https://github.com/user-attachments/assets/1f4ebc6c-5c6f-4c2f-8450-2beaf28d7edf" />
