### PR TITLE
Update approver/coi behavior

### DIFF
--- a/client/src/app/components/approvals/approval-pipes/approval.functions.ts
+++ b/client/src/app/components/approvals/approval-pipes/approval.functions.ts
@@ -20,7 +20,7 @@ export function canPerformApprovalActions(viewer: Maybe<Viewer>): boolean {
     viewer !== undefined &&
     viewer.mostRecentOrg !== undefined &&
     viewer.signedIn &&
-    !viewer.invalidCoi &&
+    viewer.hasValidCoiStatement &&
     viewer.approvableOrgIds.length > 0
   )
 }

--- a/client/src/app/components/layout/viewer-button/viewer-button.component.html
+++ b/client/src/app/components/layout/viewer-button/viewer-button.component.html
@@ -65,7 +65,7 @@
             [user]="user"
             [size]="22"
             shape="circle"
-            [ngClass]="{ 'update-coi': viewer.invalidCoi }"
+            [ngClass]="{ 'update-coi': viewer.coiNeedsUpdate }"
             *nzSpaceItem></cvc-user-avatar>
           <ng-container *ngIf="!cvcCollapsed">
             <div
@@ -100,9 +100,9 @@
     <!-- VIEWER BUTTON DROPDOWN MENU -->
     <nz-dropdown-menu #userMenu="nzDropdownMenu">
       <ul nz-menu>
-        <!-- INVALID COI STATEMENT GROUP -->
+        <!-- COI STATEMENT UPDATE GROUP -->
         <li
-          *ngIf="viewer.invalidCoi"
+          *ngIf="viewer.coiNeedsUpdate"
           nz-menu-group
           [nzTitle]="coiGroupTitle">
           <ng-template #coiGroupTitle>
@@ -112,13 +112,13 @@
               <i
                 nz-icon
                 nzType="exclamation-circle"></i>
-              Conflict of Interest Invalid
+              Conflict of Interest Statement Needed
             </span>
           </ng-template>
           <ul>
             <li nz-menu-item>
               <button
-                *ngIf="viewer.invalidCoi"
+                *ngIf="viewer.coiNeedsUpdate"
                 (click)="coiUpdateModalVisible = true"
                 nz-button
                 nzType="primary"
@@ -126,7 +126,7 @@
                 nzSize="small"
                 nzDanger
                 nzBlock>
-                Please Update COI statement
+                Update COI Statement
               </button>
             </li>
           </ul>

--- a/client/src/app/core/services/viewer/viewer.service.ts
+++ b/client/src/app/core/services/viewer/viewer.service.ts
@@ -24,7 +24,8 @@ export interface Viewer {
   isCurator: boolean
   canCurate: boolean
   canModerate: boolean
-  invalidCoi: boolean
+  coiNeedsUpdate: boolean
+  hasValidCoiStatement: boolean
 }
 
 @UntilDestroy()
@@ -63,13 +64,8 @@ export class ViewerService {
               ? []
               : v.organizationsWithApprovalPrivileges?.map((o: any) => o.id) ||
                 [],
-          invalidCoi:
-            isEditor(v) &&
-            (!v?.mostRecentConflictOfInterestStatement ||
-              v?.mostRecentConflictOfInterestStatement.coiStatus ===
-                CoiStatus.Expired ||
-              v?.mostRecentConflictOfInterestStatement.coiStatus ===
-                CoiStatus.Missing),
+          coiNeedsUpdate: coiNeedsUpdate(v),
+          hasValidCoiStatement: hasValidCoiStatement(v),
         }
       }),
       shareReplay(1)
@@ -99,14 +95,21 @@ export class ViewerService {
     }
 
     function canModerate(v?: ViewerFieldsFragment): boolean {
-      return v &&
-        (v.role === UserRole.Editor || v.role === UserRole.Admin) &&
-        v.mostRecentConflictOfInterestStatement &&
-        (v.mostRecentConflictOfInterestStatement?.coiStatus ==
-          CoiStatus.Conflict ||
-          v.mostRecentConflictOfInterestStatement?.coiStatus == CoiStatus.Valid)
-        ? true
-        : false
+      return isEditor(v) && hasValidCoiStatement(v)
+    }
+
+    function coiNeedsUpdate(v?: ViewerFieldsFragment): boolean {
+      if (!v) return false
+
+      const status = v.mostRecentConflictOfInterestStatement?.coiStatus
+      return (
+        !status || status === CoiStatus.Expired || status === CoiStatus.Missing
+      )
+    }
+
+    function hasValidCoiStatement(v?: ViewerFieldsFragment): boolean {
+      const status = v?.mostRecentConflictOfInterestStatement?.coiStatus
+      return status === CoiStatus.Conflict || status === CoiStatus.Valid
     }
 
     function mostRecentOrg(

--- a/client/src/app/views/assertions/assertions-detail/assertions-detail.view.html
+++ b/client/src/app/views/assertions/assertions-detail/assertions-detail.view.html
@@ -56,28 +56,26 @@
               </cvc-entity-subscription-button>
             }
 
