### PR TITLE
fix(forms): repair the query builder after formly 7 and apollo 4

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -29,6 +29,10 @@ import { CvcNetworkErrorAlertModule } from './components/app/network-error-alert
 import { firstValueFrom, Observable, tap } from 'rxjs'
 import { AppErrorHandler } from './core/utilities/app-error-handler'
 import { CvcForms2Module } from '@app/forms/forms.module'
+import { FormlyModule, FORMLY_CONFIG } from '@ngx-formly/core'
+import { CvcFormlyConfig2 } from '@app/forms/forms.options'
+import { registerCvcExtensions } from '@app/forms/extensions/form-extensions.config'
+import { ActivatedRoute } from '@angular/router'
 import { graphqlProvider } from './graphql/graphql.module'
 import { CvcEnvironmentBannerComponent } from './components/app/environment-banner/environment-banner.component'
 import { environment } from 'environments/environment'
@@ -63,6 +67,8 @@ const initlializerProvider = provideAppInitializer(() => {
     BrowserModule,
     NgxJsonViewerModule,
     NzIconModule.forRoot(civicIcons),
+    // forRoot must live at the root injector ONLY — see note in forms.module.ts
+    FormlyModule.forRoot(CvcFormlyConfig2),
     CvcForms2Module,
     LetDirective,
     PushPipe,
@@ -72,6 +78,13 @@ const initlializerProvider = provideAppInitializer(() => {
   providers: [
     initlializerProvider,
     graphqlProvider,
+    {
+      // inject deps, instantiate and register formly expression extensions
+      provide: FORMLY_CONFIG,
+      multi: true,
+      useFactory: registerCvcExtensions,
+      deps: [ActivatedRoute],
+    },
     {
       provide: ErrorHandler,
       useClass: AppErrorHandler,

--- a/client/src/app/forms/config/query-builder/query-builder.form.ts
+++ b/client/src/app/forms/config/query-builder/query-builder.form.ts
@@ -190,7 +190,7 @@ export class CvcQueryBuilderForm {
     const gql = this.formGQL()
 
     gql
-      .fetch(model)
+      .fetch({ variables: model })
       .pipe(
         map((r) => r.data?.[endpoint]),
         filter(isNonNulled),

--- a/client/src/app/forms/config/query-builder/query-builder.types.ts
+++ b/client/src/app/forms/config/query-builder/query-builder.types.ts
@@ -49,9 +49,10 @@ export type AdvancedSearchFilter<
 > = EndpointFilterTypes[E]
 
 // generic interface for all adv. search's Apollo GQL services
+// (apollo-angular v14 single-options-object call shape)
 export interface AdvancedSearchService {
-  fetch(variables?: any, options?: any): Observable<any>
-  watch(variables?: any, options?: any): QueryRef<any, any>
+  fetch(options?: { variables?: any; [key: string]: any }): Observable<any>
+  watch(options?: { variables?: any; [key: string]: any }): QueryRef<any, any>
 }
 
 export type QueryBuilderFormModel = {

--- a/client/src/app/forms/forms.module.ts
+++ b/client/src/app/forms/forms.module.ts
@@ -1,19 +1,22 @@
 import { NgModule } from '@angular/core'
 import { ReactiveFormsModule } from '@angular/forms'
-import { ActivatedRoute } from '@angular/router'
-import { FormlyModule, FORMLY_CONFIG } from '@ngx-formly/core'
+import { FormlyModule } from '@ngx-formly/core'
 import { FormlyNgZorroAntdModule } from '@ngx-formly/ng-zorro-antd'
 import { NzFormModule } from 'ng-zorro-antd/form'
 import { NgxJsonViewerModule } from 'ngx-json-viewer'
-import { registerCvcExtensions } from './extensions/form-extensions.config'
-import { CvcFormlyConfig2 } from './forms.options'
 import { CvcFormTypesModule } from './types/form-types.module'
 import { CvcFormWrappersModule } from './wrappers/form-wrappers.module'
 
+// NOTE: FormlyModule.forRoot(CvcFormlyConfig2) is imported by AppModule ONLY.
+// This module is imported by many lazy-loaded form modules; importing forRoot
+// here would re-provide FormlyConfig in every lazy injector, splitting formly's
+// config into multiple instances. Under formly v7, the core extension then
+// resolves types against the wrong instance and silently skips component
+// lifecycle hooks (e.g. FieldArrayType.onPopulate), breaking field arrays.
 @NgModule({
   declarations: [],
   imports: [
-    FormlyModule.forRoot(CvcFormlyConfig2),
+    FormlyModule,
     ReactiveFormsModule,
     NzFormModule,
     FormlyNgZorroAntdModule,
@@ -27,15 +30,6 @@ import { CvcFormWrappersModule } from './wrappers/form-wrappers.module'
     NzFormModule,
     CvcFormWrappersModule,
     CvcFormTypesModule,
-  ],
-  providers: [
-    {
-      // inject deps, instantiate and register expressions
-      provide: FORMLY_CONFIG,
-      multi: true,
-      useFactory: registerCvcExtensions,
-      deps: [ActivatedRoute],
-    },
   ],
 })
 export class CvcForms2Module {}

--- a/client/src/app/graphql/graphql.module.ts
+++ b/client/src/app/graphql/graphql.module.ts
@@ -1,6 +1,7 @@
 import { TypePolicies } from '@apollo/client/cache'
 import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client'
 import { CombinedGraphQLErrors } from '@apollo/client/errors'
+import { LocalState } from '@apollo/client/local-state'
 import result from '@app/generated/civic.possible-types'
 import { provideApollo } from 'apollo-angular'
 import { HttpLink } from 'apollo-angular/http'
@@ -36,6 +37,11 @@ export function createApollo(httpLink: HttpLink): ApolloClient.Options {
       possibleTypes: result.possibleTypes,
       typePolicies: typePolicies,
     }),
+    // AC4 requires explicit LocalState to support @client fields (AC3
+    // stripped them from server requests automatically). All @client
+    // fields (currently only AdvancedSearchResult.formQuery) are computed
+    // by cache type policy read functions, so no resolvers are needed.
+    localState: new LocalState(),
     defaultOptions: {
       watchQuery: {
         fetchPolicy: 'cache-and-network',

--- a/client/src/app/query-builder.smoke.spec.ts
+++ b/client/src/app/query-builder.smoke.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { TestBed } from '@angular/core/testing'
+import { RouterTestingHarness } from '@angular/router/testing'
+import { By } from '@angular/platform-browser'
+import { AppModule } from './app.module'
+import { smokeTestProviders } from './testing/smoke-test.providers'
+import { CvcQuerySubfiltersField } from '@app/forms/types/query-builder/query-subfilters/query-subfilters.type'
+
+// Regression test for the formly v7 config-split bug: when
+// FormlyModule.forRoot() is instantiated in lazy injectors, the core
+// extension binds to a different FormlyConfig than the form builder and
+// silently skips component lifecycle hooks. For FieldArrayType fields
+// (query-subfilters), onPopulate never registers the FormArray control,
+// so add() crashes with "Cannot read properties of undefined
+// (reading 'markAsDirty')".
+describe('Query builder field array smoke test', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppModule],
+      providers: smokeTestProviders(),
+    }).compileComponents()
+  })
+
+  it('builds the subfilters FieldArrayType and adds a filter row', async () => {
+    const harness = await RouterTestingHarness.create()
+    await harness.navigateByUrl('/search/query/searchAssertions')
+
+    const subfiltersDe = harness.routeDebugElement?.query(
+      By.directive(CvcQuerySubfiltersField)
+    )
+    expect(subfiltersDe).toBeTruthy()
+
+    const subfilters = subfiltersDe!
+      .componentInstance as CvcQuerySubfiltersField
+    // onPopulate must have registered the FormArray control at build time —
+    // undefined here means formly skipped the FieldArrayType lifecycle hooks
+    expect(subfilters.field.formControl).toBeDefined()
+    expect(Array.isArray(subfilters.field.model)).toBe(true)
+
+    expect(() => subfilters.addRow()).not.toThrow()
+    harness.detectChanges()
+    expect(subfilters.field.fieldGroup?.length).toBe(1)
+    expect(subfilters.field.model.length).toBe(1)
+  })
+})


### PR DESCRIPTION
CvcForms2Module called FormlyModule.forRoot() and is imported by ~18 lazy form
modules, so every lazy injector got its own FormlyConfig. formly 7 registers
configs through FormlyFormBuilder into the injected instance, so the core
extension bound to a different config than the builder populated, and silently
skipped component lifecycle hooks.

For FieldArrayType that meant onPopulate never registered the FormArray, and
add() crashed reading 'markAsDirty' of undefined. forRoot() and the extensions
provider now live in AppModule alone.
## Review map

`app.module.ts` gains the `FormlyModule.forRoot()` call and the extensions provider; `forms.module.ts` loses them. The remaining files follow that move.

## Verification

**Tree parity.** This branch's tree is byte-identical to `e281c4aba` on the
original `update-deps-v22` branch — 0 files differing. The code here is not
new; it is the same tree, regrouped. Only the commit message is rewritten.

**Build.** `ng build --configuration production` passes at this head on node 26.

**Stack parity.** The tip of this stack is byte-identical to
`origin/update-deps-v22` with nothing excluded, and `yarn test` passes there
(3 files, 8 tests). 14 commits became 9; the end state is unchanged.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>