### PR TITLE
auto resize chatbot input area and allow shift+enter to insert a newline

### DIFF
--- a/server/app/javascript/controllers/autosize_controller.js
+++ b/server/app/javascript/controllers/autosize_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+const MAX_HEIGHT = 200
+
+export default class extends Controller {
+  connect() {
+    this.resize()
+  }
+
+  resize() {
+    this.element.style.height = "auto"
+    this.element.style.height =
+      `${Math.min(this.element.scrollHeight, MAX_HEIGHT)}px`
+    this.element.style.overflowY =
+      this.element.scrollHeight > MAX_HEIGHT ? "auto" : "hidden"
+  }
+
+  submit(event) {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return
+
+    event.preventDefault()
+    this.element.form?.requestSubmit()
+  }
+}

--- a/server/app/views/chats/chats/_form.html.erb
+++ b/server/app/views/chats/chats/_form.html.erb
@@ -16,11 +16,16 @@
   <%= form.hidden_field :chat_type, value: chat_type %>
 
   <div>
-    <%= form.text_field :prompt,
-        class: "w-full px-4 py-3 rounded-xl border border-gray-300 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-civic-purple focus:border-transparent text-gray-800 placeholder-gray-400 transition-shadow",
+    <%= form.text_area :prompt,
+        rows: 1,
+        class: "w-full px-4 py-3 rounded-xl border border-gray-300 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-civic-purple focus:border-transparent text-gray-800 placeholder-gray-400 transition-shadow resize-none overflow-y-hidden leading-6",
         placeholder: placeholder,
         autocomplete: "off",
-        autofocus: true %>
+        autofocus: true,
+        data: {
+          controller: "autosize",
+          action: "input->autosize#resize keydown->autosize#submit"
+        } %>
   </div>
 
   <div>

--- a/server/app/views/chats/messages/_form.html.erb
+++ b/server/app/views/chats/messages/_form.html.erb
@@ -8,11 +8,16 @@
   <% end %>
 
   <div class="flex-1 relative">
-    <%= form.text_field :content,
-        class: "w-full px-4 py-3 rounded-xl border border-gray-300 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-civic-purple focus:border-transparent text-gray-800 placeholder-gray-400 transition-shadow",
+    <%= form.text_area :content,
+        rows: 1,
+        class: "w-full px-4 py-3 rounded-xl border border-gray-300 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-civic-purple focus:border-transparent text-gray-800 placeholder-gray-400 transition-shadow resize-none overflow-y-hidden leading-6",
         placeholder: "Send a message...",
         autofocus: true,
-        autocomplete: "off" %>
+        autocomplete: "off",
+        data: {
+          controller: "autosize",
+          action: "input->autosize#resize keydown->autosize#submit"
+        } %>
   </div>
 
   <%= form.submit "Send",

--- a/server/app/views/layouts/_chats_sidebar.html.erb
+++ b/server/app/views/layouts/_chats_sidebar.html.erb
@@ -17,11 +17,11 @@
       <div class="absolute left-0 right-0 mt-1 bg-slate-700 rounded-lg shadow-lg border border-slate-600 overflow-hidden z-10">
         <%= link_to curation_chat_path, class: "flex items-center gap-2 px-3 py-2.5 text-sm text-slate-200 hover:bg-civic-sidebar-hover hover:text-white transition-colors" do %>
           <%= render "chats/shared/icons/chat_bubble", css: "h-4 w-4 shrink-0 text-slate-400" %>
-          Curation Chat
+          Curator Help
         <% end %>
         <%= link_to mcp_chat_path, class: "flex items-center gap-2 px-3 py-2.5 text-sm text-slate-200 hover:bg-civic-sidebar-hover hover:text-white transition-colors" do %>
           <%= render "chats/shared/icons/mcp_logo", css: "h-4 w-4 shrink-0 text-amber-400" %>
-          MCP Chat
+          CIViC Knowledge Chat
         <% end %>
       </div>
     </details>


### PR DESCRIPTION
Per Obi and Malachi's request in #civic-dev this will cause the input textarea on the chatbot ui to increase as you type more. It will also allow shift+enter to insert a newline rather than submitting the form. Additionally, it updates the verbiage in the sidebar to match what they asked for. 