### PR TITLE
Serve profile images as stable, cacheable proxy URLs

### DIFF
--- a/client/src/app/components/organizations/organization-leaderboards/organization-leaderboards.component.ts
+++ b/client/src/app/components/organizations/organization-leaderboards/organization-leaderboards.component.ts
@@ -18,7 +18,7 @@ import {
   TimeWindow,
 } from '@app/generated/civic.apollo'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
-import { QueryRef, WatchQueryOptionsAlone } from 'apollo-angular'
+import { QueryRef } from 'apollo-angular'
 import { BehaviorSubject, map } from 'rxjs'
 import { TagLinkableOrganization } from '../organization-tag/organization-tag.component'
 
@@ -102,11 +102,6 @@ export class CvcOrganizationLeaderboardsComponent implements OnInit {
   initialRows: number = 25
   initialWindow: TimeWindow = TimeWindow.AllTime
 
-  fetchPolicy: WatchQueryOptionsAlone = {
-    fetchPolicy: 'no-cache',
-    nextFetchPolicy: 'no-cache',
-  }
-
   constructor(
     private commentsGQL: OrganizationCommentsLeaderboardGQL,
     private revisionsGQL: OrganizationRevisionsLeaderboardGQL,
@@ -115,6 +110,10 @@ export class CvcOrganizationLeaderboardsComponent implements OnInit {
   ) {
     this.timeWindow$ = new BehaviorSubject<TimeWindow>(this.initialWindow)
     this.timeWindow$.pipe(untilDestroyed(this)).subscribe((window) => {
+      // BehaviorSubject emits synchronously on subscribe, before ngOnInit
+      // has created the query refs; that initial window is already passed
+      // to the watch() calls
+      if (!this.commentsQueryRef) return
       this.commentsQueryRef.refetch({ window: window })
       this.revisionsQueryRef.refetch({ window: window })
       this.moderationQueryRef.refetch({ window: window })
@@ -153,13 +152,10 @@ export class CvcOrganizationLeaderboardsComponent implements OnInit {
     /*
      * REVISIONS
      */
-    this.commentsQueryRef = this.commentsGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.commentsQueryRef = this.commentsGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.commentsQueryRef.valueChanges
       .pipe(
@@ -193,13 +189,10 @@ export class CvcOrganizationLeaderboardsComponent implements OnInit {
     /*
      * MODERATIONS
      */
-    this.moderationQueryRef = this.moderationGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.moderationQueryRef = this.moderationGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.moderationQueryRef.valueChanges
       .pipe(
@@ -235,13 +228,10 @@ export class CvcOrganizationLeaderboardsComponent implements OnInit {
     // /*
     //  * REVISIONS
     //  */
-    this.revisionsQueryRef = this.revisionsGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.revisionsQueryRef = this.revisionsGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.revisionsQueryRef.valueChanges
       .pipe(
@@ -277,13 +267,10 @@ export class CvcOrganizationLeaderboardsComponent implements OnInit {
     /*
      * SUBMISSIONS
      */
-    this.submissionsQueryRef = this.submissionsGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.submissionsQueryRef = this.submissionsGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.submissionsQueryRef.valueChanges
       .pipe(

--- a/client/src/app/components/users/user-leaderboards/user-leaderboards.component.ts
+++ b/client/src/app/components/users/user-leaderboards/user-leaderboards.component.ts
@@ -18,7 +18,7 @@ import {
   UserSubmissionsLeaderboardQueryVariables,
 } from '@app/generated/civic.apollo'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
-import { QueryRef, WatchQueryOptionsAlone } from 'apollo-angular'
+import { QueryRef } from 'apollo-angular'
 import { BehaviorSubject, map } from 'rxjs'
 import { TagLinkableUser } from '../user-tag/user-tag.component'
 
@@ -104,11 +104,6 @@ export class CvcUserLeaderboardsComponent implements OnInit {
   initialRows: number = 25
   initialWindow: TimeWindow = TimeWindow.AllTime
 
-  fetchPolicy: WatchQueryOptionsAlone = {
-    fetchPolicy: 'no-cache',
-    nextFetchPolicy: 'no-cache',
-  }
-
   constructor(
     private commentsGQL: UserCommentsLeaderboardGQL,
     private revisionsGQL: UserRevisionsLeaderboardGQL,
@@ -117,6 +112,10 @@ export class CvcUserLeaderboardsComponent implements OnInit {
   ) {
     this.timeWindow$ = new BehaviorSubject<TimeWindow>(this.initialWindow)
     this.timeWindow$.pipe(untilDestroyed(this)).subscribe((window) => {
+      // BehaviorSubject emits synchronously on subscribe, before ngOnInit
+      // has created the query refs; that initial window is already passed
+      // to the watch() calls
+      if (!this.commentsQueryRef) return
       this.commentsQueryRef.refetch({ window: window })
       this.revisionsQueryRef.refetch({ window: window })
       this.moderationQueryRef.refetch({ window: window })
@@ -156,13 +155,10 @@ export class CvcUserLeaderboardsComponent implements OnInit {
     /*
      * COMMENTS VIEW
      */
-    this.commentsQueryRef = this.commentsGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.commentsQueryRef = this.commentsGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.commentsQueryRef.valueChanges
       .pipe(
@@ -192,13 +188,10 @@ export class CvcUserLeaderboardsComponent implements OnInit {
     /*
      * MODERATION VIEW
      */
-    this.moderationQueryRef = this.moderationGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.moderationQueryRef = this.moderationGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.moderationQueryRef.valueChanges
       .pipe(
@@ -230,13 +223,10 @@ export class CvcUserLeaderboardsComponent implements OnInit {
     /*
      * REVISIONS VIEW
      */
-    this.revisionsQueryRef = this.revisionsGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.revisionsQueryRef = this.revisionsGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.revisionsQueryRef.valueChanges
       .pipe(
@@ -266,13 +256,10 @@ export class CvcUserLeaderboardsComponent implements OnInit {
     /*
      * SUBMISSIONS VIEW
      */
-    this.submissionsQueryRef = this.submissionsGQL.watch(
-      {
-        first: this.initialRows,
-        window: this.initialWindow,
-      },
-      this.fetchPolicy
-    )
+    this.submissionsQueryRef = this.submissionsGQL.watch({
+      first: this.initialRows,
+      window: this.initialWindow,
+    })
 
     this.submissionsQueryRef.valueChanges
       .pipe(

--- a/client/src/app/generated/server.model.graphql
+++ b/client/src/app/generated/server.model.graphql
@@ -1744,7 +1744,7 @@ type BrowseUser {
   orcid: String
   organizations: [Organization!]!
   organizationsWithApprovalPrivileges: [Organization!]!
-  profileImagePath(size: Int = 56): String
+  profileImagePath(size: Int = 64): String
   ranks: Ranks!
   revisionCount: Int!
   role: UserRole!
@@ -6976,7 +6976,7 @@ type LeaderboardOrganization {
   name: String!
   orgAndSuborgsStatsHash: Stats!
   orgStatsHash: Stats!
-  profileImagePath(size: Int = 56): String
+  profileImagePath(size: Int = 64): String
   rank: Int!
   ranks: Ranks!
   subGroups: [Organization!]!
@@ -7119,7 +7119,7 @@ type LeaderboardUser {
   orcid: String
   organizations: [Organization!]!
   organizationsWithApprovalPrivileges: [Organization!]!
-  profileImagePath(size: Int = 56): String
+  profileImagePath(size: Int = 64): String
   rank: Int!
   ranks: Ranks!
   role: UserRole!
@@ -8814,7 +8814,7 @@ type Organization {
   name: String!
   orgAndSuborgsStatsHash: Stats!
   orgStatsHash: Stats!
-  profileImagePath(size: Int = 56): String
+  profileImagePath(size: Int = 64): String
   ranks: Ranks!
   subGroups: [Organization!]!
   url: String!
@@ -14424,7 +14424,7 @@ type User {
   orcid: String
   organizations: [Organization!]!
   organizationsWithApprovalPrivileges: [Organization!]!
-  profileImagePath(size: Int = 56): String
+  profileImagePath(size: Int = 64): String
   ranks: Ranks!
   role: UserRole!
   statsHash: Stats!

--- a/client/src/app/graphql/graphql.type-policies.ts
+++ b/client/src/app/graphql/graphql.type-policies.ts
@@ -2,7 +2,46 @@ import { relayStylePagination } from '@apollo/client/utilities'
 import { StrictTypedTypePolicies } from '@app/generated/civic.apollo-helpers'
 import { CvcAdvancedSearchResultPolicy } from '@app/graphql/policies/advanced-search-result.policy'
 
+/**
+ * Embed a type in whatever query result fetched it instead of normalizing it.
+ *
+ * Apply to "row" types that carry an entity's `id` alongside fields scoped to
+ * the query that produced them — a leaderboard row is user 12 *plus* that
+ * board's rank and actionCount for one time window. Normalization treats id as
+ * global identity: every board and every window would fold into one
+ * `LeaderboardUser:12` object, and whichever query wrote last would clobber
+ * the others' rank. `keyFields: false` keeps each row inside its own
+ * connection entry, which the default field keying already partitions by
+ * board field and arguments. (Value types with no id at all — ContributingUser,
+ * Ranks — get this behavior by default and need no policy.)
+ */
+function embeddedRow(): { keyFields: false } {
+  return { keyFields: false }
+}
+
+/**
+ * Deep-merge writes to a keyless singleton instead of replacing it.
+ *
+ * Apply to namespace objects — id-less types that exist once under ROOT_QUERY
+ * and whose fields are populated by separate queries (the four leaderboard
+ * queries each write one board field of `userLeaderboards`). Apollo's default
+ * for a keyless object is replacement, so the last query to respond would
+ * discard every other query's fields ("Cache data may be lost..." warning).
+ */
+function mergedNamespace(): { merge: true } {
+  return { merge: true }
+}
+
 export const CvcTypePolicies: StrictTypedTypePolicies = {
+  // leaderboard rows carry per-board, per-window rank/actionCount on an
+  // entity id; see embeddedRow. Before these policies the leaderboard
+  // components masked the collision with no-cache fetch policies.
+  LeaderboardUser: embeddedRow(),
+  LeaderboardOrganization: embeddedRow(),
+  // the four user/org leaderboard queries each write one field of these
+  // keyless singletons; see mergedNamespace
+  UserLeaderboards: mergedNamespace(),
+  OrganizationLeaderboards: mergedNamespace(),
   Gene: {
     fields: {
       comments: relayStylePagination(),

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     byebug (13.0.0)
@@ -771,7 +771,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   capistrano (3.19.2) sha256=e0c79823edf604ba513533b224f85f5a9fe33c4c6c9cbde9483a56b48838f563

--- a/server/app/graphql/types/entities/organization_type.rb
+++ b/server/app/graphql/types/entities/organization_type.rb
@@ -20,7 +20,7 @@ module Types::Entities
 
     profile_image_sizes = [ 256, 128, 64, 32, 18, 12 ]
     field :profile_image_path, String, null: true do
-      argument :size, Int, required: false, default_value: 56,
+      argument :size, Int, required: false, default_value: 64,
         validates: {
           inclusion: {
             in: profile_image_sizes,
@@ -50,8 +50,13 @@ module Types::Entities
     def profile_image_path(size:)
       Loaders::ActiveStorageLoader.for(:Organization, :profile_image).load(object.id).then do |image|
         if image
-          Rails.application.routes.url_helpers.url_for(
-            image.variant(resize_to_limit: [ size, size ]).processed.url
+          # Proxy-mode representation URL: stable per blob+variation (permanent
+          # signed id, no expiry timestamp) and served with long-lived public
+          # cache headers, so browsers cache the image bytes. The variant is
+          # derived by the proxy controller on first GET, not here.
+          Rails.application.routes.url_helpers.rails_storage_proxy_url(
+            image.variant(resize_to_limit: [ size, size ]),
+            **ActiveStorage::Current.url_options
           )
         else
           nil

--- a/server/app/graphql/types/entities/user_type.rb
+++ b/server/app/graphql/types/entities/user_type.rb
@@ -28,7 +28,7 @@ module Types::Entities
 
     profile_image_sizes = [ 256, 128, 64, 32, 18, 12 ]
     field :profile_image_path, String, null: true do
-      argument :size, Int, required: false, default_value: 56,
+      argument :size, Int, required: false, default_value: 64,
         validates: {
           inclusion: {
             in: profile_image_sizes,
@@ -103,10 +103,14 @@ module Types::Entities
     def profile_image_path(size:)
       Loaders::ActiveStorageLoader.for(:User, :profile_image).load(object.id).then do |image|
         if image
-          Rails.application.routes.url_helpers.url_for(
-            image.variant(resize_to_limit: [ size, size ]).processed.url
+          # Proxy-mode representation URL: stable per blob+variation (permanent
+          # signed id, no expiry timestamp) and served with long-lived public
+          # cache headers, so browsers cache the image bytes. The variant is
+          # derived by the proxy controller on first GET, not here.
+          Rails.application.routes.url_helpers.rails_storage_proxy_url(
+            image.variant(resize_to_limit: [ size, size ]),
+            **ActiveStorage::Current.url_options
           )
-        else
         end
       end
     end

--- a/server/config/initializers/rack_mini_profiler.rb
+++ b/server/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,10 @@
+# rack-mini-profiler (development group) rewrites Cache-Control to no-store on
+# every response it instruments, which defeats the long-lived public cache
+# headers on Active Storage proxy responses and re-downloads every avatar on
+# every page view in development. Profiling image byte-streams has no value,
+# so skip the Active Storage routes entirely (String entries are path
+# prefixes; skipped requests pass through with headers untouched).
+if defined?(Rack::MiniProfiler)
+  Rack::MiniProfiler.config.skip_paths ||= []
+  Rack::MiniProfiler.config.skip_paths << "/rails/active_storage"
+end


### PR DESCRIPTION
## Enhancement Opportunity

Every page view currently re-downloads every avatar, presenting an opportunity for optimization. The `profileImagePath(size:)` is resolved, and the `variant.processed.url` provides a Disk-service URL with a **5-minute, millisecond-precision expiry**. This ensures that each GraphQL resolution generates a unique URL for the same image, enhancing security and freshness. However, the response includes uncacheable headers, which can be addressed to improve efficiency. In the last 200 MB of a dev log, there were **29,895** image GETs with **29,478 distinct URLs** and zero 304s, indicating potential for caching improvements. Single files were fetched over 330 times, suggesting opportunities for optimization through caching strategies. Additionally, the `.processed` variant currently runs ImageMagick derivation synchronously within the GraphQL response, observed to take 100ms+ for first requests, and incurs 2–3 un-batched `VariantRecord` queries per avatar per request, even when warm. By addressing these aspects, we can significantly enhance the performance and efficiency of avatar image handling.

## Fix

**Server** — resolvers return `rails_storage_proxy_url(variant)` instead: one
permanent URL per blob+size, served by `ActiveStorage::Representations::ProxyController`
with `Cache-Control: public, max-age≈100y` + ETag. The variant derives once,
on first GET, outside the GraphQL request; re-uploads change the blob's
signed id, so caches bust naturally. `BrowseUser`/`LeaderboardUser`/
`LeaderboardOrganization` inherit the two resolvers, so all five image-bearing
schema types are covered. Also fixes the field's default `size: 56`, which
was not in the allowed sizes `[256,128,64,32,18,12]` (now 64; SDL dump
included), and adds a dev initializer so rack-mini-profiler stops rewriting
the proxy responses to `no-store`.

**Client** — the four user/org leaderboard queries ran with
`fetchPolicy: 'no-cache'`, refetching ~100 avatars' worth of rows on every
visit. The override was masking a normalization bug: leaderboard rows carry
the entity `id` plus per-board `rank`/`actionCount`, so cached boards folded
into one normalized object and clobbered each other, and each of the four
queries replaced the keyless `userLeaderboards`/`organizationLeaderboards`
namespace object, discarding the other boards. Two generalized type policies
fix both halves (`keyFields: false` embedded rows, `merge: true` namespaces),
letting the components inherit the app-default fetch policies. Also guards a
pre-existing per-load `TypeError`: the constructors' `timeWindow$`
BehaviorSubject emits synchronously on subscribe, calling `refetch()` on
query refs `ngOnInit` hasn't created yet.

## Verification

- Repeated identical queries return byte-identical URLs (`"exp":null`
  permanent signing); previously two requests 60ms apart differed.
- Image GETs: `Cache-Control: max-age=3155695200, public, immutable` + ETag;
  conditional GETs return 304; derivation appears in the log only on the
  first GET of a new blob+size, never inside `GraphqlController#execute`.
- Live cache probe on the Contributors page: all four boards coexist under
  one cache entry with distinct per-board ranks, zero `LeaderboardUser:<id>`
  normalized entries, window flips refetch while the prior window stays
  cached, no console errors.
- `updated_idl_test` + `example_queries_test` green on this branch;
  client `tsc --noEmit` clean.

## Notes for reviewers

- Old client + new server is safe: the field is still "a URL string", every
  client call site passes an explicit `size`, and stale 5-minute URLs simply
  age out.
- Proxy URLs are permanent-signed: rotating `secret_key_base` 404s previously
  issued URLs until pages refetch (rails#40614) — self-heals, listed here so
  it isn't chased as a bug later.
- The v22 dependency stack carries these same changes; when it rebases over
  this PR the server/component hunks are identical, `graphql.type-policies.ts`
  resolves to the stack's version (it already contains the policies), and the
  SDL is regenerated, not merged. A follow-up in that stack also removes 32
  `profileImagePath` fetches from queries that never render an avatar.