### PR TITLE
Add dedicated page for news items

### DIFF
--- a/client/src/app/components/news/news-item-list/news-item-list.component.html
+++ b/client/src/app/components/news/news-item-list/news-item-list.component.html
@@ -1,0 +1,61 @@
+@if (loading) {
+  <nz-row
+    role="status"
+    aria-label="Loading news and events"
+    [nzGutter]="[8, 16]">
+    <nz-col nzSpan="24">
+      <nz-card nzSize="small">
+        <nz-skeleton [nzActive]="true"></nz-skeleton>
+      </nz-card>
+    </nz-col>
+  </nz-row>
+} @else if (errorMessage) {
+  <nz-alert
+    nzType="error"
+    nzMessage="Unable to load news and events"
+    [nzDescription]="errorMessage"
+    [nzAction]="retryAction"
+    [nzShowIcon]="true">
+  </nz-alert>
+  <ng-template #retryAction>
+    <button
+      type="button"
+      nz-button
+      nzSize="small"
+      (click)="retry.emit()">
+      Retry
+    </button>
+  </ng-template>
+} @else if (items.length === 0) {
+  <nz-empty
+    nzNotFoundImage="simple"
+    nzNotFoundContent="No news or events are available.">
+  </nz-empty>
+} @else {
+  <nz-row [nzGutter]="[8, 16]">
+    @for (item of items; track item.id) {
+      <nz-col nzSpan="24">
+        <article [attr.aria-labelledby]="'news-item-title-' + item.id">
+          <nz-card
+            nzSize="small"
+            [nzTitle]="newsHeader">
+            <div
+              class="news-post"
+              [innerHTML]="item.contentHtml || ''"></div>
+          </nz-card>
+        </article>
+
+        <ng-template #newsHeader>
+          <header class="news-item-header">
+            <h2 [id]="'news-item-title-' + item.id">{{ item.title }}</h2>
+            @if (item.publishedAt) {
+              <time [attr.datetime]="item.publishedAt">
+                {{ item.publishedAt | date }}
+              </time>
+            }
+          </header>
+        </ng-template>
+      </nz-col>
+    }
+  </nz-row>
+}

--- a/client/src/app/components/news/news-item-list/news-item-list.component.less
+++ b/client/src/app/components/news/news-item-list/news-item-list.component.less
@@ -1,0 +1,58 @@
+@import 'themes/global-variables.less';
+
+:host,
+article {
+  display: block;
+}
+
+.news-item-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: @default-padding-xs @default-padding-sm;
+  width: 100%;
+
+  h2 {
+    margin: 0;
+    color: @heading-color;
+    font-size: @font-size-lg;
+    line-height: 1.5;
+  }
+
+  time {
+    flex: 0 0 auto;
+    color: @text-color-secondary;
+    font-weight: normal;
+    white-space: nowrap;
+  }
+}
+
+.news-post {
+  overflow-wrap: anywhere;
+}
+
+:host ::ng-deep .news-post {
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  iframe {
+    max-width: 100%;
+  }
+
+  table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}
+
+@media (max-width: 575px) {
+  .news-item-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: @default-padding-xss;
+  }
+}

--- a/client/src/app/components/news/news-item-list/news-item-list.component.ts
+++ b/client/src/app/components/news/news-item-list/news-item-list.component.ts
@@ -1,0 +1,39 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { NewsItemFieldsFragment } from '@app/generated/civic.apollo'
+import { NzAlertModule } from 'ng-zorro-antd/alert'
+import { NzButtonModule } from 'ng-zorro-antd/button'
+import { NzCardModule } from 'ng-zorro-antd/card'
+import { NzEmptyModule } from 'ng-zorro-antd/empty'
+import { NzGridModule } from 'ng-zorro-antd/grid'
+import { NzSkeletonModule } from 'ng-zorro-antd/skeleton'
+
+@Component({
+  selector: 'cvc-news-item-list',
+  templateUrl: './news-item-list.component.html',
+  styleUrls: ['./news-item-list.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    CommonModule,
+    NzAlertModule,
+    NzButtonModule,
+    NzCardModule,
+    NzEmptyModule,
+    NzGridModule,
+    NzSkeletonModule,
+  ],
+})
+export class NewsItemListComponent {
+  @Input() items: NewsItemFieldsFragment[] = []
+  @Input() loading = false
+  @Input() errorMessage?: string
+
+  @Output() retry = new EventEmitter<void>()
+}

--- a/client/src/app/components/news/news-item-list/news-item-list.fragment.gql
+++ b/client/src/app/components/news/news-item-list/news-item-list.fragment.gql
@@ -1,0 +1,6 @@
+fragment NewsItemFields on NewsItem {
+  id
+  title
+  publishedAt
+  contentHtml
+}

--- a/client/src/app/generated/civic.apollo-helpers.ts
+++ b/client/src/app/generated/civic.apollo-helpers.ts
@@ -1931,6 +1931,19 @@ export type NewsItemFieldPolicy = {
 	publishedAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	title?: FieldPolicy<any> | FieldReadFunction<any>
 };
