### PR TITLE
applies temp CSS fix for ng-zorro@v20 select box position in Safari

### DIFF
--- a/client/src/app/app.component.less
+++ b/client/src/app/app.component.less
@@ -12,3 +12,11 @@
   z-index: 0;
   overflow-y: auto;
 }
+
+// NOTE: this fixes a regression in ng-zorro v19 causing
+// dropdowns to be detached from nz-select elements.
+// See: https://github.com/NG-ZORRO/ng-zorro-antd/issues/9401
+::ng-deep .ant-select-dropdown,
+.ant-dropdown {
+  position: initial !important;
+}


### PR DESCRIPTION
See: https://github.com/NG-ZORRO/ng-zorro-antd/issues/9401