### PR TITLE
Add a few more filters to various advanced searches

### DIFF
--- a/client/src/app/forms/config/query-builder/field-config/search-diseases.config.ts
+++ b/client/src/app/forms/config/query-builder/field-config/search-diseases.config.ts
@@ -4,8 +4,10 @@ import {
   sortByLabel,
   withHideExpression,
   withStatic,
+  withRecursive
 } from '@app/forms/config/query-builder/field-config/functions/field-config-helpers'
 import { SELECT_FIELD_CONFIG } from './input-config/search-select.config'
+import { getQueryFieldConfig } from './functions/get-query-field-config'
 
 export const searchDiseasesDefaultKey = 'name'
 export const searchDiseasesFieldOptions: FormlyFieldConfig[] =
@@ -45,6 +47,24 @@ export const searchDiseasesFieldOptions: FormlyFieldConfig[] =
           props: { label: 'Deprecation Status' },
           fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
         },
+        {
+          key: 'hasAssertion',
+          props: { label: 'Has Assertion' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+        {
+          key: 'hasEvidenceItem',
+          props: { label: 'Has EvidenceItem' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+      ]),
+      ...withRecursive([
+        ...getQueryFieldConfig('assertion', 'searchAssertions', 'Assertion'),
+        ...getQueryFieldConfig(
+          'evidenceItems',
+          'searchEvidenceItems',
+          'Evidence Items'
+        ),
       ]),
     ]),
   ])

--- a/client/src/app/forms/config/query-builder/field-config/search-evidence-items.config.ts
+++ b/client/src/app/forms/config/query-builder/field-config/search-evidence-items.config.ts
@@ -96,6 +96,11 @@ export const searchEvidenceItemsFieldOptions: FormlyFieldConfig[] =
           fieldGroup: INPUT_FIELD_CONFIG['EvidenceTypeTypeSearchInput'],
         },
         {
+          key: 'hasAssertion',
+          props: { label: 'Has Assertion' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+        {
           key: 'isFlagged',
           props: { label: 'Is Flagged' },
           fieldGroup: INPUT_FIELD_CONFIG['FlaggedSearchInput'],

--- a/client/src/app/forms/config/query-builder/field-config/search-phenotypes.config.ts
+++ b/client/src/app/forms/config/query-builder/field-config/search-phenotypes.config.ts
@@ -4,8 +4,10 @@ import {
   sortByLabel,
   withHideExpression,
   withStatic,
+  withRecursive
 } from './functions/field-config-helpers'
 import { SELECT_FIELD_CONFIG } from './input-config/search-select.config'
+import { getQueryFieldConfig } from './functions/get-query-field-config'
 
 export const searchPhenotypesDefaultKey = 'name'
 export const searchPhenotypesFieldOptions: FormlyFieldConfig[] =
@@ -39,6 +41,24 @@ export const searchPhenotypesFieldOptions: FormlyFieldConfig[] =
           props: { label: 'Human Phenotype Ontology ID' },
           fieldGroup: INPUT_FIELD_CONFIG['OntologyTermSearchInput'],
         },
+        {
+          key: 'hasAssertion',
+          props: { label: 'Has Assertion' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+        {
+          key: 'hasEvidenceItem',
+          props: { label: 'Has EvidenceItem' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+      ]),
+      ...withRecursive([
+        ...getQueryFieldConfig('assertion', 'searchAssertions', 'Assertion'),
+        ...getQueryFieldConfig(
+          'evidenceItems',
+          'searchEvidenceItems',
+          'Evidence Items'
+        ),
       ]),
     ]),
   ])

--- a/client/src/app/forms/config/query-builder/field-config/search-sources.config.ts
+++ b/client/src/app/forms/config/query-builder/field-config/search-sources.config.ts
@@ -93,6 +93,11 @@ export const searchSourcesFieldOptions: FormlyFieldConfig[] =
       ]),
       ...withRecursive([
         ...getQueryFieldConfig('comment', 'searchComments', 'Comments'),
+        ...getQueryFieldConfig(
+          'evidenceItems',
+          'searchEvidenceItems',
+          'Evidence Items'
+        ),
       ]),
     ]),
   ])

