### PR TITLE
Remove leading and trailing whitespace when creating new HGVS records

### DIFF
--- a/server/app/models/hgvs_description.rb
+++ b/server/app/models/hgvs_description.rb
@@ -1,6 +1,8 @@
 class HgvsDescription < ActiveRecord::Base
   has_and_belongs_to_many :variants
 
+  before_create :strip_description
+
   def display_name
     description
   end
@@ -178,5 +180,11 @@ class HgvsDescription < ActiveRecord::Base
       "Y" =>  "NC_000024.9",
     }
     sequences[chromosome]
+  end
+
+  private
+
+  def strip_description
+    self.description = description&.strip
   end
 end

--- a/server/app/models/input_adaptors/gene_variant_input_adaptor.rb
+++ b/server/app/models/input_adaptors/gene_variant_input_adaptor.rb
@@ -26,11 +26,12 @@ class InputAdaptors::GeneVariantInputAdaptor
 
   def get_hgvs_ids
     input.hgvs_descriptions.map do |hgvs|
-      existing = HgvsDescription.where("description ILIKE ?", hgvs).first
+      normalized_hgvs = hgvs.strip
+      existing = HgvsDescription.where("description ILIKE ?", normalized_hgvs).first
       if existing
         existing.id
       else
-        HgvsDescription.create!(description: hgvs).id
+        HgvsDescription.create!(description: normalized_hgvs).id
       end
     end
   end

--- a/server/test/graphql/mutations/suggest_gene_variant_revision_test.rb
+++ b/server/test/graphql/mutations/suggest_gene_variant_revision_test.rb
@@ -71,6 +71,31 @@ class SuggestGeneVariantRevisionTest < ActiveSupport::TestCase
     assert result["results"].any?, "Expected at least one revision result"
   end
 
+  test "does not suggest an HGVS revision for whitespace-only differences" do
+    expression = "NM_004333.6:c.1799T>A"
+    hgvs_description = HgvsDescription.create!(description: expression)
+    @variant.hgvs_descriptions << hgvs_description
+    @variant.clinvar_entries << clinvar_entries(:none_found)
+
+    response = assert_no_difference "HgvsDescription.count" do
+      execute_mutation(
+        @mutation,
+        user: @user,
+        variables: {
+          id: @variant.id,
+          fields: default_fields.merge(
+            hgvsDescriptions: [ " \t#{expression} \n" ],
+          ),
+          comment: "Submitting the same HGVS expression with whitespace.",
+          organizationId: @org.id,
+        },
+      )
+    end
+
+    assert_graphql_error(response, /change at least one field/i)
+    assert_equal [ hgvs_description.id ], @variant.reload.hgvs_description_ids
+  end
+
   test "requires authentication" do
     response = execute_mutation(
       @mutation,


### PR DESCRIPTION
As per Obi's request in the last meeting. 