### PR TITLE
update graphiql page to use new CDN system and 5.0 release

### DIFF
--- a/server/app/views/graphiql/show.html.erb
+++ b/server/app/views/graphiql/show.html.erb
@@ -1,13 +1,8 @@
-<!--
- *  Copyright (c) 2021 GraphQL Contributors
- *  All rights reserved.
- *
- *  This source code is licensed under the license found in the
- *  LICENSE file in the root directory of this source tree.
--->
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CIViC GraphiQL</title>
     <style>
       body {
@@ -18,53 +13,98 @@
       }
 
       #graphiql {
-        height: 100vh;
+        height: 100dvh;
+      }
+
+      .loading {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 4rem;
       }
     </style>
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bundler.
-    -->
-    <script
-      crossorigin
-      src="https://unpkg.com/react@18/umd/react.development.js"
-    ></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
-    ></script>
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
-      type="application/javascript"
-    ></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-    <!-- 
-      These are imports for the GraphIQL Explorer plugin.
-     -->
-    <script
-      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
-      crossorigin
-    ></script>
-
+    <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+      href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css"
     />
-
     <link
       rel="stylesheet"
       href="https://www.unpkg.com/bulma@0.9.4/css/bulma.min.css"
     />
-  </head>
+    <!-- Note: the ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file. -->
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@19.1.0",
+          "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime",
 
+          "react-dom": "https://esm.sh/react-dom@19.1.0",
+          "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
+
+          "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
+          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
+          "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql",
+
+          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
+          "graphql": "https://esm.sh/graphql@16.11.0"
+        }
+      }
+    </script>
+    <script type="module">
+      // Import React and ReactDOM
+      import React from "react";
+      import ReactDOM from "react-dom/client";
+      // Import GraphiQL and the Explorer plugin
+      import { GraphiQL, HISTORY_PLUGIN } from "graphiql";
+      import { createGraphiQLFetcher } from "@graphiql/toolkit";
+      import { explorerPlugin } from "@graphiql/plugin-explorer";
+
+      import createJSONWorker from "https://esm.sh/monaco-editor/esm/vs/language/json/json.worker.js?worker";
+      import createGraphQLWorker from "https://esm.sh/monaco-graphql/esm/graphql.worker.js?worker";
+      import createEditorWorker from "https://esm.sh/monaco-editor/esm/vs/editor/editor.worker.js?worker";
+
+      globalThis.MonacoEnvironment = {
+        getWorker(_workerId, label) {
+          console.info("MonacoEnvironment.getWorker", { label });
+          switch (label) {
+            case "json":
+              return createJSONWorker();
+            case "graphql":
+              return createGraphQLWorker();
+          }
+          return createEditorWorker();
+        },
+      };
+
+      const fetcher = createGraphiQLFetcher({
+        url: "/api/graphql",
+      });
+      const plugins = [HISTORY_PLUGIN, explorerPlugin()];
+
+      function ComponentWithQuery(query) {
+        return function App() {
+          return React.createElement(GraphiQL, {
+            fetcher,
+            plugins,
+            defaultEditorToolsVisibility: true,
+            initialQuery: query,
+          });
+        }
+      }
+
+      const container = document.getElementById("graphiql");
+      const root = ReactDOM.createRoot(container);
+      const defaultQuery = `<%= @initial_query %>`
+      root.render(React.createElement(ComponentWithQuery(defaultQuery)))
+
+      function updateQuery(newQuery) {
+        root.render(React.createElement(ComponentWithQuery(newQuery)))
+      }
+      window.updateQuery = updateQuery
+    </script>
+  </head>
   <body>
     <nav class="navbar is-dark is-spaced ">
       <div class="navbar-brand">
@@ -113,38 +153,11 @@
           <% end %>
         </div>
         <div class="column">
-          <div id="graphiql">Loading...</div>
+          <div id="graphiql">
+            <div class="loading">Loading…</div>
+          </div>
         </div>
       </div>
     </section>
-
-    <script>
-      const root = ReactDOM.createRoot(document.getElementById("graphiql"));
-      const fetcher = GraphiQL.createFetcher({
-        url: "/api/graphql",
-      });
-
-      const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
-
-      const gql = React.createElement(GraphiQL, {
-        fetcher,
-        defaultQuery: `<%= @initial_query %>`,
-        defaultEditorToolsVisibility: true,
-        plugins: [explorerPlugin],
-      });
-
-      root.render(gql);
-
-      function updateQuery(newQuery) {
-        const newGQL = React.createElement(GraphiQL, {
-          fetcher,
-          query: newQuery,
-          defaultEditorToolsVisibility: true,
-          plugins: [explorerPlugin],
-        });
-
-        root.render(newGQL);
-      }
-    </script>
   </body>
 </html>


### PR DESCRIPTION
The new graphiql release broke the page on our site. I have fixed it by starting with the porting guide found here: https://github.com/graphql/graphiql/blob/main/docs/migration/graphiql-5.0.0.md#graphiql and then incorporating our query logic and wrapper html into their example.