--- a/client/src/app/forms/config/query-builder/field-config/search-therapies.config.ts
+++ b/client/src/app/forms/config/query-builder/field-config/search-therapies.config.ts
@@ -13,8 +13,10 @@ import {
   sortByLabel,
   withHideExpression,
   withStatic,
+  withRecursive
 } from './functions/field-config-helpers'
 import { SELECT_FIELD_CONFIG } from './input-config/search-select.config'
+import { getQueryFieldConfig } from './functions/get-query-field-config'
 
 export type TherapySearchFilterREF = {
   booleanOperator?: InputMaybe<BooleanOperator>
@@ -58,6 +60,24 @@ export const searchTherapiesFieldOptions: FormlyFieldConfig[] =
           props: { label: 'NCIT ID' },
           fieldGroup: INPUT_FIELD_CONFIG['OntologyTermSearchInput'],
         },
+        {
+          key: 'hasAssertion',
+          props: { label: 'Has Assertion' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+        {
+          key: 'hasEvidenceItem',
+          props: { label: 'Has EvidenceItem' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+      ]),
+      ...withRecursive([
+        ...getQueryFieldConfig('assertion', 'searchAssertions', 'Assertion'),
+        ...getQueryFieldConfig(
+          'evidenceItems',
+          'searchEvidenceItems',
+          'Evidence Items'
+        ),
       ]),
     ]),
   ])

