### PR TITLE
Fix duplicate variants being appended in MP builder

### DIFF
--- a/client/src/app/forms/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
+++ b/client/src/app/forms/types/molecular-profile-select/mp-expression-editor/mp-expression-editor.component.ts
@@ -310,7 +310,12 @@ export class MpExpressionEditorComponent implements AfterViewInit, OnChanges {
           if (!input || input.trim().length == 0) {
             return newVariant
           } else {
-            return `${input.trim()} ${newVariant}`
+            let [prevVariant] = input.trim().split(' ').slice(-1)
+            if (prevVariant == newVariant) {
+              return input.trim()
+            } else {
+              return `${input.trim()} ${newVariant}`
+            }
           }
         }),
         // tag('onVariantSelect$'),


### PR DESCRIPTION
Cara reported this issue a while back. Basically, when you add a variant using the MP builder, the #VID string gets added twice (It looks like due to a callback double-firing, once when its created and once when its "selected"). This will only append the variant string if it differs from the previously appended variant string. 