### PR TITLE
Fix subject filter on notification feed

### DIFF
--- a/client/src/app/views/users/users-notifications/users-notifications.component.ts
+++ b/client/src/app/views/users/users-notifications/users-notifications.component.ts
@@ -227,9 +227,13 @@ export class UsersNotificationsComponent {
     let orgObj: Maybe<SubscribableInput> = undefined
 
     if (s !== undefined) {
+      let entityTypeString = s.subjectWithCount.subject?.__typename
+      if (entityTypeString && ["GeneVariant", "FusionVariant", "FactorVariant", "RegionVariant"].includes(entityTypeString)) {
+        entityTypeString = "Variant"
+      }
       let entityType: keyof typeof SubscribableEntities = <
         keyof typeof SubscribableEntities
-      >s.subjectWithCount.subject?.__typename
+      >entityTypeString
       orgObj = {
         id: s.subjectWithCount.subject!.id,
         entityType: SubscribableEntities[entityType],


### PR DESCRIPTION
This PR fixes an issue where selecting a variant as a subject filter would result in a GraphQL error.

The subject filter is populated by a field on the notifications query `notificationSubjects` which returns the, well, notification subject. So if that subject was a variant it would return the whole variant object. The `id` and `__typename` of that subject would then be used to populate the subject filter input when one of the subjects is selected for filtering. But because variants have a `__typename` of `GeneVariant`, `FusionVariant` etc., that input would throw an error because it expects just `Variant`.

This PR changes the input entityType from `xVariant` to just `Variant`. It seems a bit hacky so I'm totally open to alternatives  but it works.