### PR TITLE
Use feature instance description when revising gene features

### DIFF
--- a/client/src/app/forms/config/gene-revise/gene-revise.query.gql
+++ b/client/src/app/forms/config/gene-revise/gene-revise.query.gql
@@ -6,12 +6,16 @@ query GeneRevisableFields($featureId: Int!) {
 
 fragment RevisableGeneFields on Feature {
   id
-  description
   sources {
     id
     sourceType
     citation
     citationId
+  }
+  featureInstance {
+    ... on Gene {
+      description
+    }
   }
 }
 

--- a/client/src/app/forms/utilities/gene-to-model-fields.ts
+++ b/client/src/app/forms/utilities/gene-to-model-fields.ts
@@ -1,16 +1,32 @@
-import { Maybe, RevisableGeneFieldsFragment, SuggestGeneRevisionInput } from "@app/generated/civic.apollo";
-import { GeneFields } from "../models/gene-fields.model";
-import { GeneReviseModel } from "../models/gene-revise.model";
+import {
+  Maybe,
+  RevisableGeneFieldsFragment,
+  SuggestGeneRevisionInput,
+} from '@app/generated/civic.apollo'
+import { GeneFields } from '../models/gene-fields.model'
+import { GeneReviseModel } from '../models/gene-revise.model'
 import * as fmt from '@app/forms/utilities/input-formatters'
 
-export function geneToModelFields(gene: RevisableGeneFieldsFragment): GeneFields {
-  return {
-    description: gene.description,
-    sourceIds: gene.sources.map(s => s.id)
+export function geneToModelFields(
+  gene: RevisableGeneFieldsFragment
+): GeneFields {
+  if (gene.featureInstance.__typename == 'Gene') {
+    return {
+      description: gene.featureInstance.description,
+      sourceIds: gene.sources.map((s) => s.id),
+    }
+  } else {
+    return {
+      description: undefined,
+      sourceIds: [],
+    }
   }
 }
 
-export function geneFormModelToReviseInput(gid: number, model: GeneReviseModel): Maybe<SuggestGeneRevisionInput> {
+export function geneFormModelToReviseInput(
+  gid: number,
+  model: GeneReviseModel
+): Maybe<SuggestGeneRevisionInput> {
   const fields = model.fields
   if (!model.comment) {
     return undefined
@@ -20,9 +36,9 @@ export function geneFormModelToReviseInput(gid: number, model: GeneReviseModel):
     id: gid,
     fields: {
       description: fmt.toNullableString(fields.description),
-      sourceIds: fields.sourceIds || []
+      sourceIds: fields.sourceIds || [],
     },
     organizationId: model.organizationId,
-    comment: model.comment!
+    comment: model.comment!,
   }
 }

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -9462,9 +9462,9 @@ export type GeneRevisableFieldsQueryVariables = Exact<{
 }>;
 
 
-export type GeneRevisableFieldsQuery = { __typename: 'Query', feature?: { __typename: 'Feature', id: number, description?: string | undefined, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> } | undefined };
+export type GeneRevisableFieldsQuery = { __typename: 'Query', feature?: { __typename: 'Feature', id: number, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }>, featureInstance: { __typename: 'Factor' } | { __typename: 'Fusion' } | { __typename: 'Gene', description?: string | undefined } } | undefined };
 
-export type RevisableGeneFieldsFragment = { __typename: 'Feature', id: number, description?: string | undefined, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }> };
+export type RevisableGeneFieldsFragment = { __typename: 'Feature', id: number, sources: Array<{ __typename: 'Source', id: number, sourceType: SourceSource, citation?: string | undefined, citationId: string }>, featureInstance: { __typename: 'Factor' } | { __typename: 'Fusion' } | { __typename: 'Gene', description?: string | undefined } };
 
 export type SuggestGeneRevisionMutationVariables = Exact<{
   input: SuggestGeneRevisionInput;
@@ -12571,12 +12571,16 @@ export const RevisableFusionVariantFieldsFragmentDoc = gql`
 export const RevisableGeneFieldsFragmentDoc = gql`
     fragment RevisableGeneFields on Feature {
   id
-  description
   sources {
     id
     sourceType
     citation
     citationId
+  }
+  featureInstance {
+    ... on Gene {
+      description
+    }
   }
 }
     `;


### PR DESCRIPTION
This fixes the issue Malachi reported in slack where the description revision would apply successfully, but then not appear in the form during subsequent revision attempts. 