### PR TITLE
Use "published" field for publication year, month, and date

### DIFF
--- a/server/app/lib/scrapers/crossref_work_response.rb
+++ b/server/app/lib/scrapers/crossref_work_response.rb
@@ -47,15 +47,15 @@ module Scrapers
     end
 
     def day
-      json["message"]["created"]["date-parts"][0][2]
+      json["message"]["published"]["date-parts"][0][2]
     end
 
     def month
-      json["message"]["created"]["date-parts"][0][1]
+      json["message"]["published"]["date-parts"][0][1]
     end
 
     def year
-      json["message"]["created"]["date-parts"][0][0]
+      json["message"]["published"]["date-parts"][0][0]
     end
 
     def journal


### PR DESCRIPTION
The "created" date is not always correct, sometimes up to a year later than the "published" date.

Once this PR is live, the ASCO source scrapers needs to be rerun on all the sources to fix the existing dates.