### PR TITLE
Sort by id if evidence score is equivalent

### DIFF
--- a/server/app/graphql/resolvers/browse_molecular_profiles.rb
+++ b/server/app/graphql/resolvers/browse_molecular_profiles.rb
@@ -10,7 +10,7 @@ class Resolvers::BrowseMolecularProfiles < GraphQL::Schema::Resolver
   scope do
     MaterializedViews::MolecularProfileBrowseTableRow
       .all
-      .order("evidence_score DESC")
+      .order("evidence_score DESC, id ASC")
   end
 
   option(:molecular_profile_name, type: String) do |scope, value|


### PR DESCRIPTION
This fixes the duplicate entries in the MP browse table that Malachi reported in slack. Basically, what was happening is that multiple MPs had identical evidence scores. In that case the sort order isn't guaranteed, so between multiple queries, the sorting of the MPs could result in them appearing across "page breaks" where there was a run of identically scored MPs.

Now, if they have the same mp score, the tie is broken by id which will result in a consistent ordering.