### PR TITLE
Support Oncogenic Assertions that lean benign having no associated EIDs

### DIFF
--- a/client/src/app/components/assertions/assertions-table/assertions-table.component.html
+++ b/client/src/app/components/assertions/assertions-table/assertions-table.component.html
@@ -226,7 +226,7 @@
                 nzValue="ADVERSE_RESPONSE"
                 nzLabel="Adverse Response"></nz-option>
               <nz-option
-                nzValue="REDUCED SENSITIVITY"
+                nzValue="REDUCED_SENSITIVITY"
                 nzLabel="Reduced Sensitivity"></nz-option>
               <nz-option
                 nzValue="NA"

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.html
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.html
@@ -390,8 +390,8 @@
               nzValue="COMMON_GERMLINE"
               nzLabel="Common Germline"></nz-option>
             <nz-option
-              nzValue="GERMLINE_OR_SOMATIC"
-              nzLabel="Germline or Somatic"></nz-option>
+              nzValue="MIXED"
+              nzLabel="Mixed"></nz-option>
             <nz-option
               nzValue="COMBINED"
               nzLabel="Combined"></nz-option>
@@ -650,7 +650,9 @@
         nzSpin></i>
       <span>Loading…</span>
     </nz-tag>
-    <cvc-table-downloader [vars]="queryRef.variables" tableName="evidence"></cvc-table-downloader>
+    <cvc-table-downloader
+      [vars]="queryRef.variables"
+      tableName="evidence"></cvc-table-downloader>
 
     <cvc-no-more-rows [cvcShowTag]="noMoreRows$ | ngrxPush"></cvc-no-more-rows>
     <nz-filter-trigger

--- a/client/src/app/components/evidence/evidence-table/evidence-table.component.html
+++ b/client/src/app/components/evidence/evidence-table/evidence-table.component.html
@@ -296,7 +296,7 @@
                 nzValue="ADVERSE_RESPONSE"
                 nzLabel="Adverse Response"></nz-option>
               <nz-option
-                nzValue="REDUCED SENSITIVITY"
+                nzValue="REDUCED_SENSITIVITY"
                 nzLabel="Reduced Sensitivity"></nz-option>
               <nz-option
                 nzValue="NA"

--- a/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.config.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.config.ts
@@ -110,11 +110,8 @@ export class EvidenceManagerConfig {
           inputType: 'default',
           options: [{ key: 'EID', value: null }],
           transform: (v) => {
-            if (v) {
-              return +v.toString().replace(/EID/i, '')
-            } else {
-              return null
-            }
+            const match = v?.toString().trim().match(/^(?:EID)?(\d+)$/i)
+            return match ? +match[1] : null
           },
         },
       },

--- a/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.config.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-manager/evidence-manager.config.ts
@@ -129,7 +129,7 @@ export class EvidenceManagerConfig {
           typename: 'MolecularProfile',
           options: [
             {
-              key: 'Filter Therapy Names',
+              key: 'Filter Molecular Profiles',
               value: null,
             },
           ],

--- a/client/src/app/forms/types/evidence-select/evidence-select.type.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-select.type.ts
@@ -3,17 +3,23 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
+  effect,
+  Injector,
   QueryList,
   TemplateRef,
   Type,
   ViewChildren,
 } from '@angular/core'