--- a/client/src/app/forms/config/query-builder/field-config/search-variants.config.ts
+++ b/client/src/app/forms/config/query-builder/field-config/search-variants.config.ts
@@ -34,6 +34,11 @@ export const searchVariantsFieldOptions: FormlyFieldConfig[] =
           fieldGroup: INPUT_FIELD_CONFIG['StringSearchInput'],
         },
         {
+          key: 'hasAssertion',
+          props: { label: 'Has Assertion' },
+          fieldGroup: INPUT_FIELD_CONFIG['BooleanSearchInput'],
+        },
+        {
           key: 'isDeprecated',
           props: { label: 'Is Deprecated' },
           fieldGroup: INPUT_FIELD_CONFIG['DeprecatedSearchInput'],

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -9154,6 +9154,7 @@ export type VariantSearchFilter = {
   deprecatingUser?: InputMaybe<UserSearchFilter>;
   deprecationReason?: InputMaybe<VariantDeprecationReasonTypeSearchInput>;
   feature?: InputMaybe<FeatureSearchFilter>;
+  hasAssertion?: InputMaybe<BooleanSearchInput>;
   id?: InputMaybe<IntSearchInput>;
   isDeprecated?: InputMaybe<BooleanSearchInput>;
   isFlagged?: InputMaybe<BooleanSearchInput>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -8365,8 +8365,12 @@ export type TherapyPopover = {
 };
 
 export type TherapySearchFilter = {
+  assertion?: InputMaybe<AssertionSearchFilter>;
   booleanOperator?: InputMaybe<BooleanOperator>;
   deprecated?: InputMaybe<BooleanSearchInput>;
+  evidenceItems?: InputMaybe<EvidenceItemSearchFilter>;
+  hasAssertion?: InputMaybe<BooleanSearchInput>;
+  hasEvidenceItem?: InputMaybe<BooleanSearchInput>;
   id?: InputMaybe<IntSearchInput>;
   name?: InputMaybe<StringSearchInput>;
   ncitId?: InputMaybe<OntologyTermSearchInput>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -5484,8 +5484,12 @@ export type PhenotypePopover = {
 };
 
 export type PhenotypeSearchFilter = {
+  assertion?: InputMaybe<AssertionSearchFilter>;
   booleanOperator?: InputMaybe<BooleanOperator>;
   description?: InputMaybe<StringSearchInput>;
+  evidenceItems?: InputMaybe<EvidenceItemSearchFilter>;
+  hasAssertion?: InputMaybe<BooleanSearchInput>;
+  hasEvidenceItem?: InputMaybe<BooleanSearchInput>;
   hpoId?: InputMaybe<OntologyTermSearchInput>;
   id?: InputMaybe<IntSearchInput>;
   name?: InputMaybe<StringSearchInput>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -2516,6 +2516,7 @@ export type EvidenceItemSearchFilter = {
   evidenceLevel?: InputMaybe<EvidenceLevelTypeSearchInput>;
   evidenceRating?: InputMaybe<IntSearchInput>;
   evidenceType?: InputMaybe<EvidenceTypeTypeSearchInput>;
+  hasAssertion?: InputMaybe<BooleanSearchInput>;
   id?: InputMaybe<IntSearchInput>;
   isFlagged?: InputMaybe<BooleanSearchInput>;
   moderatingUser?: InputMaybe<UserSearchFilter>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -7430,6 +7430,7 @@ export type SourceSearchFilter = {
   citationId?: InputMaybe<StringSearchInput>;
   comment?: InputMaybe<CommentSearchFilter>;
   deprecated?: InputMaybe<BooleanSearchInput>;
+  evidenceItems?: InputMaybe<EvidenceItemSearchFilter>;
   id?: InputMaybe<IntSearchInput>;
   isRetracted?: InputMaybe<BooleanSearchInput>;
   journal?: InputMaybe<StringSearchInput>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -9153,6 +9153,7 @@ export type VariantSearchFilter = {
   deprecatingUser?: InputMaybe<UserSearchFilter>;
   deprecationReason?: InputMaybe<VariantDeprecationReasonTypeSearchInput>;
   feature?: InputMaybe<FeatureSearchFilter>;
+  hasAssertion?: InputMaybe<BooleanSearchInput>;
   id?: InputMaybe<IntSearchInput>;
   isDeprecated?: InputMaybe<BooleanSearchInput>;
   isFlagged?: InputMaybe<BooleanSearchInput>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -7431,6 +7431,7 @@ export type SourceSearchFilter = {
   citationId?: InputMaybe<StringSearchInput>;
   comment?: InputMaybe<CommentSearchFilter>;
   deprecated?: InputMaybe<BooleanSearchInput>;
+  evidenceItems?: InputMaybe<EvidenceItemSearchFilter>;
   id?: InputMaybe<IntSearchInput>;
   isRetracted?: InputMaybe<BooleanSearchInput>;
   journal?: InputMaybe<StringSearchInput>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -2133,10 +2133,14 @@ export type DiseasePopover = {
 };
 
 export type DiseaseSearchFilter = {
+  assertion?: InputMaybe<AssertionSearchFilter>;
   booleanOperator?: InputMaybe<BooleanOperator>;
   deprecated?: InputMaybe<BooleanSearchInput>;
   diseaseAliases?: InputMaybe<StringSearchInput>;
   doid?: InputMaybe<OntologyTermSearchInput>;
+  evidenceItems?: InputMaybe<EvidenceItemSearchFilter>;
+  hasAssertion?: InputMaybe<BooleanSearchInput>;
+  hasEvidenceItem?: InputMaybe<BooleanSearchInput>;
   id?: InputMaybe<IntSearchInput>;
   name?: InputMaybe<StringSearchInput>;
   subFilters?: InputMaybe<Array<DiseaseSearchFilter>>;

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -8366,8 +8366,12 @@ export type TherapyPopover = {
 };
 
 export type TherapySearchFilter = {
+  assertion?: InputMaybe<AssertionSearchFilter>;
   booleanOperator?: InputMaybe<BooleanOperator>;
   deprecated?: InputMaybe<BooleanSearchInput>;
+  evidenceItems?: InputMaybe<EvidenceItemSearchFilter>;
+  hasAssertion?: InputMaybe<BooleanSearchInput>;
+  hasEvidenceItem?: InputMaybe<BooleanSearchInput>;
   id?: InputMaybe<IntSearchInput>;
   name?: InputMaybe<StringSearchInput>;
   ncitId?: InputMaybe<OntologyTermSearchInput>;

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -59877,6 +59877,18 @@
             "deprecationReason": null
           },
           {
+            "name": "evidenceItems",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "EvidenceItemSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -71515,6 +71515,18 @@
             "deprecationReason": null
           },
           {
+            "name": "hasAssertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -65046,6 +65046,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "assertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssertionSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "booleanOperator",
             "description": null,
             "type": {
@@ -65059,6 +65071,42 @@
           },
           {
             "name": "deprecated",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "evidenceItems",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "EvidenceItemSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasAssertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasEvidenceItem",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -71499,6 +71499,18 @@
             "deprecationReason": null
           },
           {
+            "name": "hasAssertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -59861,6 +59861,18 @@
             "deprecationReason": null
           },
           {
+            "name": "evidenceItems",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "EvidenceItemSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -65030,6 +65030,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "assertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssertionSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "booleanOperator",
             "description": null,
             "type": {
@@ -65043,6 +65055,42 @@
           },
           {
             "name": "deprecated",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "evidenceItems",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "EvidenceItemSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasAssertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasEvidenceItem",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -44127,6 +44127,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "assertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssertionSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "booleanOperator",
             "description": null,
             "type": {
@@ -44144,6 +44156,42 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "StringSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "evidenceItems",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "EvidenceItemSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasAssertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasEvidenceItem",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
               "ofType": null
             },
             "defaultValue": null,

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -17227,6 +17227,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "assertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssertionSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "booleanOperator",
             "description": null,
             "type": {
@@ -17268,6 +17280,42 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "OntologyTermSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "evidenceItems",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "EvidenceItemSearchFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasAssertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasEvidenceItem",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
               "ofType": null
             },
             "defaultValue": null,

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -20443,6 +20443,18 @@
             "deprecationReason": null
           },
           {
+            "name": "hasAssertion",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanSearchInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "type": {

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -3871,6 +3871,7 @@ input EvidenceItemSearchFilter {
   evidenceLevel: EvidenceLevelTypeSearchInput
   evidenceRating: IntSearchInput
   evidenceType: EvidenceTypeTypeSearchInput
+  hasAssertion: BooleanSearchInput
   id: IntSearchInput
   isFlagged: BooleanSearchInput
   moderatingUser: UserSearchFilter

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -15655,6 +15655,7 @@ input VariantSearchFilter {
   deprecatingUser: UserSearchFilter
   deprecationReason: VariantDeprecationReasonTypeSearchInput
   feature: FeatureSearchFilter
+  hasAssertion: BooleanSearchInput
   id: IntSearchInput
   isDeprecated: BooleanSearchInput
   isFlagged: BooleanSearchInput

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -14136,8 +14136,12 @@ type TherapyPopover {
 }
 
 input TherapySearchFilter {
+  assertion: AssertionSearchFilter
   booleanOperator: BooleanOperator
   deprecated: BooleanSearchInput
+  evidenceItems: EvidenceItemSearchFilter
+  hasAssertion: BooleanSearchInput
+  hasEvidenceItem: BooleanSearchInput
   id: IntSearchInput
   name: StringSearchInput
   ncitId: OntologyTermSearchInput

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -15654,6 +15654,7 @@ input VariantSearchFilter {
   deprecatingUser: UserSearchFilter
   deprecationReason: VariantDeprecationReasonTypeSearchInput
   feature: FeatureSearchFilter
+  hasAssertion: BooleanSearchInput
   id: IntSearchInput
   isDeprecated: BooleanSearchInput
   isFlagged: BooleanSearchInput

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -3214,10 +3214,14 @@ type DiseasePopover {
 }
 
 input DiseaseSearchFilter {
+  assertion: AssertionSearchFilter
   booleanOperator: BooleanOperator
   deprecated: BooleanSearchInput
   diseaseAliases: StringSearchInput
   doid: OntologyTermSearchInput
+  evidenceItems: EvidenceItemSearchFilter
+  hasAssertion: BooleanSearchInput
+  hasEvidenceItem: BooleanSearchInput
   id: IntSearchInput
   name: StringSearchInput
   subFilters: [DiseaseSearchFilter!]

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -12788,6 +12788,7 @@ input SourceSearchFilter {
   citationId: StringSearchInput
   comment: CommentSearchFilter
   deprecated: BooleanSearchInput
+  evidenceItems: EvidenceItemSearchFilter
   id: IntSearchInput
   isRetracted: BooleanSearchInput
   journal: StringSearchInput

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -14135,8 +14135,12 @@ type TherapyPopover {
 }
 
 input TherapySearchFilter {
+  assertion: AssertionSearchFilter
   booleanOperator: BooleanOperator
   deprecated: BooleanSearchInput
+  evidenceItems: EvidenceItemSearchFilter
+  hasAssertion: BooleanSearchInput
+  hasEvidenceItem: BooleanSearchInput
   id: IntSearchInput
   name: StringSearchInput
   ncitId: OntologyTermSearchInput

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -12787,6 +12787,7 @@ input SourceSearchFilter {
   citationId: StringSearchInput
   comment: CommentSearchFilter
   deprecated: BooleanSearchInput
+  evidenceItems: EvidenceItemSearchFilter
   id: IntSearchInput
   isRetracted: BooleanSearchInput
   journal: StringSearchInput

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -9097,8 +9097,12 @@ type PhenotypePopover {
 }
 
 input PhenotypeSearchFilter {
+  assertion: AssertionSearchFilter
   booleanOperator: BooleanOperator
   description: StringSearchInput
+  evidenceItems: EvidenceItemSearchFilter
+  hasAssertion: BooleanSearchInput
+  hasEvidenceItem: BooleanSearchInput
   hpoId: OntologyTermSearchInput
   id: IntSearchInput
   name: StringSearchInput

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -59669,6 +59669,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "evidenceItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "EvidenceItemSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -71101,6 +71101,18 @@
               "deprecationReason": null
             },
             {
+              "name": "hasAssertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "isFlagged",
               "description": null,
               "type": {

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -20356,6 +20356,18 @@
               "deprecationReason": null
             },
             {
+              "name": "hasAssertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "isFlagged",
               "description": null,
               "type": {

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -17170,6 +17170,54 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "hasAssertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AssertionSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasEvidenceItem",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "evidenceItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "EvidenceItemSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -71117,6 +71117,18 @@
               "deprecationReason": null
             },
             {
+              "name": "hasAssertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "isFlagged",
               "description": null,
               "type": {

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -64782,6 +64782,54 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "hasAssertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AssertionSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasEvidenceItem",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "evidenceItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "EvidenceItemSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -59685,6 +59685,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "evidenceItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "EvidenceItemSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -43981,6 +43981,54 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "hasAssertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AssertionSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasEvidenceItem",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "evidenceItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "EvidenceItemSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -64798,6 +64798,54 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "hasAssertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assertion",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AssertionSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasEvidenceItem",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BooleanSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "evidenceItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "EvidenceItemSearchFilter",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,

--- a/server/app/graphql/types/advanced_search/disease_search_filter_type.rb
+++ b/server/app/graphql/types/advanced_search/disease_search_filter_type.rb
@@ -8,6 +8,10 @@ module Types
       argument :doid, Types::AdvancedSearch::OntologyTermSearchInput, required: false
       argument :id, Types::AdvancedSearch::IntSearchInput, required: false
       argument :name, Types::AdvancedSearch::StringSearchInput, required: false
+      argument :has_assertion, Types::AdvancedSearch::BooleanSearchInput, required: false
+      argument :assertion, Types::AdvancedSearch::AssertionSearchFilterType, required: false
+      argument :has_evidence_item, Types::AdvancedSearch::BooleanSearchInput, required: false
+      argument :evidence_items, Types::AdvancedSearch::EvidenceItemSearchFilterType, required: false
     end
   end
 end

--- a/server/app/graphql/types/advanced_search/evidence_item_search_filter_type.rb
+++ b/server/app/graphql/types/advanced_search/evidence_item_search_filter_type.rb
@@ -13,6 +13,7 @@ module Types
       argument :evidence_level, Types::AdvancedSearch::EnumSearchInput.for(Types::EvidenceLevelType, is_activerecord_enum: true), required: false
       argument :evidence_rating, Types::AdvancedSearch::IntSearchInput, required: false
       argument :evidence_type, Types::AdvancedSearch::EnumSearchInput.for(Types::EvidenceTypeType, is_activerecord_enum: true), required: false
+      argument :has_assertion, Types::AdvancedSearch::BooleanSearchInput, required: false
       argument :is_flagged, Types::AdvancedSearch::BooleanSearchInput, required: false
       argument :id, Types::AdvancedSearch::IntSearchInput, required: false
       argument :molecular_profile, Types::AdvancedSearch::MolecularProfileSearchFilterType, required: false

--- a/server/app/graphql/types/advanced_search/phenotype_search_filter_type.rb
+++ b/server/app/graphql/types/advanced_search/phenotype_search_filter_type.rb
@@ -7,6 +7,10 @@ module Types
       argument :hpo_id, Types::AdvancedSearch::OntologyTermSearchInput, required: false
       argument :id, Types::AdvancedSearch::IntSearchInput, required: false
       argument :name, Types::AdvancedSearch::StringSearchInput, required: false
+      argument :has_assertion, Types::AdvancedSearch::BooleanSearchInput, required: false
+      argument :assertion, Types::AdvancedSearch::AssertionSearchFilterType, required: false
+      argument :has_evidence_item, Types::AdvancedSearch::BooleanSearchInput, required: false
+      argument :evidence_items, Types::AdvancedSearch::EvidenceItemSearchFilterType, required: false
     end
   end
 end

--- a/server/app/graphql/types/advanced_search/source_search_filter_type.rb
+++ b/server/app/graphql/types/advanced_search/source_search_filter_type.rb
@@ -15,6 +15,7 @@ module Types
       argument :title, Types::AdvancedSearch::StringSearchInput, required: false
       argument :is_retracted, Types::AdvancedSearch::BooleanSearchInput, required: false
       argument :comment, Types::AdvancedSearch::CommentSearchFilterType, required: false
+      argument :evidence_items, Types::AdvancedSearch::EvidenceItemSearchFilterType, required: false
     end
   end
 end

--- a/server/app/graphql/types/advanced_search/therapy_search_filter_type.rb
+++ b/server/app/graphql/types/advanced_search/therapy_search_filter_type.rb
@@ -8,6 +8,10 @@ module Types
       argument :name, Types::AdvancedSearch::StringSearchInput, required: false
       argument :ncit_id, Types::AdvancedSearch::OntologyTermSearchInput, required: false
       argument :therapy_aliases, Types::AdvancedSearch::StringSearchInput, required: false
+      argument :has_assertion, Types::AdvancedSearch::BooleanSearchInput, required: false
+      argument :assertion, Types::AdvancedSearch::AssertionSearchFilterType, required: false
+      argument :has_evidence_item, Types::AdvancedSearch::BooleanSearchInput, required: false
+      argument :evidence_items, Types::AdvancedSearch::EvidenceItemSearchFilterType, required: false
     end
   end
 end

--- a/server/app/graphql/types/advanced_search/variant_search_filter_type.rb
+++ b/server/app/graphql/types/advanced_search/variant_search_filter_type.rb
@@ -7,6 +7,7 @@ module Types
       argument :is_deprecated, Types::AdvancedSearch::BooleanSearchInput, required: false
       argument :deprecation_reason, Types::AdvancedSearch::EnumSearchInput.for(Types::VariantDeprecationReasonType, is_activerecord_enum: true), required: false
       argument :feature, Types::AdvancedSearch::FeatureSearchFilterType, required: false
+      argument :has_assertion, Types::AdvancedSearch::BooleanSearchInput, required: false
       argument :is_flagged, Types::AdvancedSearch::BooleanSearchInput, required: false
       argument :id, Types::AdvancedSearch::IntSearchInput, required: false
       argument :molecular_profile, Types::AdvancedSearch::MolecularProfileSearchFilterType, required: false

--- a/server/app/models/advanced_searches/disease.rb
+++ b/server/app/models/advanced_searches/disease.rb
@@ -19,6 +19,10 @@ module AdvancedSearches
         resolve_doid_filter(node),
         resolve_deprecated_filter(node),
         resolve_disease_aliases_filter(node),
+        resolve_has_assertion_filter(node),
+        resolve_assertion_filter(node),
+        resolve_has_evidence_item_filter(node),
+        resolve_evidence_items_filter(node),
       ]
     end
 
@@ -57,6 +61,48 @@ module AdvancedSearches
       end
       clause, value = node.disease_aliases.resolve_query_for_type("disease_aliases.name")
       base_query.where(clause, value)
+    end
+
+    def resolve_has_assertion_filter(node)
+      if node.has_assertion.nil?
+        return nil
+      end
+
+      matching_ids = ::Assertion.joins(:disease).distinct.pluck("diseases.id")
+
+      if node.has_assertion.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
+    end
+
+    def resolve_assertion_filter(node)
+      return nil if node.assertion.nil?
+      assertion_ids = ::AdvancedSearches::Assertion.new(query: node.assertion).results
+      disease_ids = ::Disease.joins(:assertions).where(assertions: { id: assertion_ids }).select(:id)
+      base_query.where(id: disease_ids)
+    end
+
+    def resolve_has_evidence_item_filter(node)
+      if node.has_evidence_item.nil?
+        return nil
+      end
+
+      matching_ids = ::EvidenceItem.joins(:disease).distinct.pluck("diseases.id")
+
+      if node.has_evidence_item.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
+    end
+
+    def resolve_evidence_items_filter(node)
+      return nil if node.evidence_items.nil?
+      matching_ids = ::AdvancedSearches::EvidenceItem.new(query: node.evidence_items).results
+      disease_ids = ::Disease.joins(:evidence_items).where(evidence_items: { id: matching_ids }).select(:id)
+      base_query.where(id: disease_ids)
     end
   end
 end

--- a/server/app/models/advanced_searches/evidence_item.rb
+++ b/server/app/models/advanced_searches/evidence_item.rb
@@ -23,6 +23,7 @@ module AdvancedSearches
         resolve_evidence_level_filter(node),
         resolve_evidence_rating_filter(node),
         resolve_evidence_type_filter(node),
+        resolve_has_assertion_filter(node),
         resolve_is_flagged_filter(node),
         resolve_significance_filter(node),
         resolve_evidence_source_filter(node),
@@ -71,6 +72,21 @@ module AdvancedSearches
       return nil if node.evidence_type.nil?
       node.evidence_type.resolve_query_for_activerecord_enum(base_query, "evidence_items.evidence_type")
     end
+
+    def resolve_has_assertion_filter(node)
+      if node.has_assertion.nil?
+        return nil
+      end
+
+      matching_ids = ::Assertion.joins(:evidence_items).distinct.pluck("evidence_items.id")
+
+      if node.has_assertion.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
+    end
+
 
     def resolve_significance_filter(node)
       return nil if node.significance.nil?

--- a/server/app/models/advanced_searches/molecular_profile.rb
+++ b/server/app/models/advanced_searches/molecular_profile.rb
@@ -119,7 +119,7 @@ module AdvancedSearches
         return nil
       end
 
-      matching_ids = ::Assertion.joins(molecular_profile: { variants: [ :feature ] }).distinct.pluck("molecular_profiles.id")
+      matching_ids = ::Assertion.joins(:molecular_profile).distinct.pluck("molecular_profiles.id")
 
       if node.has_assertion.value
         base_query.where(id: matching_ids)

--- a/server/app/models/advanced_searches/phenotype.rb
+++ b/server/app/models/advanced_searches/phenotype.rb
@@ -18,6 +18,10 @@ module AdvancedSearches
         resolve_name_filter(node),
         resolve_description_filter(node),
         resolve_hpo_id_filter(node),
+        resolve_has_assertion_filter(node),
+        resolve_assertion_filter(node),
+        resolve_has_evidence_item_filter(node),
+        resolve_evidence_items_filter(node),
       ]
     end
 
@@ -30,6 +34,48 @@ module AdvancedSearches
     def resolve_hpo_id_filter(node)
       return nil if node.hpo_id.nil?
       node.hpo_id.resolve_ontology_query(base_query, "phenotypes.hpo_id")
+    end
+
+    def resolve_has_assertion_filter(node)
+      if node.has_assertion.nil?
+        return nil
+      end
+
+      matching_ids = ::Assertion.joins(:phenotypes).distinct.pluck("phenotypes.id")
+
+      if node.has_assertion.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
+    end
+
+    def resolve_assertion_filter(node)
+      return nil if node.assertion.nil?
+      assertion_ids = ::AdvancedSearches::Assertion.new(query: node.assertion).results
+      phenotype_ids = ::Phenotype.joins(:assertions).where(assertions: { id: assertion_ids }).select(:id)
+      base_query.where(id: phenotype_ids)
+    end
+
+    def resolve_has_evidence_item_filter(node)
+      if node.has_evidence_item.nil?
+        return nil
+      end
+
+      matching_ids = ::EvidenceItem.joins(:phenotypes).distinct.pluck("phenotypes.id")
+
+      if node.has_evidence_item.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
+    end
+
+    def resolve_evidence_items_filter(node)
+      return nil if node.evidence_items.nil?
+      matching_ids = ::AdvancedSearches::EvidenceItem.new(query: node.evidence_items).results
+      phenotype_ids = ::Phenotype.joins(:evidence_items).where(evidence_items: { id: matching_ids }).select(:id)
+      base_query.where(id: phenotype_ids)
     end
   end
 end

--- a/server/app/models/advanced_searches/source.rb
+++ b/server/app/models/advanced_searches/source.rb
@@ -24,6 +24,7 @@ module AdvancedSearches
         resolve_deprecated_filter(node),
         resolve_is_retracted_filter(node),
         resolve_comment_filter(node),
+        resolve_evidence_items_filter(node),
       ]
     end
 
@@ -121,6 +122,13 @@ module AdvancedSearches
     def resolve_author_field_filter(filter, column_name)
       clause, value = filter.resolve_query_for_type(column_name)
       source_ids = source_author_query.where(clause, value).distinct.select(:id)
+      base_query.where(id: source_ids)
+    end
+
+    def resolve_evidence_items_filter(node)
+      return nil if node.evidence_items.nil?
+      matching_ids = ::AdvancedSearches::EvidenceItem.new(query: node.evidence_items).results
+      source_ids = ::Source.joins(:evidence_items).where(evidence_items: { id: matching_ids }).select(:id)
       base_query.where(id: source_ids)
     end
   end

--- a/server/app/models/advanced_searches/therapy.rb
+++ b/server/app/models/advanced_searches/therapy.rb
@@ -19,6 +19,10 @@ module AdvancedSearches
         resolve_is_deprecated_filter(node),
         resolve_ncit_id_filter(node),
         resolve_therapy_aliases_filter(node),
+        resolve_has_assertion_filter(node),
+        resolve_assertion_filter(node),
+        resolve_has_evidence_item_filter(node),
+        resolve_evidence_items_filter(node),
       ]
     end
 
@@ -39,6 +43,48 @@ module AdvancedSearches
       return nil if node.therapy_aliases.nil?
       clause, value = node.therapy_aliases.resolve_query_for_type("therapy_aliases.name")
       base_query.where(clause, value)
+    end
+
+    def resolve_has_assertion_filter(node)
+      if node.has_assertion.nil?
+        return nil
+      end
+
+      matching_ids = ::Assertion.joins(:therapies).distinct.pluck("therapies.id")
+
+      if node.has_assertion.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
+    end
+
+    def resolve_assertion_filter(node)
+      return nil if node.assertion.nil?
+      assertion_ids = ::AdvancedSearches::Assertion.new(query: node.assertion).results
+      therapy_ids = ::Therapy.joins(:assertions).where(assertions: { id: assertion_ids }).select(:id)
+      base_query.where(id: therapy_ids)
+    end
+
+    def resolve_has_evidence_item_filter(node)
+      if node.has_evidence_item.nil?
+        return nil
+      end
+
+      matching_ids = ::EvidenceItem.joins(:therapies).distinct.pluck("therapies.id")
+
+      if node.has_evidence_item.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
+    end
+
+    def resolve_evidence_items_filter(node)
+      return nil if node.evidence_items.nil?
+      matching_ids = ::AdvancedSearches::EvidenceItem.new(query: node.evidence_items).results
+      therapy_ids = ::Therapy.joins(:evidence_items).where(evidence_items: { id: matching_ids }).select(:id)
+      base_query.where(id: therapy_ids)
     end
   end
 end

--- a/server/app/models/advanced_searches/variant.rb
+++ b/server/app/models/advanced_searches/variant.rb
@@ -18,6 +18,7 @@ module AdvancedSearches
       [
         resolve_id_filter(node),
         resolve_name_filter(node),
+        resolve_has_assertion_filter(node),
         resolve_is_flagged_filter(node),
         resolve_is_deprecated_filter(node),
         resolve_deprecation_reason_filter(node),
@@ -33,6 +34,20 @@ module AdvancedSearches
         resolve_activity_user(node.creating_user, "CreateVariantActivity"),
         resolve_activity_user(node.deprecating_user, "DeprecateVariantActivity"),
       ]
+    end
+
+    def resolve_has_assertion_filter(node)
+      if node.has_assertion.nil?
+        return nil
+      end
+
+      matching_ids = ::Assertion.joins(molecular_profile: [ :variants ]).distinct.pluck("variants.id")
+
+      if node.has_assertion.value
+        base_query.where(id: matching_ids)
+      else
+        base_query.where.not(id: matching_ids)
+      end
     end
 
     def resolve_variant_alias_filter(node)


### PR DESCRIPTION
This PR adds a few filters to various advanced searches:
- The ability to filter on hasAssertion on the evidence item and variant advanced searches
- The ability to filter on hasAssertion, assertion, hasEvidence, and evidence on disease, therapy, and phenotype advanced searches
- The ability to filter on evidence on the source advanced search