### PR TITLE
Fix revision submission form validation for Oncogenic Assertions

### DIFF
--- a/client/src/app/forms/config/assertion-revise/assertion-revise.form.config.ts
+++ b/client/src/app/forms/config/assertion-revise/assertion-revise.form.config.ts
@@ -1,3 +1,4 @@
+import { AssertionFields } from '@app/forms/models/assertion-fields.model'
 import { assertionReviseFormInitialModel } from '@app/forms/models/assertion-revise.model'
 import { CvcAcmgCodeSelectFieldOptions } from '@app/forms/types/acmg-code-select/acmg-code-select.type'
 import { CvcAmpCategorySelectFieldOptions } from '@app/forms/types/amp-category-select/amp-category-select.type'
@@ -12,6 +13,7 @@ import { CvcOriginSelectFieldOptions } from '@app/forms/types/origin-select/orig
 import { CvcPhenotypeSelectFieldOptions } from '@app/forms/types/phenotype-select/phenotype-select.type'
 import { CvcTherapySelectFieldOptions } from '@app/forms/types/therapy-select/therapy-select.type'
 import { CvcEntityTypeSelectFieldConfig } from '@app/forms/types/type-select/type-select.type'
+import { assertionRequiresEvidenceItems } from '@app/forms/utilities/assertion-requires-evidence-items'
 import assignFieldConfigDefaultValues from '@app/forms/utilities/assign-field-default-values'
 import { CvcFormCardWrapperProps } from '@app/forms/wrappers/form-card/form-card.wrapper'
 import { CvcFormLayoutWrapperProps } from '@app/forms/wrappers/form-layout/form-layout.wrapper'
@@ -185,6 +187,12 @@ const formFieldConfig: FormlyFieldConfig[] = [
                 props: {
                   required: true,
                   isMultiSelect: true,
+                },
+                expressions: {
+                  'props.required': (field: FormlyFieldConfig) =>
+                    assertionRequiresEvidenceItems(
+                      field.model as AssertionFields
+                    ),
                 },
               },
               {

--- a/client/src/app/forms/config/assertion-submit/assertion-submit.form.config.ts
+++ b/client/src/app/forms/config/assertion-submit/assertion-submit.form.config.ts
@@ -9,16 +9,12 @@ import { CvcOrgSubmitButtonFieldConfig } from '@app/forms/types/org-submit-butto
 import { CvcOriginSelectFieldOptions } from '@app/forms/types/origin-select/origin-select.type'
 import { CvcPhenotypeSelectFieldOptions } from '@app/forms/types/phenotype-select/phenotype-select.type'
 import { CvcTherapySelectFieldOptions } from '@app/forms/types/therapy-select/therapy-select.type'
+import { assertionRequiresEvidenceItems } from '@app/forms/utilities/assertion-requires-evidence-items'
 import assignFieldConfigDefaultValues from '@app/forms/utilities/assign-field-default-values'
 import { CvcFormCardWrapperProps } from '@app/forms/wrappers/form-card/form-card.wrapper'
 import { CvcFormLayoutWrapperProps } from '@app/forms/wrappers/form-layout/form-layout.wrapper'
 import { CvcFormRowWrapperProps } from '@app/forms/wrappers/form-row/form-row.wrapper'
-import { AssertionType } from '@app/generated/civic.apollo'
 import { FormlyFieldConfig } from '@ngx-formly/core'
-
-function assertionRequiresEvidenceItems(model?: AssertionFields): boolean {
-  return model?.assertionType !== AssertionType.Oncogenic
-}
 
 const formFieldConfig: FormlyFieldConfig[] = [
   {

--- a/client/src/app/forms/utilities/assertion-requires-evidence-items.ts
+++ b/client/src/app/forms/utilities/assertion-requires-evidence-items.ts
@@ -1,0 +1,8 @@
+import { AssertionFields } from '@app/forms/models/assertion-fields.model'
+import { AssertionType } from '@app/generated/civic.apollo'
+
+export function assertionRequiresEvidenceItems(
+  model?: AssertionFields
+): boolean {
+  return model?.assertionType !== AssertionType.Oncogenic
+}


### PR DESCRIPTION
This pulls the the form validation logic from the assertion submission form into a shared helper and re-uses it for the assertion revision form.