### PR TITLE
Do not queue jobs to Sidekiq until after the corresponding Postgres transaction has committed. 

### DIFF
--- a/server/app/jobs/application_job.rb
+++ b/server/app/jobs/application_job.rb
@@ -1,4 +1,5 @@
 class ApplicationJob < ActiveJob::Base
+  self.enqueue_after_transaction_commit = true
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 


### PR DESCRIPTION
This is actually the default behavior for background jobs after rails 7.2 but our app was generated on rails 6.1 and loads its default config options unless overridden specifically for background compatibility: (https://github.com/griffithlab/civic-v2/blob/main/server/config/application.rb#L24)