### PR TITLE
fix typo and logic in approval batch loading

### DIFF
--- a/server/app/graphql/types/entities/approval_type.rb
+++ b/server/app/graphql/types/entities/approval_type.rb
@@ -43,12 +43,14 @@ module Types::Entities
         if entries.blank?
           true
         else
-          Promise.all([
+          release_status_promises = entries.map do |entry|
             Loaders::AssociationLoader
               .for(ClinvarBatchEntry, :clinvar_batch_submission)
               .load(entry)
-              .then { |batch| batch&.release_status },
-          ]).then do |relase_statuses|
+              .then { |batch| batch&.release_status }
+          end
+
+          Promise.all(release_status_promises).then do |release_statuses|
             release_statuses.any? { |s| s == "released" }
           end
         end


### PR DESCRIPTION
This was just flat out broken previously, `entry` wasn't defined, but it wasn't getting exercised yet in prod because the batch status tracking display logic hasn't been deployed yet. 