-            <!-- CURATION ACTION BUTTONS-->
-            @if (vwr.canModerate) {
-              @if (entity.status === 'SUBMITTED') {
-                <!-- Revert Button -->
-                <cvc-revert-entity-button
-                  *nzSpaceItem
-                  entityType="Assertion"
-                  [entityId]="entity.id"
-                  (onReverted)="onRevert($event)">
-                </cvc-revert-entity-button>
-              }
-              <!-- Create Approval Button -->
-              @if (vwr | canPerformApprovalActions) {
-                <cvc-approve-assertion-button
-                  *nzSpaceItem
-                  mode="approve"
-                  [assertionId]="entity.id"
-                  [disabled]="!(vwr | canCreateApproval: entity)"
-                  [tooltipText]="vwr | approvalActionTooltip: 'create' : entity"
-                  (onApproved)="onApproval($event)">
-                </cvc-approve-assertion-button>
-              }
+            <!-- CURATION ACTION BUTTONS -->
+            @if (vwr.canModerate && entity.status === 'SUBMITTED') {
+              <!-- Revert Button -->
+              <cvc-revert-entity-button
+                *nzSpaceItem
+                entityType="Assertion"
+                [entityId]="entity.id"
+                (onReverted)="onRevert($event)">
+              </cvc-revert-entity-button>
+            }
+            <!-- Create Approval Button -->
+            @if (vwr | canPerformApprovalActions) {
+              <cvc-approve-assertion-button
+                *nzSpaceItem
+                mode="approve"
+                [assertionId]="entity.id"
+                [disabled]="!(vwr | canCreateApproval: entity)"
+                [tooltipText]="vwr | approvalActionTooltip: 'create' : entity"
+                (onApproved)="onApproval($event)">
+              </cvc-approve-assertion-button>
             }
           </nz-space>
         }

--- a/client/src/app/views/users/users-detail/users-detail.component.html
+++ b/client/src/app/views/users/users-detail/users-detail.component.html
@@ -234,11 +234,10 @@
               </nz-descriptions-item>
             </nz-descriptions>
 
-            <!-- Editor COI card -->
-            <ng-container
-              *ngIf="user.role === 'EDITOR' || user.role === 'ADMIN'">
+            <!-- COI card -->
+            <ng-container>
               <nz-card
-                class="editor-coi-card"
+                class="user-coi-card"
                 [nzTitle]="statementTitle"
                 nzSize="small"
                 [nzExtra]="updateCoi"
@@ -249,7 +248,7 @@
                     [nzType]="'civic-' + (user.role | lowercase)"
                     nzTheme="twotone"
                     [nzTwotoneColor]="user.role | titlecase | entityColor"></i>
-                  Editor Conflict of Interest Statement
+                  Conflict of Interest Statement
                 </ng-template>
                 <ng-template #updateCoi>
                   <ng-container *ngIf="ownProfile$ | ngrxPush">

--- a/client/src/app/views/users/users-detail/users-detail.component.less
+++ b/client/src/app/views/users/users-detail/users-detail.component.less
@@ -35,7 +35,7 @@
   }
 }
 
-.editor-coi-card {
+.user-coi-card {
   ::ng-deep .ant-card-body {
     padding: 0;
     // prevent card body and descriptions container double width border

--- a/client/src/app/views/users/users-detail/users-detail.component.ts
+++ b/client/src/app/views/users/users-detail/users-detail.component.ts
@@ -135,6 +135,7 @@ export class UsersDetailComponent implements OnDestroy {
   coiUpdated() {
     this.updateCoiModalVisible = false
     this.queryRef?.refetch()
+    this.viewerService.refetch()
   }
 
   profileUpdated() {


### PR DESCRIPTION
This update does a couple of things around COI and Approvals.

* It makes it so the approval button will be shown even if a user is not an editor, if they have approval permissions
* It makes it so that any user (not just editors and admins) may fill out a COI statement
* It does not change any backend behavior yet, curators may continue to submit things for now regardless of COI status
* An up-to-date COI is still required for editorial actions and approval actions.