### PR TITLE
Create versioned civicpy release in addition to the nightly one

### DIFF
--- a/server/app/jobs/create_civicpy_cache_pkl.rb
+++ b/server/app/jobs/create_civicpy_cache_pkl.rb
@@ -6,10 +6,15 @@ class CreateCivicpyCachePkl < ApplicationJob
     if not status.success?
       raise stderr
     end
+    create_versioned_path
   end
 
   private
   def civicpy_cache_file_location
     raise "Implement in subclass!"
+  end
+
+  def create_versioned_path
+    # noop
   end
 end

--- a/server/app/jobs/create_nightly_civicpy_cache_pkl.rb
+++ b/server/app/jobs/create_nightly_civicpy_cache_pkl.rb
@@ -1,6 +1,14 @@
+require "fileutils"
+
 class CreateNightlyCivicpyCachePkl < CreateCivicpyCachePkl
   private
   def civicpy_cache_file_location
     File.join(Rails.root, "public", "downloads", "nightly", "nightly-civicpy_cache.pkl")
+  end
+
+  def create_versioned_path
+    civicpy_version = `pip show civicpy | grep Version`.split(":").last.strip
+    versioned_path = File.join(Rails.root, "public", "downloads", "nightly", "nightly-civicpy_cache-#{civicpy_version}.pkl")
+    FileUtils.cp(civicpy_cache_file_location, versioned_path)
   end
 end


### PR DESCRIPTION
This is a prerequisite to the feature request in https://github.com/griffithlab/civicpy/issues/216.

This PR creates a versioned version of the nightly civicpy pkl. By copying the nightly file to a versioned path, we keep the latest nightly pkl created by any given version going forward.