### PR TITLE
fix(forms): correct entity-tag placement in single-mode selects

### DIFF
--- a/client/src/themes/default.less
+++ b/client/src/themes/default.less
@@ -82,3 +82,12 @@
 .hide-dropdown {
   display: none;
 }
+
+// ng-zorro 22 sets single-select selection items to `display: block`
+// (v20 had no display rule). Our custom nzCustomTemplate select templates
+// wrap selected content in div.ant-select-selection-item-content, a class
+// ant only styles in multiple mode — as a raw block div it stacks a second
+// line box and the item overflows the control, misplacing entity tags.
+.ant-select-single .ant-select-selector .ant-select-selection-item-content {
+  display: inline-block;
+}


### PR DESCRIPTION
ng-zorro 22 sets .ant-select-single selection items to display: block, where
v20 had no display rule. Our nzCustomTemplate select templates wrap selected
content in div.ant-select-selection-item-content, which ant only styles in
multiple mode — as a raw block div it stacks a second line box, so the 52px
item overflows the 28px control and shifts entity tags out of the field.
Visible throughout the advanced-search query builder.
## Review map

One `.less` rule.

## Verification

**Tree parity.** This branch's tree is byte-identical to `c0d26a21b` on the
original `update-deps-v22` branch — 0 files differing. The code here is not
new; it is the same tree, regrouped. Only the commit message is rewritten.

**Build.** `ng build --configuration production` passes at this head on node 26.

**Stack parity.** The tip of this stack is byte-identical to
`origin/update-deps-v22` with nothing excluded, and `yarn test` passes there
(3 files, 8 tests). 14 commits became 9; the end state is unchanged.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>