### PR TITLE
Entrez Importer Should Default Gene descriptions to nil instead of empty string

### DIFF
--- a/server/app/lib/importer/entrez_symbols.rb
+++ b/server/app/lib/importer/entrez_symbols.rb
@@ -33,7 +33,7 @@ module Importer
         feature = Feature.create!(
           name: line["Symbol_from_nomenclature_authority"],
           full_name: line["description"],
-          description: "",
+          description: nil,
           feature_instance: gene
         )
         feature.save(validate: false)
@@ -60,7 +60,7 @@ module Importer
       end
 
       if feature.description.blank?
-        feature.description = ""
+        feature.description = nil
       end
 
       gene.save(validate: false)


### PR DESCRIPTION
closes #1393

Will need to run a data backfill script after deploy to correct existing features.