### PR TITLE
build(ci): bump brakeman and fix a codespell false positive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,5 @@
 skip = .git*,*.svg,*.lock,*.css,.codespellrc,*.js,generated,assets,variants-summary.page.html
 check-hidden = true
 # Ignore super long lines -- must be minimized etc
-ignore-regex = ^.{120,}|\b(AllTime|allTime)\b
+# mor.nlm.nih.gov is the RxNav host (my-chem-info component)
+ignore-regex = ^.{120,}|\b(AllTime|allTime)\b|mor\.nlm\.nih\.gov

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     byebug (13.0.0)
@@ -771,7 +771,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   capistrano (3.19.2) sha256=e0c79823edf604ba513533b224f85f5a9fe33c4c6c9cbde9483a56b48838f563


### PR DESCRIPTION
Two unrelated CI gates fail on `main` today. One line each.

**brakeman.** `bin/brakeman --ensure-latest` exits 5 as soon as a new brakeman
release lands upstream — before it scans anything — so every open PR fails on a
gate unrelated to its own changes. `main` pins 8.0.5; upstream is 8.0.6.

**codespell.** It reads `mor.nlm.nih.gov`, the RxNav host used by the
my-chem-info component, as a misspelling.

## Review map

- `server/Gemfile.lock` — brakeman 8.0.5 → 8.0.6, lockfile only. No `Gemfile`
  change, so the dependency itself is unpinned as before.
- `.codespellrc` — one alternation appended to `ignore-regex`, with a comment
  naming the host so the next reader doesn't have to re-derive why it's exempt.

## Verification

- `gem list brakeman --remote --exact` reports 8.0.6 as the current release, so
  the new pin satisfies `--ensure-latest`.
- codespell isn't installed locally, so its gate is verified by this PR's own
  CI run rather than by me.

Both gates run on this PR, which is the check that matters for both changes.