+import { toSignal } from '@angular/core/rxjs-interop'
 import { ApolloQueryResult } from '@apollo/client/core'
 import { CvcSelectEntityName } from '@app/forms/components/entity-select/entity-select.component'
 import { BaseFieldType } from '@app/forms/mixins/base/base-field'
 import { EntitySelectField } from '@app/forms/mixins/entity-select-field.mixin'
 import {
   AssertionFields,
+  AssertionSignificance,
+  AssertionType,
   EvidenceSelectTagGQL,
   EvidenceSelectTagQuery,
   EvidenceSelectTagQueryVariables,
@@ -174,7 +180,8 @@ export class CvcEvidenceSelectField
     private taq: EvidenceSelectTypeaheadGQL,
     private tq: EvidenceSelectTagGQL,
     private changeDetectorRef: ChangeDetectorRef,
-    private apollo: Apollo
+    private apollo: Apollo,
+    private injector: Injector
   ) {
     super()
     this.onEid$ = new ReplaySubject<Maybe<number[]>>()
@@ -227,6 +234,7 @@ export class CvcEvidenceSelectField
 
   private configureStateConnections() {
     if (!this.state) return
+    this.configureAssertionEvidenceRequirement()
 
     // for each synchronized field specified, find its state.field stream,
     // add it to the synchronized fields array
@@ -305,6 +313,54 @@ export class CvcEvidenceSelectField
       debounceTime(100),
       shareReplay(1)
     )
+  }
+
+  private configureAssertionEvidenceRequirement(): void {
+    const assertionType$ = this.state?.fields.assertionType$
+    const significance$ = this.state?.fields.significance$
+
+    if (!assertionType$ || !significance$) return
+
+    const assertionType = toSignal<Maybe<AssertionType>>(assertionType$, {
+      initialValue: assertionType$.value,
+      injector: this.injector,
+    })
+    const significance = toSignal<Maybe<AssertionSignificance>>(significance$, {
+      initialValue: significance$.value,
+      injector: this.injector,
+    })
+
+    const evidenceItemsRequired = computed(() =>
+      this.assertionRequiresEvidenceItems(assertionType(), significance())
+    )
+
+    effect(
+      () => {
+        this.props.required = evidenceItemsRequired()
+        this.formControl.updateValueAndValidity({ emitEvent: false })
+        this.changeDetectorRef.markForCheck()
+      },
+      { injector: this.injector }
+    )
+  }
+
+  private assertionRequiresEvidenceItems(
+    assertionType: Maybe<AssertionType>,
+    significance: Maybe<AssertionSignificance>
+  ): boolean {
+    const optionalSignificances = [
+      AssertionSignificance.Benign,
+      AssertionSignificance.LikelyBenign,
+      AssertionSignificance.UncertainSignificance,
+    ]
+
+    const optionalBySignificance =
+      assertionType === AssertionType.Oncogenic &&
+      significance !== undefined &&
+      significance !== null &&
+      optionalSignificances.includes(significance)
+
+    return !optionalBySignificance
   }
 
   getTypeaheadVarsFn(id: string, param: Maybe<number>) {

--- a/client/src/app/forms/types/evidence-select/evidence-select.type.ts
+++ b/client/src/app/forms/types/evidence-select/evidence-select.type.ts
@@ -364,8 +364,9 @@ export class CvcEvidenceSelectField
   }
 
   getTypeaheadVarsFn(id: string, param: Maybe<number>) {
+    const match = id.trim().match(/^(?:EID)?(\d+)$/i)
     return {
-      eid: +id.replace(/EID/i, ''),
+      eid: match ? +match[1] : 0,
     }
   }
 

--- a/server/app/validators/assertion_validator.rb
+++ b/server/app/validators/assertion_validator.rb
@@ -1,10 +1,20 @@
 class AssertionValidator < ActiveModel::Validator
+  OPTIONAL_SIGNIFICANCES = [
+    "Benign",
+    "Likely Benign",
+    "Uncertain Significance",
+  ]
+
   def validate(record)
     validator = valid_types[record.assertion_type]
 
     if validator.blank?
       record.errors.add :assertion_type, "Invalid assertion type: #{record.assertion_type}"
       return
+    end
+
+    if record.evidence_item_ids.blank? && !allows_assertion_without_evidence_items?(record)
+      record.errors.add :evidence_item_ids, "At least one Evidence Item is required for this Assertion type and significance."
     end
 
     if !validator[:significance].include? record.significance
@@ -76,6 +86,11 @@ class AssertionValidator < ActiveModel::Validator
     if record.variant_origin == "Combined" && !record.molecular_profile.is_multi_variant?
       record.errors.add :variant_origin, "Combined variant origin can only apply when the Molecular Profile has multiple Variants."
     end
+  end
+
+  def allows_assertion_without_evidence_items?(record)
+    record.assertion_type == "Oncogenic" &&
+      OPTIONAL_SIGNIFICANCES.include?(record.significance)
   end
 
   def valid_types

--- a/server/test/fixtures/assertions_evidence_items.yml
+++ b/server/test/fixtures/assertions_evidence_items.yml
@@ -1,0 +1,19 @@
+submitted_assertion_accepted_ei:
+  assertion_id: <%= ActiveRecord::FixtureSet.identify(:submitted_assertion) %>
+  evidence_item_id: <%= ActiveRecord::FixtureSet.identify(:accepted_ei) %>
+
+accepted_assertion_accepted_ei:
+  assertion_id: <%= ActiveRecord::FixtureSet.identify(:accepted_assertion) %>
+  evidence_item_id: <%= ActiveRecord::FixtureSet.identify(:accepted_ei) %>
+
+accepted_unapproved_assertion_accepted_ei:
+  assertion_id: <%= ActiveRecord::FixtureSet.identify(:accepted_unapproved_assertion) %>
+  evidence_item_id: <%= ActiveRecord::FixtureSet.identify(:accepted_ei) %>
+
+submitted_assertion_by_editor_accepted_ei:
+  assertion_id: <%= ActiveRecord::FixtureSet.identify(:submitted_assertion_by_editor) %>
+  evidence_item_id: <%= ActiveRecord::FixtureSet.identify(:accepted_ei) %>
+
+flagged_assertion_accepted_ei:
+  assertion_id: <%= ActiveRecord::FixtureSet.identify(:flagged_assertion) %>
+  evidence_item_id: <%= ActiveRecord::FixtureSet.identify(:accepted_ei) %>


### PR DESCRIPTION
The primary change in this PR is allowing Oncogenic Assertions that are benign/likely benign/vus to be created without any associated EIDs.

There are a number of other small bug fixes here including mislabeled placeholder text and outdated enum values in filters 