+export type NewsItemConnectionKeySpecifier = ('edges' | 'nodes' | 'pageCount' | 'pageInfo' | 'totalCount' | NewsItemConnectionKeySpecifier)[];
+export type NewsItemConnectionFieldPolicy = {
+	edges?: FieldPolicy<any> | FieldReadFunction<any>,
+	nodes?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageCount?: FieldPolicy<any> | FieldReadFunction<any>,
+	pageInfo?: FieldPolicy<any> | FieldReadFunction<any>,
+	totalCount?: FieldPolicy<any> | FieldReadFunction<any>
+};
+export type NewsItemEdgeKeySpecifier = ('cursor' | 'node' | NewsItemEdgeKeySpecifier)[];
+export type NewsItemEdgeFieldPolicy = {
+	cursor?: FieldPolicy<any> | FieldReadFunction<any>,
+	node?: FieldPolicy<any> | FieldReadFunction<any>
+};
 export type NotificationKeySpecifier = ('createdAt' | 'event' | 'id' | 'notifiedUser' | 'originatingUser' | 'seen' | 'subscription' | 'type' | 'updatedAt' | NotificationKeySpecifier)[];
 export type NotificationFieldPolicy = {
 	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -3707,6 +3720,14 @@ export type StrictTypedTypePolicies = {
 	NewsItem?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | NewsItemKeySpecifier | (() => undefined | NewsItemKeySpecifier),
 		fields?: NewsItemFieldPolicy,
+	},
+	NewsItemConnection?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | NewsItemConnectionKeySpecifier | (() => undefined | NewsItemConnectionKeySpecifier),
+		fields?: NewsItemConnectionFieldPolicy,
+	},
+	NewsItemEdge?: Omit<TypePolicy, "fields" | "keyFields"> & {
+		keyFields?: false | NewsItemEdgeKeySpecifier | (() => undefined | NewsItemEdgeKeySpecifier),
+		fields?: NewsItemEdgeFieldPolicy,
 	},
 	Notification?: Omit<TypePolicy, "fields" | "keyFields"> & {
 		keyFields?: false | NotificationKeySpecifier | (() => undefined | NotificationKeySpecifier),

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -5071,6 +5071,30 @@ export type NewsItem = {
   title: Scalars['String']['output'];
 };
 
+/** The connection type for NewsItem. */
+export type NewsItemConnection = {
+  __typename: 'NewsItemConnection';
+  /** A list of edges. */
+  edges: Array<NewsItemEdge>;
+  /** A list of nodes. */
+  nodes: Array<NewsItem>;
+  /** Total number of pages, based on filtered count and pagesize. */
+  pageCount: Scalars['Int']['output'];
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The total number of records in this filtered collection. */
+  totalCount: Scalars['Int']['output'];
+};
+
+/** An edge in a connection. */
+export type NewsItemEdge = {
+  __typename: 'NewsItemEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge. */
+  node?: Maybe<NewsItem>;
+};
+
 export type Notification = {
   __typename: 'Notification';
   createdAt: Scalars['ISO8601DateTime']['output'];
@@ -5568,7 +5592,8 @@ export type Query = {
   nccnGuideline?: Maybe<NccnGuideline>;
   /** Retrieve NCCN Guideline options as a typeahead */
   nccnGuidelinesTypeahead: Array<NccnGuideline>;
-  newsItems: Array<NewsItem>;
+  /** List published news items. */
+  newsItems: NewsItemConnection;
   /** List and filter notifications for the logged in user. */
   notifications: NotificationConnection;
   /** Find an organization by CIViC ID */
@@ -6159,6 +6184,14 @@ export type QueryNccnGuidelineArgs = {
 
 export type QueryNccnGuidelinesTypeaheadArgs = {
   queryTerm: Scalars['String']['input'];
+};
+
+
+export type QueryNewsItemsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -9859,6 +9892,8 @@ export type MolecularProfileMenuQuery = { __typename: 'Query', molecularProfiles
 
 export type MenuMolecularProfileFragment = { __typename: 'MolecularProfile', id: number, name: string, link: string, flagged: boolean, deprecated: boolean };
 
+export type NewsItemFieldsFragment = { __typename: 'NewsItem', id: number, title: string, publishedAt?: any | undefined, contentHtml?: string | undefined };
+
 export type LeaderboardOrganizationFieldsFragment = { __typename: 'LeaderboardOrganization', id: number, name: string, actionCount: number, rank: number, profileImagePath?: string | undefined };
 
 export type OrganizationCommentsLeaderboardQueryVariables = Exact<{
@@ -11503,6 +11538,14 @@ type VariantMolecularProfileCardFields_Variant_Fragment = { __typename: 'Variant
 
 export type VariantMolecularProfileCardFieldsFragment = VariantMolecularProfileCardFields_FactorVariant_Fragment | VariantMolecularProfileCardFields_FusionVariant_Fragment | VariantMolecularProfileCardFields_GeneVariant_Fragment | VariantMolecularProfileCardFields_RegionVariant_Fragment | VariantMolecularProfileCardFields_Variant_Fragment;
 
+export type NewsItemsPageQueryVariables = Exact<{
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type NewsItemsPageQuery = { __typename: 'Query', newsItems: { __typename: 'NewsItemConnection', totalCount: number, edges: Array<{ __typename: 'NewsItemEdge', cursor: string, node?: { __typename: 'NewsItem', id: number, title: string, publishedAt?: any | undefined, contentHtml?: string | undefined } | undefined }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | undefined, hasNextPage: boolean } } };
+
 export type OrganizationDetailQueryVariables = Exact<{
   organizationId: Scalars['Int']['input'];
 }>;
@@ -11736,9 +11779,7 @@ export type MyVariantInfoFieldsFragment = { __typename: 'MyVariantInfo', myVaria
 export type HomepageNewsItemsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type HomepageNewsItemsQuery = { __typename: 'Query', newsItems: Array<{ __typename: 'NewsItem', publishedAt?: any | undefined, contentHtml?: string | undefined, title: string }> };
-
-export type NewsItemFragment = { __typename: 'NewsItem', publishedAt?: any | undefined, contentHtml?: string | undefined, title: string };
+export type HomepageNewsItemsQuery = { __typename: 'Query', newsItems: { __typename: 'NewsItemConnection', edges: Array<{ __typename: 'NewsItemEdge', cursor: string, node?: { __typename: 'NewsItem', id: number, title: string, publishedAt?: any | undefined, contentHtml?: string | undefined } | undefined }> } };
 
 export const ActivitiesPageInfoFieldsFragmentDoc = gql`
     fragment ActivitiesPageInfoFields on ActivityInterfaceConnection {
@@ -13314,6 +13355,14 @@ export const MenuMolecularProfileFragmentDoc = gql`
   link
   flagged
   deprecated
+}
+    `;
+export const NewsItemFieldsFragmentDoc = gql`
+    fragment NewsItemFields on NewsItem {
+  id
+  title
+  publishedAt
+  contentHtml
 }
     `;
 export const LeaderboardOrganizationFieldsFragmentDoc = gql`
@@ -16076,13 +16125,6 @@ ${GeneVariantSummaryFieldsFragmentDoc}
 ${FactorVariantSummaryFieldsFragmentDoc}
 ${FusionVariantSummaryFieldsFragmentDoc}
 ${RegionVariantSummaryFieldsFragmentDoc}`;
-export const NewsItemFragmentDoc = gql`
-    fragment newsItem on NewsItem {
-  publishedAt
-  contentHtml
-  title
-}
-    `;
 export const ActivityFeedDocument = gql`
     query ActivityFeed($subject: [SubscribableQueryInput!], $first: Int, $last: Int, $before: String, $after: String, $organizationId: [Int!], $includeSubgroups: Boolean!, $userId: [Int!], $activityType: [ActivityTypeInput!], $subjectType: [ActivitySubjectInput!], $linkedApprovalId: Int, $includeAutomatedEvents: Boolean, $includeConnection: Boolean = true, $includePageInfo: Boolean = true, $mode: EventFeedMode, $showFilters: Boolean!, $requestDetails: Boolean!, $occurredAfter: ISO8601DateTime, $occurredBefore: ISO8601DateTime, $sortBy: DateSort) {
   activities(
@@ -21035,6 +21077,34 @@ export const MolecularProfileSummaryDocument = gql`
       super(apollo);
     }
   }
+export const NewsItemsPageDocument = gql`
+    query NewsItemsPage($first: Int!, $after: String) {
+  newsItems(first: $first, after: $after) {
+    edges {
+      cursor
+      node {
+        ...NewsItemFields
+      }
+    }
+    totalCount
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+    ${NewsItemFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class NewsItemsPageGQL extends Apollo.Query<NewsItemsPageQuery, NewsItemsPageQueryVariables> {
+    document = NewsItemsPageDocument;
+
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
 export const OrganizationDetailDocument = gql`
     query OrganizationDetail($organizationId: Int!) {
   organization(id: $organizationId) {
@@ -21473,11 +21543,16 @@ export const VariantSummaryDocument = gql`
   }
 export const HomepageNewsItemsDocument = gql`
     query HomepageNewsItems {
-  newsItems {
-    ...newsItem
+  newsItems(first: 5) {
+    edges {
+      cursor
+      node {
+        ...NewsItemFields
+      }
+    }
   }
 }
-    ${NewsItemFragmentDoc}`;
+    ${NewsItemFieldsFragmentDoc}`;
 
   @Injectable({
     providedIn: 'root'

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -41386,6 +41386,154 @@
       },
       {
         "kind": "OBJECT",
+        "name": "NewsItemConnection",
+        "description": "The connection type for NewsItem.",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": "A list of edges.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": null,
+                "kind": "LIST",
+                "ofType": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "name": "NewsItemEdge",
+                    "kind": "OBJECT",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": "A list of nodes.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": null,
+                "kind": "LIST",
+                "ofType": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "name": "NewsItem",
+                    "kind": "OBJECT",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageCount",
+            "description": "Total number of pages, based on filtered count and pagesize.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "Int",
+                "kind": "SCALAR",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "Information to aid in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "PageInfo",
+                "kind": "OBJECT",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "The total number of records in this filtered collection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "Int",
+                "kind": "SCALAR",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NewsItemEdge",
+        "description": "An edge in a connection.",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "name": "String",
+                "kind": "SCALAR",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The item at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "NewsItem",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Notification",
         "description": null,
         "isOneOf": null,
@@ -48931,23 +49079,64 @@
           },
           {
             "name": "newsItems",
-            "description": null,
-            "args": [],
+            "description": "List published news items.",
+            "args": [
+              {
+                "name": "after",
+                "description": "Returns the elements in the list that come after the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Returns the elements in the list that come before the specified cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "Returns the first _n_ elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Returns the last _n_ elements from the list.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "name": null,
-                "kind": "LIST",
-                "ofType": {
-                  "name": null,
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "name": "NewsItem",
-                    "kind": "OBJECT",
-                    "ofType": null
-                  }
-                }
+                "name": "NewsItemConnection",
+                "kind": "OBJECT",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -8440,6 +8440,51 @@ type NewsItem {
   title: String!
 }
 
+"""
+The connection type for NewsItem.
+"""
+type NewsItemConnection {
+  """
+  A list of edges.
+  """
+  edges: [NewsItemEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [NewsItem!]!
+
+  """
+  Total number of pages, based on filtered count and pagesize.
+  """
+  pageCount: Int!
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  The total number of records in this filtered collection.
+  """
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type NewsItemEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: NewsItem
+}
+
 type Notification {
   createdAt: ISO8601DateTime!
   event: Event!
@@ -10412,7 +10457,31 @@ type Query {
   Retrieve NCCN Guideline options as a typeahead
   """
   nccnGuidelinesTypeahead(queryTerm: String!): [NccnGuideline!]!
-  newsItems: [NewsItem!]!
+
+  """
+  List published news items.
+  """
+  newsItems(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): NewsItemConnection!
 
   """
   List and filter notifications for the logged in user.

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -41192,6 +41192,152 @@
         },
         {
           "kind": "OBJECT",
+          "name": "NewsItemConnection",
+          "description": "The connection type for NewsItem.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NewsItemEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NewsItem",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageCount",
+              "description": "Total number of pages, based on filtered count and pagesize.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "The total number of records in this filtered collection.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NewsItemEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "NewsItem",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Notification",
           "description": null,
           "fields": [
@@ -48706,23 +48852,64 @@
             },
             {
               "name": "newsItems",
-              "description": null,
-              "args": [],
+              "description": "List published news items.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "NewsItem",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "OBJECT",
+                  "name": "NewsItemConnection",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,

--- a/client/src/app/graphql/graphql.type-policies.ts
+++ b/client/src/app/graphql/graphql.type-policies.ts
@@ -88,6 +88,7 @@ export const CvcTypePolicies: StrictTypedTypePolicies = {
         'eventType',
       ]),
       variants: relayStylePagination(['featureId', 'name']),
+      newsItems: relayStylePagination(),
       molecularProfiles: relayStylePagination([
         'featureId',
         'name',
@@ -190,7 +191,7 @@ export const CvcTypePolicies: StrictTypedTypePolicies = {
         'organizatioName',
         'subjectType',
         'id',
-      ])
+      ]),
     },
   },
   AdvancedSearchResult: CvcAdvancedSearchResultPolicy as any,

--- a/client/src/app/layout/layout-routing.module.ts
+++ b/client/src/app/layout/layout-routing.module.ts
@@ -190,6 +190,14 @@ const routes: Routes = [
         },
       },
       {
+        path: 'news',
+        loadChildren: () =>
+          import('@app/views/news/news.module').then((m) => m.NewsModule),
+        data: {
+          breadcrumb: 'News & Events',
+        },
+      },
+      {
         path: 'releases',
         loadChildren: () =>
           import('@app/views/releases/releases.module').then(

--- a/client/src/app/layout/layout.component.html
+++ b/client/src/app/layout/layout.component.html
@@ -269,6 +269,21 @@
             nz-menu-item
             nz-tooltip
             nzTooltipPlacement="right"
+            [nzTooltipTitle]="isCollapsed ? 'News & Events' : ''"
+            nzMatchRouter>
+            <i
+              nz-icon
+              nzType="notification"></i>
+            <a
+              routerLink="/news"
+              id="news">
+              <span>News & Events</span>
+            </a>
+          </li>
+          <li
+            nz-menu-item
+            nz-tooltip
+            nzTooltipPlacement="right"
             [nzTooltipTitle]="isCollapsed ? 'Data Releases' : ''"
             nzMatchRouter>
             <i

--- a/client/src/app/layout/layout.component.html
+++ b/client/src/app/layout/layout.component.html
@@ -269,21 +269,6 @@
             nz-menu-item
             nz-tooltip
             nzTooltipPlacement="right"
-            [nzTooltipTitle]="isCollapsed ? 'News & Events' : ''"
-            nzMatchRouter>
-            <i
-              nz-icon
-              nzType="notification"></i>
-            <a
-              routerLink="/news"
-              id="news">
-              <span>News & Events</span>
-            </a>
-          </li>
-          <li
-            nz-menu-item
-            nz-tooltip
-            nzTooltipPlacement="right"
             [nzTooltipTitle]="isCollapsed ? 'Data Releases' : ''"
             nzMatchRouter>
             <i
@@ -389,6 +374,16 @@
               <a routerLink="/pages/about">{{
                 isCollapsed ? 'About' : 'About CIViC'
               }}</a>
+            </li>
+            <li
+              nz-menu-item
+              nzSelected
+              nzMatchRouter>
+              <a
+                routerLink="/news"
+                id="news">
+                {{ isCollapsed ? 'News' : 'News & Events' }}
+              </a>
             </li>
             <li
               nz-menu-item

--- a/client/src/app/views/news/news-routing.module.ts
+++ b/client/src/app/views/news/news-routing.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core'
+import { RouterModule, Routes } from '@angular/router'
+import { NewsPage } from './news.page'
+
+const routes: Routes = [{ path: '', component: NewsPage }]
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class NewsRoutingModule {}

--- a/client/src/app/views/news/news.module.ts
+++ b/client/src/app/views/news/news.module.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common'
+import { NgModule } from '@angular/core'
+import { NewsItemListComponent } from '@app/components/news/news-item-list/news-item-list.component'
+import { CvcSectionNavigationModule } from '@app/components/shared/section-navigation/section-navigation.module'
+import { NzAlertModule } from 'ng-zorro-antd/alert'
+import { NzButtonModule } from 'ng-zorro-antd/button'
+import { NzPageHeaderModule } from 'ng-zorro-antd/page-header'
+import { NewsRoutingModule } from './news-routing.module'
+import { NewsPage } from './news.page'
+
+@NgModule({
+  declarations: [NewsPage],
+  imports: [
+    CommonModule,
+    NewsRoutingModule,
+    NzAlertModule,
+    NzButtonModule,
+    NzPageHeaderModule,
+    CvcSectionNavigationModule,
+    NewsItemListComponent,
+  ],
+})
+export class NewsModule {}

--- a/client/src/app/views/news/news.page.html
+++ b/client/src/app/views/news/news.page.html
@@ -1,0 +1,60 @@
+<cvc-section-navigation displayName="News & Events"></cvc-section-navigation>
+
+<nz-page-header class="site-page-header">
+  <h1 nz-page-header-title>News & Events</h1>
+  <nz-page-header-subtitle>
+    Updates and announcements from the CIViC community
+  </nz-page-header-subtitle>
+
+  <nz-page-header-content>
+    <div class="news-page-content">
+      @if (!loading() && !errorMessage() && totalCount() > 0) {
+        <p
+          class="results-summary"
+          aria-live="polite">
+          Showing {{ newsItems().length }} of {{ totalCount() }} news items
+        </p>
+      }
+
+      <cvc-news-item-list
+        [items]="newsItems()"
+        [loading]="loading()"
+        [errorMessage]="errorMessage()"
+        (retry)="retryNewsItems()">
+      </cvc-news-item-list>
+
+      <div
+        #loadMoreSentinel
+        class="load-more-sentinel"
+        aria-live="polite">
+        @if (loadMoreError()) {
+          <nz-alert
+            nzType="error"
+            nzMessage="Unable to load more news and events"
+            [nzDescription]="loadMoreError() ?? null"
+            [nzShowIcon]="true">
+          </nz-alert>
+        }
+
+        @if (hasNextPage()) {
+          <button
+            type="button"
+            nz-button
+            [nzLoading]="loadingMore()"
+            [attr.aria-busy]="loadingMore()"
+            (click)="loadMoreNewsItems()">
+            @if (loadingMore()) {
+              Loading more news and events
+            } @else if (loadMoreError()) {
+              Retry loading news and events
+            } @else {
+              Load more news and events
+            }
+          </button>
+        } @else if (!loading() && !errorMessage() && newsItems().length > 0) {
+          <span class="end-of-feed">All news and events are loaded.</span>
+        }
+      </div>
+    </div>
+  </nz-page-header-content>
+</nz-page-header>

--- a/client/src/app/views/news/news.page.less
+++ b/client/src/app/views/news/news.page.less
@@ -1,0 +1,39 @@
+@import 'themes/global-variables.less';
+@import 'themes/overrides/entity-page-header.overrides.less';
+
+.news-page-content {
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.results-summary {
+  margin-bottom: @default-padding-sm;
+  color: @text-color-secondary;
+  text-align: right;
+}
+
+.load-more-sentinel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: @default-padding-sm;
+  min-height: 40px;
+  margin-top: @default-padding-lg;
+  text-align: center;
+
+  nz-alert {
+    width: 100%;
+  }
+}
+
+.end-of-feed {
+  color: @text-color-secondary;
+}
+
+@media (max-width: 575px) {
+  .results-summary {
+    text-align: left;
+  }
+}

--- a/client/src/app/views/news/news.page.ts
+++ b/client/src/app/views/news/news.page.ts
@@ -1,0 +1,168 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  inject,
+  signal,
+} from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
+import {
+  NewsItemFieldsFragment,
+  NewsItemsPageGQL,
+} from '@app/generated/civic.apollo'
+
+@Component({
+  selector: 'cvc-news-page',
+  templateUrl: './news.page.html',
+  styleUrls: ['./news.page.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class NewsPage implements OnInit, AfterViewInit, OnDestroy {
+  @ViewChild('loadMoreSentinel', { static: true })
+  private loadMoreSentinel!: ElementRef<HTMLElement>
+
+  readonly pageSize = 10
+  readonly totalCount = signal(0)
+  readonly newsItems = signal<NewsItemFieldsFragment[]>([])
+  readonly loading = signal(true)
+  readonly loadingMore = signal(false)
+  readonly hasNextPage = signal(false)
+  readonly errorMessage = signal<string | undefined>(undefined)
+  readonly loadMoreError = signal<string | undefined>(undefined)
+
+  private readonly destroyRef = inject(DestroyRef)
+  private endCursor?: string
+  private intersectionObserver?: IntersectionObserver
+  private sentinelRefreshFrame?: number
+
+  constructor(private readonly gql: NewsItemsPageGQL) {}
+
+  ngOnInit(): void {
+    this.loadPage()
+  }
+
+  ngAfterViewInit(): void {
+    if (typeof IntersectionObserver === 'undefined') return
+
+    this.intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          this.loadMoreNewsItems()
+        }
+      },
+      { rootMargin: '300px 0px' }
+    )
+    this.intersectionObserver.observe(this.loadMoreSentinel.nativeElement)
+  }
+
+  ngOnDestroy(): void {
+    this.intersectionObserver?.disconnect()
+    if (this.sentinelRefreshFrame !== undefined) {
+      cancelAnimationFrame(this.sentinelRefreshFrame)
+    }
+  }
+
+  retryNewsItems(): void {
+    this.loadPage()
+  }
+
+  loadMoreNewsItems(): void {
+    if (
+      this.loading() ||
+      this.loadingMore() ||
+      !this.hasNextPage() ||
+      !this.endCursor
+    ) {
+      return
+    }
+
+    this.loadPage(this.endCursor)
+  }
+
+  private loadPage(after?: string): void {
+    const appending = after !== undefined
+
+    if (appending) {
+      this.loadingMore.set(true)
+      this.loadMoreError.set(undefined)
+    } else {
+      this.newsItems.set([])
+      this.totalCount.set(0)
+      this.endCursor = undefined
+      this.hasNextPage.set(false)
+      this.loading.set(true)
+      this.errorMessage.set(undefined)
+      this.loadMoreError.set(undefined)
+    }
+
+    this.gql
+      .fetch({ first: this.pageSize, after }, { fetchPolicy: 'network-only' })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ data }) => {
+          const connection = data.newsItems
+          const incomingItems = connection.edges
+            .map(({ node }) => node)
+            .filter(
+              (node): node is NewsItemFieldsFragment => node !== undefined
+            )
+          this.newsItems.update((items) =>
+            appending
+              ? this.appendUniqueItems(items, incomingItems)
+              : incomingItems
+          )
+          this.totalCount.set(connection.totalCount)
+          this.endCursor = connection.pageInfo.endCursor ?? undefined
+          this.hasNextPage.set(connection.pageInfo.hasNextPage)
+          this.loading.set(false)
+          this.loadingMore.set(false)
+          this.refreshSentinelObservation()
+        },
+        error: () => {
+          if (appending) {
+            this.loadMoreError.set(
+              'Additional news and events could not be loaded. Please try again.'
+            )
+            this.loadingMore.set(false)
+          } else {
+            this.errorMessage.set(
+              'News and events could not be loaded. Please try again.'
+            )
+            this.loading.set(false)
+          }
+        },
+      })
+  }
+
+  private appendUniqueItems(
+    existingItems: NewsItemFieldsFragment[],
+    incomingItems: NewsItemFieldsFragment[]
+  ): NewsItemFieldsFragment[] {
+    const existingIds = new Set(existingItems.map(({ id }) => id))
+    return [
+      ...existingItems,
+      ...incomingItems.filter(({ id }) => !existingIds.has(id)),
+    ]
+  }
+
+  private refreshSentinelObservation(): void {
+    if (!this.intersectionObserver) return
+
+    if (this.sentinelRefreshFrame !== undefined) {
+      cancelAnimationFrame(this.sentinelRefreshFrame)
+    }
+
+    this.sentinelRefreshFrame = requestAnimationFrame(() => {
+      const sentinel = this.loadMoreSentinel.nativeElement
+      this.intersectionObserver?.unobserve(sentinel)
+      this.intersectionObserver?.observe(sentinel)
+      this.sentinelRefreshFrame = undefined
+    })
+  }
+}

--- a/client/src/app/views/news/news.query.gql
+++ b/client/src/app/views/news/news.query.gql
@@ -1,0 +1,15 @@
+query NewsItemsPage($first: Int!, $after: String) {
+  newsItems(first: $first, after: $after) {
+    edges {
+      cursor
+      node {
+        ...NewsItemFields
+      }
+    }
+    totalCount
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}

--- a/client/src/app/views/welcome/news-item-list/news-item-list.component.html
+++ b/client/src/app/views/welcome/news-item-list/news-item-list.component.html
@@ -1,38 +1,18 @@
-@if (loading()) {
-  <nz-row [nzGutter]="[8, 16]">
-    <nz-col nzSpan="24">
-      <nz-card>
-        <nz-skeleton [nzActive]="true"></nz-skeleton>
-      </nz-card>
-    </nz-col>
-  </nz-row>
-} @else {
-  <nz-row [nzGutter]="[8, 16]">
-    @for (item of newsItems(); track item.title) {
-      <nz-col nzSpan="24">
-        <nz-card
-          nzSize="small"
-          [nzTitle]="newsTitle"
-          [nzExtra]="newsDate">
-          <span
-            class="news-post"
-            [innerHtml]="item.contentHtml"></span>
-        </nz-card>
+<cvc-news-item-list
+  [items]="newsItems()"
+  [loading]="loading()"
+  [errorMessage]="errorMessage()"
+  (retry)="retryNewsItems()">
+</cvc-news-item-list>
 
-        <!-- title -->
-        <ng-template #newsTitle>
-          {{ item.title }}
-        </ng-template>
-
-        <!-- date -->
-        <ng-template #newsDate>
-          <span
-            nz-typography
-            nzType="secondary">
-            {{ item.publishedAt | date }}
-          </span>
-        </ng-template>
-      </nz-col>
-    }
-  </nz-row>
+@if (!loading() && !errorMessage()) {
+  <a
+    class="all-news-link"
+    nz-button
+    nzType="default"
+    nzSize="small"
+    nzBlock
+    routerLink="/news">
+    See All News & Events
+  </a>
 }

--- a/client/src/app/views/welcome/news-item-list/news-item-list.component.less
+++ b/client/src/app/views/welcome/news-item-list/news-item-list.component.less
@@ -1,27 +1,7 @@
-@import 'themes/global-variables.less';
-
 :host {
   display: block;
-  ::ng-deep .news-cover-card {
-    .ant-card-meta-description {
-      color: @text-color;
-    }
-    // adjust cover-card title styles to match standard card's styles
-    .ant-card-meta-title {
-      font-size: 12px;
-      line-height: 20px;
-    }
-  }
-  ::ng-deep .news-post img {
-    max-width: 100%;
-    height: auto;
-  }
 }
 
-nz-divider {
-  margin: 12px 0 8px 0;
-}
-.cover-card-date {
-  text-align: right;
-  font-weight: normal;
+.all-news-link {
+  margin-top: 16px;
 }

--- a/client/src/app/views/welcome/news-item-list/news-item-list.component.ts
+++ b/client/src/app/views/welcome/news-item-list/news-item-list.component.ts
@@ -1,35 +1,66 @@
-import { Component, OnInit, signal, WritableSignal } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  inject,
+  signal,
+} from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import {
   HomepageNewsItemsGQL,
-  NewsItemFragment,
+  NewsItemFieldsFragment,
 } from '@app/generated/civic.apollo'
-import { filter, map } from 'rxjs'
-import { isNonNulled } from 'rxjs-etc'
-import { pluck } from 'rxjs-etc/dist/esm/operators'
 
 @Component({
-  selector: 'cvc-news-item-list',
+  selector: 'cvc-homepage-news-items',
   templateUrl: './news-item-list.component.html',
   styleUrls: ['./news-item-list.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
-export class NewsItemListComponent implements OnInit {
-  loading: WritableSignal<boolean> = signal(true)
-  newsItems: WritableSignal<NewsItemFragment[]> = signal([])
+export class HomepageNewsItemsComponent implements OnInit {
+  readonly loading = signal(true)
+  readonly newsItems = signal<NewsItemFieldsFragment[]>([])
+  readonly errorMessage = signal<string | undefined>(undefined)
+
+  private readonly destroyRef = inject(DestroyRef)
 
   constructor(private gql: HomepageNewsItemsGQL) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
+    this.loadNewsItems()
+  }
+
+  retryNewsItems(): void {
+    this.loadNewsItems()
+  }
+
+  private loadNewsItems(): void {
+    this.loading.set(true)
+    this.errorMessage.set(undefined)
+
     this.gql
-      .fetch()
-      .pipe(
-        pluck('data'),
-        filter(isNonNulled),
-        map(({ newsItems }) => {
+      .fetch(undefined, { fetchPolicy: 'network-only' })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ data }) => {
+          this.newsItems.set(
+            data.newsItems.edges
+              .map(({ node }) => node)
+              .filter(
+                (node): node is NewsItemFieldsFragment => node !== undefined
+              )
+          )
           this.loading.set(false)
-          this.newsItems.set(newsItems)
-        })
-      )
-      .subscribe()
+        },
+        error: () => {
+          this.newsItems.set([])
+          this.errorMessage.set(
+            'News and events could not be loaded. Please try again.'
+          )
+          this.loading.set(false)
+        },
+      })
   }
 }

--- a/client/src/app/views/welcome/news-item-list/news-item-list.query.gql
+++ b/client/src/app/views/welcome/news-item-list/news-item-list.query.gql
@@ -1,11 +1,10 @@
 query HomepageNewsItems {
-  newsItems {
-    ... newsItem
+  newsItems(first: 5) {
+    edges {
+      cursor
+      node {
+        ...NewsItemFields
+      }
+    }
   }
-}
-
-fragment newsItem on NewsItem {
-    publishedAt
-    contentHtml
-    title
 }

--- a/client/src/app/views/welcome/welcome.component.html
+++ b/client/src/app/views/welcome/welcome.component.html
@@ -31,19 +31,26 @@
   <nz-col [nzSpan]="24">
     <cvc-site-stats-card></cvc-site-stats-card>
   </nz-col>
-  <nz-col [nzSpan]="10">
+  <nz-col
+    [nzXs]="24"
+    [nzLg]="10">
     <nz-card
       nzTitle="News & Events"
       nzSize="small"
       class="home-card">
       <div
+        role="region"
+        aria-label="Recent news and events"
+        tabindex="0"
         cvcAutoHeightDiv="52"
         cvcAutoHeightTarget="viewport">
-        <cvc-news-item-list></cvc-news-item-list>
+        <cvc-homepage-news-items></cvc-homepage-news-items>
       </div>
     </nz-card>
   </nz-col>
-  <nz-col [nzSpan]="14">
+  <nz-col
+    [nzXs]="24"
+    [nzLg]="14">
     <div style="border-radius: 8px; overflow: hidden">
       <cvc-activity-feed
         cvcTitle="Live Activity Feed"

--- a/client/src/app/views/welcome/welcome.component.ts
+++ b/client/src/app/views/welcome/welcome.component.ts
@@ -1,6 +1,5 @@
 import { HttpClient } from '@angular/common/http'
 import { Component, OnInit } from '@angular/core'
-import { EventFeedMode, Maybe } from '@app/generated/civic.apollo'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { feedDefaultSettings } from '@app/components/activities/activity-feed/activity-feed.config'
@@ -21,107 +20,6 @@ interface GithubRelease {
 export class WelcomeComponent implements OnInit {
   release$?: Observable<GithubRelease>
 
-  feedMode = EventFeedMode.Unscoped
-
-  newsItems = [
-    {
-      title: 'Introducing Organizational Endorsements',
-      date: '2025-06-03',
-      htmlText: `We have just rolled out support for a feature we call Endorsements. Endorsements allow CIViC Organizations to add their organizational “stamp of approval” to Assertions which are then displayed prominently on the site. This feature will allow Organizations, including ClinGen Variant Curation Expert Panels, to highlight gold-standard Assertions that have been vetted through their organizational review process. Any significant changes to an Endorsed Assertion are automatically tracked and flagged for re-review. Additionally, in a future release, Endorsed Assertions will be automatically submitted to ClinVar on behalf of the endorsing organization if desired.
-          <br/><br/>
-          If you are interested in becoming an Endorsing Organization in CIViC, please reach out to us!`,
-    },
-    {
-      title: 'Join us in Houston on August 2nd!',
-      date: '2025-05-01',
-      htmlText: `Please join the CIViC team for the annual <a href="https://www.cancergenomics.org/meetings/2025_variant_interpretation_un.php" target="_blank">Variant Interpretation Unconference</a> attached as a pre-meeting to the Cancer Genomics Consortium's <a href="https://cancergenomics.org/meetings/cgc_2025_annual_meeting.php" target="_blank">Annual Meeting</a> in Houston! <br/><br/>
-
-          This event, hosted by The Variant Interpretation for Cancer Consortium (VICC), The CGC, ClinGen, and CIViC is a chance to engage with the CIViC team directly and collaborate with clinical experts, laboratory directors, variant scientists, software developers, and bioinformaticians from industry, government, and academia on projects related to variant interpretation, curation, and tool building.`,
-    },
-    {
-      title: 'Spring Development Updates',
-      date: '2025-04-22',
-      htmlText: `Its been a busy year already for CIViC development, and we wanted to highlight some recent improvements and upcoming features! <br/><br/>
-
-        <ul>
-          <li><a href="https://www.opencravat.org/" target="_blank">OpenCRAVAT</a> calibrated variant effect predictor scores are now integrated directly into <a href="https://civicdb.org/variants/12/summary" target="_blank">CIViC Variant Pages</a>.</li>
-            <br/>
-          <li>CIViC users can now generate and manage API Keys, allowing for programmatic submission of Evidence from their own internal repositories.</li>
-            <br/>
-          <li>We have launched an entirely redesigned <a href="https://civicdb.org/curation/activity/curation-timeline" target="_blank">Activity Feed</a> backed by an even more robust data provenance system under the hood. This strengthens CIViC's commitment to transparency and makes the full history of each piece of Evidence more discoverable.</li>
-            <br/>
-          <li>Coming Soon: We are actively testing a new feature that allows approved Organizations (e.g., ClinGen SC-VCEPs) to Endorse Assertions. These Endorsed Assertions will be automatically submitted to ClinVar under the corresponding organization.</li>
-        </ul>
-        <br/>
-        If you have any questions about these new features, our development roadmap, or require assistance using CIViC feel free to reach out to us at <a href="mailto:help@civicdb.org">help@civicdb.org</a>!
-      `,
-    },
-    {
-      title: 'Moving Beyond the Gene-Variant Data Model',
-      date: '2024-09-16',
-      htmlText: `Since its inception, CIViC’s data model has revolved around curating variants present on specific genes. While this was simple and worked well, it did not allow us to capture the full breadth of clinically relevant variants in cancer. In order to support additional variant types, we have updated the data model to include what we are calling “Features.” <br/><br/>
-
-    Instead of only being associated with a Gene, variants are now associated with a Feature. The first and most common Feature is still the Gene, but we are rolling out support for two additional Feature types: Factors and Fusions. <br/></br>
-
-    Factors can include genomic events that are not specific mutations such as <a href="https://civicdb.org/features/61746/summary" target="_blank">Microsatellite Instability</a> or <a href="https://civicdb.org/features/61745/" target="_blank">Tumor Mutational Burden</a>. Factors can be associated with terms from the <a href="https://ncithesaurus.nci.nih.gov/ncitbrowser/pages/home.jsf?version=24.07e" target="_blank">NCI Thesaurus</a>. <br/> <br/>
-
-    Meanwhile, our new Fusions model allows us to capture richer, more structured, data about the fusion partners and the fusion site at the exon level. Initially, we support a subset of the <a href="https://fusions.cancervariants.org/en/latest/" target="blank">VICC Gene Fusion Specification</a> with plans to support additional parts of the spec in the near future.`,
-    },
-    {
-      title:
-        '2024 VICC/CIViC/ClinGen Cancer Variant Curation and Coding Unconference',
-      date: '2024-08-04',
-      imageUrl: 'assets/images/cgc-hackathon-2024.jpg',
-      htmlText: `CIViC, alongside VICC and ClinGen Somatic hosted the 5th Cancer Variant Curation and Coding Unconference before the <a href="https://www.cancergenomics.org/meetings/registration.php" target="_blank">Annual Cancer Genomics Consortium Conference</a> in St. Louis. Scientists and developers gathered to discuss data standards, software improvements, and resource interoperability. Topics and summaries were <a href="https://github.com/griffithlab/civic-meeting/issues?q=is%3Aissue+is%3Aopen+label%3A2024" target="_blank">posted online</a>.`,
-    },
-    {
-      title: 'PUBLIC NOTICE: CIViC v1 API TO BE DEPRECATED',
-      date: '2023-10-01',
-      htmlText: `<strong style="color: red;"><i>The CIViC V1 REST API will officially be retired on November 1st, 2023.</i></strong> All CIViC integrations should transition to our new V2 GraphQL API. The new API is more powerful and provides access to the newest CIViC data model, features, and data. The easiest way to get started is to try out queries and browse the documentation in the <a href="https://civicdb.org/api/graphiql" target="_blank">GraphiQL sandbox</a>.`,
-      link: {
-        url: 'https://civicdb.org/api/graphiql',
-        label: 'Try the CIViC GraphiQL Sandbox',
-      },
-    },
-    {
-      title: 'CIViC Online Training Now Open!',
-      date: '2023-10-01',
-      htmlText: `A new course was developed by the CIViC team covering an introduction to somatic variants, including the rapid development of this field over the last decade with the introduction of next generation sequencing into clinical practice. The course was created using the <a href="https://www.itcrtraining.org/">ITCR training network’s</a> Open-source Tools for Training Resources (OTTR), which allows co-publication on multiple platforms, including <a href="https://course.civicdb.org">bookdown</a> and <a href="https://leanpub.com/c/introcivic">leanpub</a>.`,
-      link: {
-        url: 'https://course.civicdb.org',
-        label: 'Take the CIViC Intro Course',
-      },
-    },
-    {
-      title: '2023 CGC Hackathon Report',
-      date: '2023-08-14',
-      htmlText: `CIViC together with VICC and ClinGen Somatic hosted the 4th Cancer Variant Interpretation Hackathon and Jamboree as a <a href="https://www.cancergenomics.org/meetings/2023_vicc_civic_clingen_hackat.php" target="_blank">pre-meeting of the Annual Cancer Genomics Consortium Conference</a>. Over 50 variant scientists and developers gathered in St Louis to discuss and code resources for the clinical interpretation of cancer variants including ClinGen/CGC/VICC Oncogenicity classification, new CIViC Variant Classes, and more.`,
-      imageUrl: 'assets/images/2023-CGC-hackathon-attendees.jpg',
-    },
-    {
-      title: 'Introducing Molecular Profiles',
-      date: '2023-01-09',
-      htmlText: `Today we have rolled out support for a new core concept in CIViC: <a href="https://civic.readthedocs.io/en/latest/model/molecular_profiles.html" target="_blank"> Molecular Profiles</a>. Molecular Profiles are logical combinations of one or more CIViC Variants. While most Molecular Profiles will consist of a single Variant (“Simple”) they will also allow users to build “Complex” (multi-variant) Molecular Profiles to associate Evidence with. These complex profiles expand the CIViC data model to allow for clinical significance to be evaluated within contexts such as variant co-occurrence or mutual exclusivity. Going forward, Evidence will be associated with a Molecular Profile rather than directly with a Variant. If you have any questions about this change, please feel free to <a href="mailto:help@civicdb.org">contact us</a>. We have also prepared a <a href="https://www.youtube.com/watch?v=--i54jy746w" target="_blank" >video</a > explaining this new feature.`,
-      link: {
-        url: 'https://www.youtube.com/watch?v=--i54jY746w',
-        label: 'View Molecular Profiles Intro Video',
-      },
-    },
-    {
-      title: 'Announcing Support for ASH Abstracts',
-      date: '2023-01-09',
-      htmlText: `ASH Annual Meeting Abstracts can now be used as Sources when submitting Evidence Items to CIViC. They can be specified by DOI in the 'Add Source' section of the Evidence form.`,
-    },
-    {
-      title: 'CIViC named as a Global Core Biodata Resource',
-      date: '2022-12-15',
-      htmlText: `CIViC has been named in a <a href="https://globalbiodata.org/scientific-activities/global-core-biodata-resources/" title="Global Core Biodata Resources List" target="_blank" >list of 37 Global Core Biodata Resources</a> alongside other important resources such as Ensembl, ClinGen and Gnomad. The GCBR includes <a href="https://globalbiodata.org/scientific-activities/global-core-biodata-resources/gcbr-selection-2022/" title="GCBR Selection Process Overview, 2022" target="_blank" >select resources</a> that ensure the long term preservation of biological data, and are of fundamental importance to the biological and life sciences community.`,
-      link: {
-        url: 'https://globalbiodata.org/scientific-activities/global-core-biodata-resources/',
-        label: 'View the GCBR List',
-      },
-    },
-  ]
   feedSettings: ActivityFeedSettings = {
     ...feedDefaultSettings,
     showOrganization: false,

--- a/client/src/app/views/welcome/welcome.module.ts
+++ b/client/src/app/views/welcome/welcome.module.ts
@@ -3,66 +3,35 @@ import { NgModule } from '@angular/core'
 import { WelcomeRoutingModule } from './welcome-routing.module'
 
 import { WelcomeComponent } from './welcome.component'
-import { NzCarouselModule } from 'ng-zorro-antd/carousel'
-import { NzStatisticModule } from 'ng-zorro-antd/statistic'
 import { NzGridModule } from 'ng-zorro-antd/grid'
 import { CommonModule } from '@angular/common'
 import { NzCardModule } from 'ng-zorro-antd/card'
 import { NzButtonModule } from 'ng-zorro-antd/button'
-import { NzRadioModule } from 'ng-zorro-antd/radio'
-import { FormsModule } from '@angular/forms'
-import { NzListModule } from 'ng-zorro-antd/list'
 import { NzTypographyModule } from 'ng-zorro-antd/typography'
-import { LetDirective, PushPipe } from '@ngrx/component'
 import { CvcSiteStatsCardModule } from '@app/components/shared/site-stats-card/site-stats-card.module'
-import { CvcHomepageEventFeedModule } from '@app/components/events/homepage-event-feed/homepage-event-feed.module'
-import { NewsItemListComponent } from './news-item-list/news-item-list.component'
-import { NzEmptyModule } from 'ng-zorro-antd/empty'
-import { NzPipesModule } from 'ng-zorro-antd/pipes'
-import { NzDividerModule } from 'ng-zorro-antd/divider'
-import { NzIconModule } from 'ng-zorro-antd/icon'
-import { NzSelectModule } from 'ng-zorro-antd/select'
-import { NzPopoverModule } from 'ng-zorro-antd/popover'
-import { NzCheckboxModule } from 'ng-zorro-antd/checkbox'
+import { HomepageNewsItemsComponent } from './news-item-list/news-item-list.component'
 import { CvcActivityFeed } from '@app/components/activities/activity-feed/activity-feed.component'
 import { CvcAutoHeightDivModule } from '@app/directives/auto-height-div/auto-height-div.module'
-import { CvcAutoHeightCardModule } from '@app/directives/auto-height-card/auto-height-card.module'
 import { CvcWelcomeBannerComponent } from '@app/views/welcome/banners/welcome-banner/welcome-banner.component'
 import { CvcDiscoverBannerComponent } from '@app/views/welcome/banners/discover-banner/discover-banner.component'
 import { CvcLicenseBannerComponent } from '@app/views/welcome/banners/license-banner/license-banner.component'
 import { CvcContributeBannerComponent } from '@app/views/welcome/banners/contribute-banner/contribute-banner.component'
 import { CvcEditorBannerComponent } from '@app/views/welcome/banners/editor-banner/editor-banner.component'
-import { NzSkeletonModule } from 'ng-zorro-antd/skeleton'
 import { CvcAiBannerComponent } from '@app/views/welcome/banners/ai-banner/ai-banner.component'
+import { NewsItemListComponent } from '@app/components/news/news-item-list/news-item-list.component'
 
 @NgModule({
   imports: [
     CommonModule,
-    FormsModule,
-    LetDirective,
-    PushPipe,
     NzButtonModule,
     NzGridModule,
-    NzCarouselModule,
     NzCardModule,
-    NzCheckboxModule,
-    NzListModule,
-    NzRadioModule,
-    NzStatisticModule,
     NzTypographyModule,
-    NzEmptyModule,
-    NzPipesModule,
-    NzPopoverModule,
-    NzDividerModule,
-    NzIconModule,
-    NzSelectModule,
-    NzSkeletonModule,
     WelcomeRoutingModule,
     CvcAutoHeightDivModule,
-    CvcAutoHeightCardModule,
     CvcSiteStatsCardModule,
-    CvcHomepageEventFeedModule,
     CvcActivityFeed,
+    NewsItemListComponent,
     CvcWelcomeBannerComponent,
     CvcDiscoverBannerComponent,
     CvcLicenseBannerComponent,
@@ -70,7 +39,7 @@ import { CvcAiBannerComponent } from '@app/views/welcome/banners/ai-banner/ai-ba
     CvcEditorBannerComponent,
     CvcAiBannerComponent,
   ],
-  declarations: [WelcomeComponent, NewsItemListComponent],
+  declarations: [WelcomeComponent, HomepageNewsItemsComponent],
   exports: [WelcomeComponent],
 })
 export class WelcomeModule {}

--- a/server/app/graphql/resolvers/news_items.rb
+++ b/server/app/graphql/resolvers/news_items.rb
@@ -1,0 +1,15 @@
+require "search_object/plugin/graphql"
+
+class Resolvers::NewsItems < GraphQL::Schema::Resolver
+  include SearchObject.module(:graphql)
+
+  type Types::NewsItemType.connection_type, null: false
+
+  description "List published news items."
+
+  scope do
+    NewsItem.where(published: true)
+      .with_rich_text_content_and_embeds
+      .order(published_at: :desc)
+  end
+end

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -49,7 +49,7 @@ module Types
       field :search, resolver: Resolvers::Quicksearch
     end
 
-    field :news_items, [ Types::NewsItemType ], null: false
+    field :news_items, resolver: Resolvers::NewsItems
 
     field :disease, Types::Entities::DiseaseType, null: true do
       description "Find a disease by CIViC ID"
@@ -396,10 +396,6 @@ module Types
       Rails.cache.fetch("homepage_timepoint_stats", expires_in: 10.minutes) do
         CivicStats.homepage_stats
       end
-    end
-
-    def news_items
-      NewsItem.where(published: true).order("published_at desc")
     end
 
     def region_variant_names_for_feature_id(feature_id:)


### PR DESCRIPTION
The homepage news feed is constrained to a small box which contains every news item we've ever posted. Now we will display only the first several and then there's a link at the end to go to a dedicated page (as well as a corresponding new sidebar item)


<img width="863" height="208" alt="Screenshot 2026-07-17 at 5 46 08 PM" src="https://github.com/user-attachments/assets/23d6ac31-edb9-47b7-82f9-957f785f21e9" />
<img width="1845" height="818" alt="Screenshot 2026-07-17 at 5 46 29 PM" src="https://github.com/user-attachments/assets/d63c6ce3-59c2-42ef-86de-f4e8e2092086" />
