### PR TITLE
Add support for bioRxiv and medRxiv sources

### DIFF
--- a/client/src/app/components/sources/sources-table/sources-table.component.html
+++ b/client/src/app/components/sources/sources-table/sources-table.component.html
@@ -160,6 +160,12 @@
             <nz-option
               nzValue="ASH"
               nzLabel="ASH"></nz-option>
+            <nz-option
+              nzValue="BIORXIV"
+              nzLabel="bioRxiv"></nz-option>
+            <nz-option
+              nzValue="MEDRXIV"
+              nzLabel="medRxiv"></nz-option>
           </nz-select>
         </th>
         <th>

--- a/client/src/app/core/utilities/enum-formatters/format-source-type-enum.ts
+++ b/client/src/app/core/utilities/enum-formatters/format-source-type-enum.ts
@@ -8,6 +8,10 @@ export function formatSourceTypeEnum(value: SourceSource): string {
       return 'PubMed'
     case 'ASH':
       return 'ASH'
+    case 'BIORXIV':
+      return 'bioRxiv'
+    case 'MEDRXIV':
+      return 'medRxiv'
     default:
       return value
   }

--- a/client/src/app/forms/types/source-select/source-select.type.html
+++ b/client/src/app/forms/types/source-select/source-select.type.html
@@ -19,6 +19,12 @@
       <nz-option
         nzValue="ASH"
         nzLabel="ASH"></nz-option>
+      <nz-option
+        nzValue="BIORXIV"
+        nzLabel="bioRxiv"></nz-option>
+      <nz-option
+        nzValue="MEDRXIV"
+        nzLabel="medRxiv"></nz-option>
     </nz-select>
   </nz-col>
   <nz-col

--- a/client/src/app/forms/types/source-select/source-select.type.ts
+++ b/client/src/app/forms/types/source-select/source-select.type.ts
@@ -111,9 +111,9 @@ export class CvcSourceSelectField
       isMultiSelect: false,
       minSearchStrLength: 2,
       tooltip:
