### PR TITLE
Move current TopLevelUsers query to BrowseUsers namespace and restore original TopLevelUsers to query users db table

### DIFF
--- a/client/src/app/components/activities/activity-feed/feed-filters/user-filter-select/user-filter-select.component.ts
+++ b/client/src/app/components/activities/activity-feed/feed-filters/user-filter-select/user-filter-select.component.ts
@@ -67,7 +67,7 @@ export class CvcUserFilterSelect {
       }),
       map(
         (result) =>
-          result.data?.users.edges.map((e) => e.node! as BrowseUser) ?? []
+          result.data?.browseUsers.edges.map((e) => e.node! as BrowseUser) ?? []
       ),
       tag(`${this.constructor.name} filteredUser$ after`)
     )

--- a/client/src/app/components/activities/activity-feed/feed-filters/user-filter-select/user-filter-select.query.gql
+++ b/client/src/app/components/activities/activity-feed/feed-filters/user-filter-select/user-filter-select.query.gql
@@ -1,5 +1,5 @@
 query UserFilterSearch($name: String) {
-  users(name: $name) {
+  browseUsers(name: $name) {
     pageInfo {
       endCursor
       hasNextPage

--- a/client/src/app/components/users/users-table/users-table.component.ts
+++ b/client/src/app/components/users/users-table/users-table.component.ts
@@ -133,7 +133,7 @@ export class CvcUsersTableComponent implements OnInit {
 
     // entity relay connection
     this.connection$ = this.result$.pipe(
-      pluck('data', 'users'),
+      pluck('data', 'browseUsers'),
       filter(isNonNulled)
     ) as Observable<BrowseUserConnection>
 

--- a/client/src/app/components/users/users-table/users-table.query.gql
+++ b/client/src/app/components/users/users-table/users-table.query.gql
@@ -8,7 +8,7 @@ query UsersBrowse(
   $userRole: UserRole
   $sortBy: UsersSort
 ) {
-  users(
+  browseUsers(
     first: $first
     last: $last
     before: $before

--- a/client/src/app/generated/civic.apollo-helpers.ts
+++ b/client/src/app/generated/civic.apollo-helpers.ts
@@ -901,7 +901,7 @@ export type EndorseAssertionPayloadFieldPolicy = {
 	assertion?: FieldPolicy<any> | FieldReadFunction<any>,
 	clientMutationId?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type EndorsementKeySpecifier = ('assertion' | 'createdAt' | 'endorsementActivity' | 'id' | 'lastReviewed' | 'organization' | 'revocationActivity' | 'status' | 'updatedAt' | 'user' | EndorsementKeySpecifier)[];
+export type EndorsementKeySpecifier = ('assertion' | 'createdAt' | 'endorsementActivity' | 'id' | 'lastReviewed' | 'organization' | 'readyForClinvarSubmission' | 'revocationActivity' | 'status' | 'updatedAt' | 'user' | EndorsementKeySpecifier)[];
 export type EndorsementFieldPolicy = {
 	assertion?: FieldPolicy<any> | FieldReadFunction<any>,
 	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -909,6 +909,7 @@ export type EndorsementFieldPolicy = {
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastReviewed?: FieldPolicy<any> | FieldReadFunction<any>,
 	organization?: FieldPolicy<any> | FieldReadFunction<any>,
+	readyForClinvarSubmission?: FieldPolicy<any> | FieldReadFunction<any>,
 	revocationActivity?: FieldPolicy<any> | FieldReadFunction<any>,
 	status?: FieldPolicy<any> | FieldReadFunction<any>,
 	updatedAt?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1938,7 +1939,7 @@ export type PhenotypePopoverFieldPolicy = {
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	url?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type QueryKeySpecifier = ('acmgCode' | 'acmgCodesTypeahead' | 'activities' | 'activity' | 'assertion' | 'assertions' | 'browseDiseases' | 'browseFeatures' | 'browseMolecularProfiles' | 'browseOrganizations' | 'browsePhenotypes' | 'browseSources' | 'browseTherapies' | 'browseVariantGroups' | 'browseVariants' | 'clingenCode' | 'clingenCodesTypeahead' | 'clinicalTrial' | 'clinicalTrials' | 'comment' | 'comments' | 'contributors' | 'countries' | 'dataReleases' | 'disease' | 'diseasePopover' | 'diseaseTypeahead' | 'diseases' | 'endorsements' | 'entityTypeahead' | 'events' | 'evidenceItem' | 'evidenceItems' | 'factor' | 'factors' | 'feature' | 'featureTypeahead' | 'flag' | 'flags' | 'fusion' | 'fusions' | 'gene' | 'genes' | 'molecularProfile' | 'molecularProfiles' | 'nccnGuideline' | 'nccnGuidelinesTypeahead' | 'notifications' | 'organization' | 'organizationLeaderboards' | 'organizations' | 'phenotype' | 'phenotypePopover' | 'phenotypeTypeahead' | 'phenotypes' | 'previewCommentText' | 'previewMolecularProfileName' | 'remoteCitation' | 'revision' | 'revisions' | 'search' | 'searchByPermalink' | 'searchGenes' | 'source' | 'sourcePopover' | 'sourceSuggestionValues' | 'sourceSuggestions' | 'sourceTypeahead' | 'sources' | 'subscriptionForEntity' | 'therapies' | 'therapy' | 'therapyPopover' | 'therapyTypeahead' | 'timepointStats' | 'user' | 'userLeaderboards' | 'userTypeahead' | 'users' | 'validateRevisionsForAcceptance' | 'variant' | 'variantGroup' | 'variantGroups' | 'variantType' | 'variantTypePopover' | 'variantTypeTypeahead' | 'variantTypes' | 'variants' | 'variantsTypeahead' | 'viewer' | QueryKeySpecifier)[];
+export type QueryKeySpecifier = ('acmgCode' | 'acmgCodesTypeahead' | 'activities' | 'activity' | 'assertion' | 'assertions' | 'browseDiseases' | 'browseFeatures' | 'browseMolecularProfiles' | 'browseOrganizations' | 'browsePhenotypes' | 'browseSources' | 'browseTherapies' | 'browseUsers' | 'browseVariantGroups' | 'browseVariants' | 'clingenCode' | 'clingenCodesTypeahead' | 'clinicalTrial' | 'clinicalTrials' | 'comment' | 'comments' | 'contributors' | 'countries' | 'dataReleases' | 'disease' | 'diseasePopover' | 'diseaseTypeahead' | 'diseases' | 'endorsements' | 'entityTypeahead' | 'events' | 'evidenceItem' | 'evidenceItems' | 'factor' | 'factors' | 'feature' | 'featureTypeahead' | 'flag' | 'flags' | 'fusion' | 'fusions' | 'gene' | 'genes' | 'molecularProfile' | 'molecularProfiles' | 'nccnGuideline' | 'nccnGuidelinesTypeahead' | 'notifications' | 'organization' | 'organizationLeaderboards' | 'organizations' | 'phenotype' | 'phenotypePopover' | 'phenotypeTypeahead' | 'phenotypes' | 'previewCommentText' | 'previewMolecularProfileName' | 'remoteCitation' | 'revision' | 'revisions' | 'search' | 'searchByPermalink' | 'searchGenes' | 'source' | 'sourcePopover' | 'sourceSuggestionValues' | 'sourceSuggestions' | 'sourceTypeahead' | 'sources' | 'subscriptionForEntity' | 'therapies' | 'therapy' | 'therapyPopover' | 'therapyTypeahead' | 'timepointStats' | 'user' | 'userLeaderboards' | 'userTypeahead' | 'users' | 'validateRevisionsForAcceptance' | 'variant' | 'variantGroup' | 'variantGroups' | 'variantType' | 'variantTypePopover' | 'variantTypeTypeahead' | 'variantTypes' | 'variants' | 'variantsTypeahead' | 'viewer' | QueryKeySpecifier)[];
 export type QueryFieldPolicy = {
 	acmgCode?: FieldPolicy<any> | FieldReadFunction<any>,
 	acmgCodesTypeahead?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -1953,6 +1954,7 @@ export type QueryFieldPolicy = {
 	browsePhenotypes?: FieldPolicy<any> | FieldReadFunction<any>,
 	browseSources?: FieldPolicy<any> | FieldReadFunction<any>,
 	browseTherapies?: FieldPolicy<any> | FieldReadFunction<any>,
+	browseUsers?: FieldPolicy<any> | FieldReadFunction<any>,
 	browseVariantGroups?: FieldPolicy<any> | FieldReadFunction<any>,
 	browseVariants?: FieldPolicy<any> | FieldReadFunction<any>,
 	clingenCode?: FieldPolicy<any> | FieldReadFunction<any>,

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -5010,6 +5010,8 @@ export type Query = {
   browsePhenotypes: BrowsePhenotypeConnection;
   browseSources: BrowseSourceConnection;
   browseTherapies: BrowseTherapyConnection;
+  /** List and filter users. */
+  browseUsers: BrowseUserConnection;
   browseVariantGroups: BrowseVariantGroupConnection;
   browseVariants: BrowseVariantConnection;
   /** Find a ClinGen code by CIViC ID */
@@ -5126,7 +5128,7 @@ export type Query = {
   /** Retrieve user type typeahead fields for a search term. */
   userTypeahead: Array<User>;
   /** List and filter users. */
-  users: BrowseUserConnection;
+  users: UserConnection;
   validateRevisionsForAcceptance: ValidationErrors;
   /** Find a variant by CIViC ID */
   variant?: Maybe<VariantInterface>;
@@ -5313,6 +5315,19 @@ export type QueryBrowseTherapiesArgs = {
   ncitId?: InputMaybe<Scalars['String']['input']>;
   sortBy?: InputMaybe<TherapySort>;
   therapyAlias?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBrowseUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  organization?: InputMaybe<OrganizationFilter>;
+  role?: InputMaybe<UserRole>;
+  sortBy?: InputMaybe<UsersSort>;
+  username?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -5814,7 +5829,6 @@ export type QueryUsersArgs = {
   name?: InputMaybe<Scalars['String']['input']>;
   organization?: InputMaybe<OrganizationFilter>;
   role?: InputMaybe<UserRole>;
-  sortBy?: InputMaybe<UsersSort>;
   username?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -8162,7 +8176,7 @@ export type UserFilterSearchQueryVariables = Exact<{
 }>;
 
 
-export type UserFilterSearchQuery = { __typename: 'Query', users: { __typename: 'BrowseUserConnection', pageInfo: { __typename: 'PageInfo', endCursor?: string | undefined, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | undefined }, edges: Array<{ __typename: 'BrowseUserEdge', node?: { __typename: 'BrowseUser', id: number, displayName: string, name?: string | undefined, username: string, role: UserRole } | undefined }> } };
+export type UserFilterSearchQuery = { __typename: 'Query', browseUsers: { __typename: 'BrowseUserConnection', pageInfo: { __typename: 'PageInfo', endCursor?: string | undefined, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | undefined }, edges: Array<{ __typename: 'BrowseUserEdge', node?: { __typename: 'BrowseUser', id: number, displayName: string, name?: string | undefined, username: string, role: UserRole } | undefined }> } };
 
 export type AcceptRevisionsActivityDetailFragment = { __typename: 'AcceptRevisionsActivity', id: number, verbiage: string, createdAt: any, parsedNote: Array<{ __typename: 'CommentTagSegment', entityId: number, displayName: string, tagType: TaggableEntity, link: string, revisionSetId?: number | undefined, feature?: { __typename: 'LinkableFeature', id: number, name: string, link: string, deprecated: boolean, flagged: boolean } | undefined } | { __typename: 'CommentTagSegmentFlagged', entityId: number, displayName: string, tagType: TaggableEntity, flagged: boolean, link: string, revisionSetId?: number | undefined, feature?: { __typename: 'LinkableFeature', id: number, name: string, link: string, deprecated: boolean, flagged: boolean } | undefined } | { __typename: 'CommentTagSegmentFlaggedAndDeprecated', entityId: number, displayName: string, tagType: TaggableEntity, flagged: boolean, deprecated: boolean, link: string, revisionSetId?: number | undefined, feature?: { __typename: 'LinkableFeature', id: number, name: string, link: string, deprecated: boolean, flagged: boolean } | undefined } | { __typename: 'CommentTagSegmentFlaggedAndWithStatus', entityId: number, displayName: string, tagType: TaggableEntity, status: EvidenceStatus, flagged: boolean, link: string, revisionSetId?: number | undefined, feature?: { __typename: 'LinkableFeature', id: number, name: string, link: string, deprecated: boolean, flagged: boolean } | undefined } | { __typename: 'CommentTextSegment', text: string } | { __typename: 'User', id: number, username: string, displayName: string, name?: string | undefined, role: UserRole, profileImagePath?: string | undefined, organizations: Array<{ __typename: 'Organization', id: number, name: string, profileImagePath?: string | undefined }> }>, revisions: Array<{ __typename: 'Revision', id: number, name: string, status: RevisionStatus, currentValue?: any | undefined, suggestedValue?: any | undefined, fieldName: string, link: string, linkoutData: { __typename: 'LinkoutData', name: string, diffValue: { __typename: 'ObjectFieldDiff', currentObjects: Array<{ __typename: 'ModeratedObjectField', id: number, displayName?: string | undefined, displayType?: string | undefined, entityType: string, link?: string | undefined, deleted: boolean, deprecated?: boolean | undefined, flagged?: boolean | undefined, feature?: { __typename: 'LinkableFeature', link: string, id: number, name: string, deprecated: boolean, flagged: boolean } | undefined }>, addedObjects: Array<{ __typename: 'ModeratedObjectField', id: number, displayName?: string | undefined, displayType?: string | undefined, entityType: string, link?: string | undefined, deleted: boolean, deprecated?: boolean | undefined, flagged?: boolean | undefined, feature?: { __typename: 'LinkableFeature', link: string, id: number, name: string, deprecated: boolean, flagged: boolean } | undefined }>, removedObjects: Array<{ __typename: 'ModeratedObjectField', id: number, displayName?: string | undefined, displayType?: string | undefined, entityType: string, link?: string | undefined, deleted: boolean, deprecated?: boolean | undefined, flagged?: boolean | undefined, feature?: { __typename: 'LinkableFeature', link: string, id: number, name: string, deprecated: boolean, flagged: boolean } | undefined }>, keptObjects: Array<{ __typename: 'ModeratedObjectField', id: number, displayName?: string | undefined, displayType?: string | undefined, entityType: string, link?: string | undefined, deleted: boolean, deprecated?: boolean | undefined, flagged?: boolean | undefined, feature?: { __typename: 'LinkableFeature', link: string, id: number, name: string, deprecated: boolean, flagged: boolean } | undefined }>, suggestedObjects: Array<{ __typename: 'ModeratedObjectField', id: number, displayName?: string | undefined, displayType?: string | undefined, entityType: string, link?: string | undefined, deleted: boolean, deprecated?: boolean | undefined, flagged?: boolean | undefined, feature?: { __typename: 'LinkableFeature', link: string, id: number, name: string, deprecated: boolean, flagged: boolean } | undefined }> } | { __typename: 'ScalarFieldDiff', left: string, right: string } } }>, supersededRevisions: Array<{ __typename: 'Revision', id: number, link: string, name: string, fieldName: string, createdAt: any, creationActivity?: { __typename: 'SuggestRevisionSetActivity', user: { __typename: 'User', displayName: string, profileImagePath?: string | undefined, id: number, role: UserRole } } | undefined }>, organization?: { __typename: 'Organization', id: number, name: string } | undefined, user: { __typename: 'User', id: number, displayName: string, role: UserRole }, subject: { __typename: 'Assertion', id: number, name: string, link: string } | { __typename: 'Comment', deleted: boolean, deletedAt?: any | undefined, id: number, name: string, link: string, commentable: { __typename: 'Assertion', id: number, name: string, link: string } | { __typename: 'EvidenceItem', id: number, name: string, link: string } | { __typename: 'Factor', id: number, name: string, link: string } | { __typename: 'FactorVariant', id: number, name: string, link: string, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'Feature', id: number, name: string, link: string } | { __typename: 'Flag', id: number, name: string, link: string } | { __typename: 'Fusion', id: number, name: string, link: string } | { __typename: 'FusionVariant', id: number, name: string, link: string, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'Gene', id: number, name: string, link: string } | { __typename: 'GeneVariant', id: number, name: string, link: string, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'MolecularProfile', id: number, name: string, link: string } | { __typename: 'Revision', id: number, name: string, link: string } | { __typename: 'Source', id: number, name: string, link: string } | { __typename: 'SourcePopover', id: number, name: string, link: string } | { __typename: 'Variant', id: number, name: string, link: string } | { __typename: 'VariantGroup', id: number, name: string, link: string } } | { __typename: 'EvidenceItem', id: number, name: string, link: string } | { __typename: 'ExonCoordinate', id: number, name: string, link: string } | { __typename: 'Factor', id: number, name: string, link: string } | { __typename: 'FactorVariant', id: number, name: string, link: string, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'Feature', id: number, name: string, link: string } | { __typename: 'Flag', id: number, name: string, link: string } | { __typename: 'Fusion', id: number, name: string, link: string } | { __typename: 'FusionVariant', id: number, name: string, link: string, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'Gene', id: number, name: string, link: string } | { __typename: 'GeneVariant', id: number, name: string, link: string, feature: { __typename: 'Feature', id: number, name: string, link: string } } | { __typename: 'MolecularProfile', id: number, name: string, link: string } | { __typename: 'Revision', id: number, name: string, link: string } | { __typename: 'RevisionSet', id: number, name: string, link: string } | { __typename: 'Source', id: number, name: string, link: string } | { __typename: 'SourcePopover', id: number, name: string, link: string } | { __typename: 'SourceSuggestion', id: number, name: string, link: string } | { __typename: 'Variant', id: number, name: string, link: string } | { __typename: 'VariantCoordinate', id: number, name: string, link: string } | { __typename: 'VariantGroup', id: number, name: string, link: string }, events: Array<{ __typename: 'Event', id: number, createdAt: any, action: EventAction, originatingObject?: { __typename: 'Assertion', id: number, name: string, link: string } | { __typename: 'Comment', id: number, name: string, link: string } | { __typename: 'EvidenceItem', id: number, name: string, link: string } | { __typename: 'Factor', id: number, name: string, link: string } | { __typename: 'FactorVariant', id: number, name: string, link: string } | { __typename: 'Feature', id: number, name: string, link: string } | { __typename: 'Flag', id: number, name: string, link: string } | { __typename: 'Fusion', id: number, name: string, link: string } | { __typename: 'FusionVariant', id: number, name: string, link: string } | { __typename: 'Gene', id: number, name: string, link: string } | { __typename: 'GeneVariant', id: number, name: string, link: string } | { __typename: 'MolecularProfile', id: number, name: string, link: string } | { __typename: 'Revision', id: number, name: string, link: string } | { __typename: 'SourceSuggestion', id: number, name: string, link: string } | { __typename: 'Variant', id: number, name: string, link: string } | undefined, originatingUser: { __typename: 'User', id: number, displayName: string } }> };
 
@@ -8964,7 +8978,7 @@ export type UsersBrowseQueryVariables = Exact<{
 }>;
 
 
-export type UsersBrowseQuery = { __typename: 'Query', users: { __typename: 'BrowseUserConnection', totalCount: number, pageInfo: { __typename: 'PageInfo', endCursor?: string | undefined, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | undefined }, edges: Array<{ __typename: 'BrowseUserEdge', cursor: string, node?: { __typename: 'BrowseUser', id: number, name?: string | undefined, displayName: string, username: string, role: UserRole, evidenceCount: number, revisionCount: number, profileImagePath?: string | undefined, mostRecentActivityTimestamp?: any | undefined, organizations: Array<{ __typename: 'Organization', id: number, name: string }> } | undefined }> } };
+export type UsersBrowseQuery = { __typename: 'Query', browseUsers: { __typename: 'BrowseUserConnection', totalCount: number, pageInfo: { __typename: 'PageInfo', endCursor?: string | undefined, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | undefined }, edges: Array<{ __typename: 'BrowseUserEdge', cursor: string, node?: { __typename: 'BrowseUser', id: number, name?: string | undefined, displayName: string, username: string, role: UserRole, evidenceCount: number, revisionCount: number, profileImagePath?: string | undefined, mostRecentActivityTimestamp?: any | undefined, organizations: Array<{ __typename: 'Organization', id: number, name: string }> } | undefined }> } };
 
 export type UserBrowseTableRowFieldsFragment = { __typename: 'BrowseUser', id: number, name?: string | undefined, displayName: string, username: string, role: UserRole, evidenceCount: number, revisionCount: number, profileImagePath?: string | undefined, mostRecentActivityTimestamp?: any | undefined, organizations: Array<{ __typename: 'Organization', id: number, name: string }> };
 
@@ -10072,7 +10086,7 @@ export type OrganizationMembersQueryVariables = Exact<{
 }>;
 
 
-export type OrganizationMembersQuery = { __typename: 'Query', users: { __typename: 'BrowseUserConnection', pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | undefined, endCursor?: string | undefined }, edges: Array<{ __typename: 'BrowseUserEdge', cursor: string, node?: { __typename: 'BrowseUser', id: number, name?: string | undefined, displayName: string, username: string, profileImagePath?: string | undefined, role: UserRole, url?: string | undefined, areaOfExpertise?: AreaOfExpertise | undefined, orcid?: string | undefined, twitterHandle?: string | undefined, facebookProfile?: string | undefined, linkedinProfile?: string | undefined, organizations: Array<{ __typename: 'Organization', id: number, name: string, url: string }> } | undefined }> } };
+export type OrganizationMembersQuery = { __typename: 'Query', browseUsers: { __typename: 'BrowseUserConnection', pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | undefined, endCursor?: string | undefined }, edges: Array<{ __typename: 'BrowseUserEdge', cursor: string, node?: { __typename: 'BrowseUser', id: number, name?: string | undefined, displayName: string, username: string, profileImagePath?: string | undefined, role: UserRole, url?: string | undefined, areaOfExpertise?: AreaOfExpertise | undefined, orcid?: string | undefined, twitterHandle?: string | undefined, facebookProfile?: string | undefined, linkedinProfile?: string | undefined, organizations: Array<{ __typename: 'Organization', id: number, name: string, url: string }> } | undefined }> } };
 
 export type OrganizationMembersFieldsFragment = { __typename: 'BrowseUser', id: number, name?: string | undefined, displayName: string, username: string, profileImagePath?: string | undefined, role: UserRole, url?: string | undefined, areaOfExpertise?: AreaOfExpertise | undefined, orcid?: string | undefined, twitterHandle?: string | undefined, facebookProfile?: string | undefined, linkedinProfile?: string | undefined, organizations: Array<{ __typename: 'Organization', id: number, name: string, url: string }> };
 
@@ -14267,7 +14281,7 @@ export const OrgFilterSearchDocument = gql`
   }
 export const UserFilterSearchDocument = gql`
     query UserFilterSearch($name: String) {
-  users(name: $name) {
+  browseUsers(name: $name) {
     pageInfo {
       endCursor
       hasNextPage
@@ -16026,7 +16040,7 @@ export const UserPopoverDocument = gql`
   }
 export const UsersBrowseDocument = gql`
     query UsersBrowse($first: Int, $last: Int, $before: String, $after: String, $userName: String, $orgName: OrganizationFilter, $userRole: UserRole, $sortBy: UsersSort) {
-  users(
+  browseUsers(
     first: $first
     last: $last
     before: $before
@@ -18621,7 +18635,7 @@ export const OrganizationGroupsDocument = gql`
   }
 export const OrganizationMembersDocument = gql`
     query OrganizationMembers($organizationId: [Int!], $first: Int, $last: Int, $before: String, $after: String) {
-  users(
+  browseUsers(
     organization: {ids: $organizationId}
     first: $first
     last: $last

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -8875,6 +8875,56 @@ type Query {
     sortBy: TherapySort
     therapyAlias: String
   ): BrowseTherapyConnection!
+
+  """
+  List and filter users.
+  """
+  browseUsers(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering on name
+    """
+    name: String
+
+    """
+    Limit to users that belong to a certain organizations
+    """
+    organization: OrganizationFilter
+
+    """
+    Filtering on role.
+    """
+    role: UserRole
+
+    """
+    Sort user columns in ascending or decending order
+    """
+    sortBy: UsersSort
+
+    """
+    Filtering on username
+    """
+    username: String
+  ): BrowseUserConnection!
   browseVariantGroups(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -10025,15 +10075,10 @@ type Query {
     role: UserRole
 
     """
-    Sort user columns in ascending or decending order
-    """
-    sortBy: UsersSort
-
-    """
     Filtering on username
     """
     username: String
-  ): BrowseUserConnection!
+  ): UserConnection!
   validateRevisionsForAcceptance(
     """
     A list of CIViC Revisions IDs to validate

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -41039,6 +41039,131 @@
               "deprecationReason": null
             },
             {
+              "name": "browseUsers",
+              "description": "List and filter users.",
+              "args": [
+                {
+                  "name": "organization",
+                  "description": "Limit to users that belong to a certain organizations",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "OrganizationFilter",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "name",
+                  "description": "Filtering on name",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "username",
+                  "description": "Filtering on username",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "role",
+                  "description": "Filtering on role.",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "UserRole",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "sortBy",
+                  "description": "Sort user columns in ascending or decending order",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UsersSort",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "BrowseUserConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "browseVariantGroups",
               "description": null,
               "args": [
@@ -45399,18 +45524,6 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "sortBy",
-                  "description": "Sort user columns in ascending or decending order",
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "UsersSort",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
                   "name": "after",
                   "description": "Returns the elements in the list that come after the specified cursor.",
                   "type": {
@@ -45464,7 +45577,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "BrowseUserConnection",
+                  "name": "UserConnection",
                   "ofType": null
                 }
               },

--- a/client/src/app/views/organizations/organizations-members/organizations-members.component.ts
+++ b/client/src/app/views/organizations/organizations-members/organizations-members.component.ts
@@ -42,14 +42,14 @@ export class OrganizationsMembersComponent implements OnDestroy {
 
 
       this.members$ = observable.pipe(
-        pluck('data', 'users', 'edges'),
+        pluck('data', 'browseUsers', 'edges'),
         filter(isNotNullish),
         map((edges) => {
           return edges.map((e) => e.node)
         })
       )
 
-      this.pageInfo$ = observable.pipe(pluck('data', 'users', 'pageInfo'))
+      this.pageInfo$ = observable.pipe(pluck('data', 'browseUsers', 'pageInfo'))
 
       this.viewer$ = this.viewerService.viewer$
     })

--- a/client/src/app/views/organizations/organizations-members/organizations-members.query.gql
+++ b/client/src/app/views/organizations/organizations-members/organizations-members.query.gql
@@ -5,7 +5,7 @@ query OrganizationMembers(
   $before: String
   $after: String
 ) {
-  users(
+  browseUsers(
     organization: { ids: $organizationId }
     first: $first
     last: $last

--- a/server/app/graphql/resolvers/browse_users.rb
+++ b/server/app/graphql/resolvers/browse_users.rb
@@ -1,14 +1,14 @@
 require "search_object"
 require "search_object/plugin/graphql"
 
-class Resolvers::TopLevelUsers < GraphQL::Schema::Resolver
+class Resolvers::BrowseUsers < GraphQL::Schema::Resolver
   include SearchObject.module(:graphql)
 
-  type Types::Entities::UserType.connection_type, null: false
+  type Types::BrowseTables::BrowseUserType.connection_type, null: false
 
   description "List and filter users."
 
-  scope { User.all.order(:id) }
+  scope { MaterializedViews::UserBrowseTableRow.all.order(:id) }
 
   option(:organization, type: Types::OrganizationFilterType, description: "Limit to users that belong to a certain organizations") do |scope, value|
     if value.include_subgroups && !value.ids.nil?
@@ -35,5 +35,22 @@ class Resolvers::TopLevelUsers < GraphQL::Schema::Resolver
 
   option(:role, type: Types::Entities::UserRoleType, description: "Filtering on role.") do | scope, value |
     scope.where(role: value)
+  end
+
+  option(:sort_by, type: Types::BrowseTables::UsersSortType, description: "Sort user columns in ascending or decending order") do |scope, value|
+    case value.column
+    when "ID"
+      scope.reorder("id #{value.direction}")
+    when "NAME"
+      scope.where.not("name = ? AND name = ?", nil, "").reorder("name #{value.direction}")
+    when "ROLE"
+      scope.reorder("role #{value.direction}")
+    when "LAST_ACTION"
+      scope.reorder("most_recent_activity_timestamp #{value.direction} NULLS LAST")
+    when "REVISION_COUNT"
+      scope.reorder("revision_count #{value.direction}")
+    when "EVIDENCE_COUNT"
+      scope.reorder("evidence_count #{value.direction}")
+    end
   end
 end

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -23,6 +23,7 @@ module Types
     field :browsePhenotypes, resolver: Resolvers::BrowsePhenotypes
     field :browseMolecularProfiles, resolver: Resolvers::BrowseMolecularProfiles
     field :browseOrganizations, resolver: Resolvers::BrowseOrganizations
+    field :browseUsers, resolver: Resolvers::BrowseUsers
     field :events, resolver: Resolvers::TopLevelEvents
     field :comments, resolver: Resolvers::TopLevelComments
     field :source_suggestions, resolver: Resolvers::BrowseSourceSuggestions


### PR DESCRIPTION
Closes #1223 (organizations were previously addressed in https://github.com/griffithlab/civic-v2/pull/1232)