-        'PubMed, ASCO, or ASH Abstract Source(s) that support items, statements or descriptions.',
+        'PubMed, ASCO, ASH, bioRxiv, or medRxiv Abstract Source(s) that support items, statements or descriptions.',
       placeholders: {
-        default: 'Search PubMed, ASCO, and ASH Sources',
+        default: 'Search PubMed, ASCO, ASH, bioRxiv, and medRxiv Sources',
         contextualFn: (sourceName: string) => {
           return `Search ${sourceName} Sources`
         },

--- a/client/src/app/generated/civic.apollo.ts
+++ b/client/src/app/generated/civic.apollo.ts
@@ -7437,6 +7437,8 @@ export type SourceSearchFilter = {
 export enum SourceSource {
   Asco = 'ASCO',
   Ash = 'ASH',
+  Biorxiv = 'BIORXIV',
+  Medrxiv = 'MEDRXIV',
   Pubmed = 'PUBMED'
 }
 

--- a/client/src/app/generated/client.schema.json
+++ b/client/src/app/generated/client.schema.json
@@ -59935,6 +59935,18 @@
             "deprecationReason": null
           },
           {
+            "name": "BIORXIV",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MEDRXIV",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PUBMED",
             "description": null,
             "isDeprecated": false,

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -12794,6 +12794,8 @@ input SourceSearchFilter {
 enum SourceSource {
   ASCO
   ASH
+  BIORXIV
+  MEDRXIV
   PUBMED
 }
 

--- a/client/src/app/generated/server.schema.json
+++ b/client/src/app/generated/server.schema.json
@@ -59668,6 +59668,18 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "BIORXIV",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MEDRXIV",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null

--- a/client/src/app/views/sources/sources-detail/sources-summary/sources-summary.page.html
+++ b/client/src/app/views/sources/sources-detail/sources-summary/sources-summary.page.html
@@ -65,9 +65,11 @@
           nzTitle="ASCO Abstract ID">
           {{ source.ascoAbstractId }}
         </nz-descriptions-item>
-        <nz-descriptions-item nzTitle="Journal"
-          >{{ source.fullJournalTitle }}
-        </nz-descriptions-item>
+        @if (source.displayType != "bioRxiv" && source.displayType != "medRxiv") {
+          <nz-descriptions-item nzTitle="Journal"
+            >{{ source.fullJournalTitle }}
+          </nz-descriptions-item>
+        }
         <nz-descriptions-item nzTitle="PMC ID">
           <ng-container *ngIf="source.pmcId; else notAvailable">
             <cvc-link-tag

--- a/server/app/graphql/types/entities/source_type.rb
+++ b/server/app/graphql/types/entities/source_type.rb
@@ -71,7 +71,7 @@ module Types::Entities
     end
 
     def author_string
-      if object.source_type == "PubMed" || object.source_type == "ASH"
+      if [ "PubMed", "ASH", "bioRxiv", "medRxiv" ].include?(object.source_type)
         Loaders::AssociationLoader.for(Source, :authors_sources).load(object).then do |authors_sources|
           Promise.all(authors_sources.map { |as| Loaders::AssociationLoader.for(AuthorsSource, :author).load(as) }).then do |authors|
             authors_sources.sort_by { |as| as.author_position }

--- a/server/app/graphql/types/queries/source_queries.rb
+++ b/server/app/graphql/types/queries/source_queries.rb
@@ -29,6 +29,10 @@ module Types::Queries
           Scrapers::PubMed.get_citation_from_pubmed_id(citation_id)
         when "ASH"
           Scrapers::Ash.get_citation_from_doi(doi: citation_id)
+        when "bioRxiv"
+          Scrapers::BioRxiv.get_citation_from_doi(doi: citation_id)
+        when "medRxiv"
+          Scrapers::MedRxiv.get_citation_from_doi(doi: citation_id)
         else
           raise GraphQL::ExecutionError, "#{source_type} not found for existence check, non-exhaustive match"
         end

--- a/server/app/graphql/types/source_source_type.rb
+++ b/server/app/graphql/types/source_source_type.rb
@@ -3,5 +3,7 @@ module Types
     value "PUBMED", value: "PubMed"
     value "ASCO", value: "ASCO"
     value "ASH", value: "ASH"
+    value "BIORXIV", value: "bioRxiv"
+    value "MEDRXIV", value: "medRxiv"
   end
 end

--- a/server/app/jobs/fetch_source_data.rb
+++ b/server/app/jobs/fetch_source_data.rb
@@ -7,6 +7,10 @@ class FetchSourceData < ApplicationJob
       Scrapers::Asco.populate_source_fields(source)
     when "ASH"
       Scrapers::Ash.populate_source_fields(source)
+    when "bioRxiv"
+      Scrapers::BioRxiv.populate_source_fields(source)
+    when "medRxiv"
+      Scrapers::MedRxiv.populate_source_fields(source)
     else
       raise StandardError.new("Unknown source type #{source.source_type}. Non-exhaustive match.")
     end

--- a/server/app/jobs/update_preprints.rb
+++ b/server/app/jobs/update_preprints.rb
@@ -1,19 +1,71 @@
-
 class UpdatePreprints < ApplicationJob
   attr_reader :civicbot_user
 
   def perform
     @civicbot_user = User.find(Constants::CIVICBOT_USER_ID)
     update_pubmed_preprints
+    update_biorxiv_preprints
+    update_medrxiv_preprints
   end
 
   def update_pubmed_preprints
     Source.where(source_type: "PubMed", is_preprint: true).each do |source|
-      resp = Scrapers::PubMed.call_pubmed_api(source.citation_id)
-      update_pmid = resp.update_pmid
+      if source.evidence_items.count > 0
+        resp = Scrapers::PubMed.call_pubmed_api(source.citation_id)
+        update_pmid = resp.update_pmid
 
-      update_source = create_update_source("PubMed", update_pmid)
-      create_revisions(source, update_source)
+        unless update_pmid.nil?
+          update_source = create_update_source("PubMed", update_pmid)
+          create_revisions(source, update_source)
+        end
+      end
+    end
+  end
+
+  def update_biorxiv_preprints
+    Source.where(source_type: "bioRxiv", is_preprint: true).each do |source|
+      if source.evidence_items.count > 0
+        resp = Scrapers::BioRxiv.fetch_biorxiv_page(doi: source.citation_id)
+        update_doi = resp.update_doi
+
+        unless update_doi.nil?
+          update_pmid = get_pmid_from_doi(update_doi)
+
+          unless update_pmid.nil?
+            update_source = create_update_source("PubMed", update_pmid)
+            create_revisions(source, update_source)
+          end
+        end
+      end
+    end
+  end
+
+  def update_medrxiv_preprints
+    Source.where(source_type: "medRxiv", is_preprint: true).each do |source|
+      if source.evidence_items.count > 0
+        resp = Scrapers::MedRxiv.fetch_medrxiv_page(doi: source.citation_id)
+        update_doi = resp.update_doi
+
+        unless update_doi.nil?
+          update_pmid = get_pmid_from_doi(update_doi)
+
+          unless update_pmid.nil?
+            update_source = create_update_source("PubMed", update_pmid)
+            create_revisions(source, update_source)
+          end
+        end
+      end
+    end
+  end
+
+  def get_pmid_from_doi(doi)
+    url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=#{doi}&retmode=json"
+    response_body = Scrapers::Util.make_get_request(url)
+    json = JSON(response_body)
+    if json["esearchresult"]["count"].to_i == 1
+      json["esearchresult"]["idlist"][0]
+    else
+      nil
     end
   end
 

--- a/server/app/jobs/update_preprints.rb
+++ b/server/app/jobs/update_preprints.rb
@@ -18,6 +18,7 @@ class UpdatePreprints < ApplicationJob
           update_source = create_update_source("PubMed", update_pmid)
           create_revisions(source, update_source)
         end
+        sleep(1)
       end
     end
   end
@@ -36,6 +37,7 @@ class UpdatePreprints < ApplicationJob
             create_revisions(source, update_source)
           end
         end
+        sleep(1)
       end
     end
   end
@@ -54,6 +56,7 @@ class UpdatePreprints < ApplicationJob
             create_revisions(source, update_source)
           end
         end
+        sleep(1)
       end
     end
   end

--- a/server/app/lib/scrapers/bio_rxiv.rb
+++ b/server/app/lib/scrapers/bio_rxiv.rb
@@ -1,0 +1,49 @@
+require "net/http"
+require "uri"
+require "nokogiri"
+
+module Scrapers
+  class BioRxiv
+    def self.get_citation_from_doi(doi:)
+      resp = fetch_biorxiv_page(doi: doi)
+      resp.citation
+    end
+
+    def self.fetch_biorxiv_page(doi:)
+      resp = Util.make_get_request("https://api.crossref.org/works/#{doi}")
+      response = CrossrefWorkResponse.new(resp)
+      if response.json["message"]["institution"][0]["name"] != "bioRxiv"
+        raise StandardError.new("Institution not 'bioRxiv': #{response.json['message']['institution'][0]["name"]}")
+      end
+      response
+    end
+
+    def self.populate_source_fields(source)
+      resp = fetch_biorxiv_page(doi: source.citation_id)
+
+      resp.authors.each do |author|
+        author_obj = Author.where(
+          last_name: author[:last_name],
+          fore_name: author[:fore_name]
+        ).first_or_create!
+        AuthorsSource.where(
+          source: source,
+          author: author_obj,
+          author_position: author[:author_position]
+        ).first_or_create!
+      end
+
+      source.publication_day = resp.day
+      source.publication_month = resp.month
+      source.publication_year = resp.year
+      if !resp.abstract.blank?
+        source.abstract = Nokogiri::HTML(resp.abstract).text.strip.split("Disclosures").first.sub(/\AAbstract/, "").strip
+      end
+      source.title = resp.article_title
+      source.citation = resp.citation
+      source.is_preprint = true
+
+      source.save!
+    end
+  end
+end

--- a/server/app/lib/scrapers/crossref_work_response.rb
+++ b/server/app/lib/scrapers/crossref_work_response.rb
@@ -83,5 +83,14 @@ module Scrapers
       a = json["message"]["author"].first
       "#{a['given']} #{a['family']}"
     end
+
+    def update_doi
+      preprint = json["message"]["relation"]["is-preprint-of"]&.find { |e| e["id-type"] == "doi" }
+      if preprint.nil?
+        nil
+      else
+        preprint["id"]
+      end
+    end
   end
 end

--- a/server/app/lib/scrapers/med_rxiv.rb
+++ b/server/app/lib/scrapers/med_rxiv.rb
@@ -1,0 +1,49 @@
+require "net/http"
+require "uri"
+require "nokogiri"
+
+module Scrapers
+  class MedRxiv
+    def self.get_citation_from_doi(doi:)
+      resp = fetch_medrxiv_page(doi: doi)
+      resp.citation
+    end
+
+    def self.fetch_medrxiv_page(doi:)
+      resp = Util.make_get_request("https://api.crossref.org/works/#{doi}")
+      response = CrossrefWorkResponse.new(resp)
+      if response.json["message"]["institution"][0]["name"] != "medRxiv"
+        raise StandardError.new("Institution not 'medRxiv': #{response.json['message']['institution'][0]["name"]}")
+      end
+      response
+    end
+
+    def self.populate_source_fields(source)
+      resp = fetch_medrxiv_page(doi: source.citation_id)
+
+      resp.authors.each do |author|
+        author_obj = Author.where(
+          last_name: author[:last_name],
+          fore_name: author[:fore_name]
+        ).first_or_create!
+        AuthorsSource.where(
+          source: source,
+          author: author_obj,
+          author_position: author[:author_position]
+        ).first_or_create!
+      end
+
+      source.publication_day = resp.day
+      source.publication_month = resp.month
+      source.publication_year = resp.year
+      if !resp.abstract.blank?
+        source.abstract = Nokogiri::HTML(resp.abstract).text.strip.split("Disclosures").first.sub(/\AAbstract/, "").strip
+      end
+      source.title = resp.article_title
+      source.citation = resp.citation
+      source.is_preprint = true
+
+      source.save!
+    end
+  end
+end

--- a/server/app/models/materialized_views/source_browse_table_row.rb
+++ b/server/app/models/materialized_views/source_browse_table_row.rb
@@ -2,5 +2,5 @@ class MaterializedViews::SourceBrowseTableRow < MaterializedViews::MaterializedV
   self.primary_key = :id
   has_and_belongs_to_many :clinical_trials, join_table: :clinical_trials_sources, foreign_key: :source_id
 
-  enum :source_type, [ "PubMed", "ASCO", "ASH" ]
+  enum :source_type, [ "PubMed", "ASCO", "ASH", "bioRxiv", "medRxiv" ]
 end

--- a/server/app/models/source.rb
+++ b/server/app/models/source.rb
@@ -16,7 +16,7 @@ class Source < ActiveRecord::Base
   has_many :sources_variant_groups, class_name: "SourceVariantGroup"
   has_many :variant_groups, through: :sources_variant_groups
 
-  enum :source_type, [ "PubMed", "ASCO", "ASH" ]
+  enum :source_type, [ "PubMed", "ASCO", "ASH", "bioRxiv", "medRxiv" ]
 
   validate :citation_id_format_matches_source_type
 
@@ -55,9 +55,7 @@ class Source < ActiveRecord::Base
   def self.url_for(source:)
     if source.source_type == "PubMed"
       "http://www.ncbi.nlm.nih.gov/pubmed/#{source.citation_id}"
-    elsif source.source_type == "ASCO"
-      "https://doi.org/#{source.citation_id}"
-    elsif source.source_type == "ASH"
+    elsif [ "ASCO", "ASH", "bioRxiv", "medRxiv" ].include?(source.source_type)
       "https://doi.org/#{source.citation_id}"
     end
   end
@@ -87,6 +85,12 @@ class Source < ActiveRecord::Base
       elsif source_type == "ASH"
         unless citation_id =~ /\A10.1182\/blood[-._;()\/:A-Z0-9]+\z/i
           errors.add(:citation_id, "#{citation_id} doesn't appear to be a valid ASH Abstract DOI")
+        end
+      elsif [ "bioRxiv", "medRxiv" ].include?(source_type)
+        if citation_id =~ /\A10.64898\/[-._;()\/:A-Z0-9]+\z/i || citation_id =~ /\A10.1101\/[-._;()\/:A-Z0-9]+\z/i
+          # no op
+        else
+          errors.add(:citation_id, "#{citation_id} doesn't appear to be a valid #{source_type} Abstract DOI")
         end
       else
         errors.add(:source_type, "Unexpected Source Type: #{source_type}")

--- a/server/app/reports/eids_by_source.rb
+++ b/server/app/reports/eids_by_source.rb
@@ -11,7 +11,7 @@ class EidsBySource < Report
 
   def self.inputs
     {
-      source_type: [ "PubMed", "ASCO", "ASH" ],
+      source_type: [ "PubMed", "ASCO", "ASH", "bioRxiv", "medRxiv" ],
       source_id: :text,
     }
   end


### PR DESCRIPTION
This PR adds two new source types: bioRxiv, and medRxiv. Sources of types are automatically treated as preprints.

The UpdatePreprints jobs has been update to also handle these source types. This is done by looking at the `is-preprint-of` relation of the crossref work response and if a DOI is listed there it is then used to find the matching PMID using the PubMed search API.

Because these sources are not journals in the traditional sense the `journal` and `full_journal_title` are not being set and these fields are not displayed in the UI. 